### PR TITLE
feat(lifecycle): the two-verb session lifecycle — capsule + resume

### DIFF
--- a/.claude/settings.json.template
+++ b/.claude/settings.json.template
@@ -4,6 +4,28 @@
     "AIGENT_VAULT": "__AIGENT_ROOT__"
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"__AIGENT_ROOT__/daemons/sessionstart-reinject.mjs\"",
+            "timeout": 3000
+          }
+        ]
+      },
+      {
+        "matcher": "clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"__AIGENT_ROOT__/daemons/resume-verb.mjs\"",
+            "timeout": 3000
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "matcher": "",
@@ -12,6 +34,18 @@
             "type": "command",
             "command": "bash \"__AIGENT_ROOT__/daemons/caddy.sh\"",
             "timeout": 2000
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"__AIGENT_ROOT__/daemons/ctx-refresh-sensor.mjs\"",
+            "timeout": 3000
           }
         ]
       }
@@ -53,6 +87,18 @@
           {
             "type": "command",
             "command": "bash \"__AIGENT_ROOT__/daemons/caddy-detect-new-skill.sh\"",
+            "timeout": 2000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"__AIGENT_ROOT__/daemons/stop-capsule-writer.mjs\"",
             "timeout": 2000
           }
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,29 @@ For changes to the kernel itself (the 15 numbered system documents and extended 
 
 ## [Unreleased]
 
-(empty — pending next release)
+### Added
+- **Two-verb lifecycle** — `/context-capsule` and `/resume` replace `/open`/`/close`/`/pause` as the session-continuity model. See `docs/two-verb-lifecycle.md` for the full design.
+  - `daemons/lifecycle-common.mjs` — shared identity/vault resolution, CRLF-safe frontmatter flip (`flipCapsuleToResumed`) with dedupe of a pre-seeded null-stamp placeholder.
+  - `daemons/capsule-content-gate.mjs` — shared injection-echo / ceremony-action content gate.
+  - `daemons/capsule-verb.mjs` + `daemons/curated-close-pointer.mjs` — the trusted-writer path: validates capsule content, collects deterministic evidence (git always, board pluggable via `AIGENT_BOARD_ADAPTER`), stamps the one pointer at `BODY_STATE.json`'s `state.last_capsule`, verifies the stamp read-back.
+  - `daemons/reconcile-collector.mjs` + `daemons/effect-receipts.mjs` — deterministic, model-free evidence collection; the effect-receipt ledger is a business-OS seam, unwired by default.
+  - `daemons/refresh-cycle.mjs`, `daemons/refresh-request.mjs`, `daemons/refresh-cursor.mjs` — the transactional cycle record, the controller→session challenge-crossing request, and the byte-exact transcript capture-cursor primitive.
+  - `daemons/resume-verb.mjs` — the resume verb's runtime container, a new `SessionStart(clear)` hook.
+  - `daemons/sessionstart-reinject.mjs` — warm-start pointer-table reinject, a new `SessionStart` hook covering every source (startup/resume/clear/compact) in one merged file.
+  - `daemons/stop-capsule-writer.mjs` — every-turn rolling capsule delta writer, a new `Stop` hook. Includes a speaker-tag classifier (`OPERATOR`/`RELAY:x`/`PEER:x`/`INJECT:harness`) so injected instructions and cross-session relay text never masquerade as the operator's own objective.
+  - `daemons/ctx-refresh-sensor.mjs` — optional context-pressure self-refresh reflex, a new `PreToolUse` hook. Silently inert unless a statusline integration writes `~/.claude/ctx-refresh/<sid>.json`.
+  - `.claude/settings.json.template` — wires the four new hooks above.
+  - `skills/context-capsule/SKILL.md`, `skills/resume/SKILL.md` — rewritten to the two-verb contract.
+  - `skill-index.json` — added `sk_resume`; `sk_open`/`sk_close` marked `active: false` (deprecated, not removed).
+  - `docs/two-verb-lifecycle.md` — the design doc.
+  - Test suite: `daemons/tests/*.test.mjs` (8 files) — content gate, trusted writer, resume verb, the CRLF-safe flip, the pointer clobber-guard, the challenge-crossing request, the capture-cursor primitive, and the speaker-tag classifier.
+
+### Known issue
+- Fresh autosave capsules seed `waiting_on: null`, which the content gate correctly refuses as non-resumable — an automated refresh cycle can be refused against a just-created autosave capsule until a later turn fills in a real `waiting_on`. Documented in `docs/two-verb-lifecycle.md`; the fix is planned as a follow-up commit on this branch, not bundled into this port.
+
+### Changed
+- `docs/capsule-v2-doctrine.md` — added a forward pointer to the two-verb lifecycle doc; the v2 field schema is unchanged and still current.
+- `skills/open/SKILL.md`, `skills/close/SKILL.md` — marked deprecated in favor of `/resume` and `/context-capsule`; kept for manual invocation during the transition, not deleted.
 
 ## [0.8.0] — 2026-07-07 — "Public readiness pass"
 

--- a/daemons/capsule-content-gate.mjs
+++ b/daemons/capsule-content-gate.mjs
@@ -1,0 +1,71 @@
+// capsule-content-gate.mjs — non-null ≠ resumable.
+//
+// ONE vocabulary for "this capsule text is ceremony echo, not the operator's real
+// content", shared by BOTH enforcement points:
+//   - capsule-verb.mjs validateCapsuleText()  — the trusted-receipt gate
+//   - stop-capsule-writer.mjs                 — the field-refresh gate
+// Zero imports by design: the stop-writer lazy-loads this on the Stop hot path and
+// must never drag the reconcile stack with it.
+//
+// Every pattern here was written against REAL clobbered capsules observed in
+// production: an autosave capsule whose `objective` was literally the harness's
+// own injected instruction text (verbatim), and a `next_valid_action` that was
+// literally "re-read the active turn state" — a resume-verb boot ceremony echoed
+// back as if it were the seat's own next step. Patterns are START-ANCHORED on
+// purpose: a curated capsule may legitimately REFERENCE the ceremony mid-action
+// ("On resume: comply with any supervisor-resume instruction ...") — that is
+// content and must pass. Only text that IS the injection/ceremony (leads with it)
+// fails.
+
+// Harness/supervisor injection markers. An OBJECTIVE matching any of these is
+// injected instruction echo, never the operator's actual objective.
+export const INJECTION_TEMPLATES = Object.freeze([
+  /^\[supervisor-resume\]/i,
+  /^\[refresh-cycle\]/i,
+  /^\[auto-pull\]/i,
+  /^\[context-refresh\b/i,
+  /^\[capsule-request\]/i,
+  /^\[room from /i,
+  /^\[inbox\b/i,
+  /^# Autonomous loop check/i,
+  /^Autonomous loop tick/i,
+  /^<task-notification>/i,
+  /^\[SYSTEM NOTIFICATION/i,
+]);
+
+// Resume-ceremony openers — the stop-writer's own historical templates plus the
+// observed echo shapes. A NEXT_VALID_ACTION that leads with one of these tells a
+// fresh session nothing but "you have resumed"; a crash after it strands the
+// session in a capsule instructing it to resume.
+export const CEREMONY_PATTERNS = Object.freeze([
+  /^re-?read the (active )?turn state\b/i,        // writer template (pre-fix)
+  /^resume from the latest session log\b/i,       // writer fallback (pre-fix)
+  /^resume (is |was )?(now )?complete\b/i,
+  /^(the )?receipt (is |was )?written\b/i,
+  /^RESUME-ACK\b/,
+  /^comply with (any|the) supervisor-resume instruction\b/i, // echo of the resume verb's step text AS the whole action
+]);
+
+export function isInjectionEcho(s) {
+  const t = String(s || '').trim();
+  return !!t && INJECTION_TEMPLATES.some((re) => re.test(t));
+}
+
+export function isCeremonyAction(s) {
+  const t = String(s || '').trim();
+  return !!t && CEREMONY_PATTERNS.some((re) => re.test(t));
+}
+
+// Content-side problems for a capsule that will serve as a RESUME SOURCE.
+// Complements (never replaces) the non-empty checks in validateCapsuleText —
+// field presence stays the verb's concern; field MEANING is gated here.
+export function contentProblems(fields) {
+  const problems = [];
+  if (isInjectionEcho(fields?.objective)) {
+    problems.push('capsule objective is harness-injection echo, not the operator\'s own objective (content gate)');
+  }
+  if (isCeremonyAction(fields?.next_valid_action)) {
+    problems.push('capsule next_valid_action opens with resume ceremony — a fresh session cannot act on it (content gate)');
+  }
+  return problems;
+}

--- a/daemons/capsule-verb.mjs
+++ b/daemons/capsule-verb.mjs
@@ -1,0 +1,774 @@
+// capsule-verb.mjs — the trusted-writer orchestration for the capsule verb.
+//
+// The model authors capsule prose; this module is the authority that deterministic
+// reconciliation ran. Clear gating, CAS consumption, TTL, and quiescence
+// enforcement remain deliberately out of scope (see refresh-cycle.mjs's header).
+
+import {
+  existsSync, readFileSync, realpathSync, statSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  canonicalJson, collectEvidence, reconcileDigest,
+} from './reconcile-collector.mjs';
+import {
+  cycleRecordPath, readCycleRecord, writeCycleRecord,
+} from './refresh-cycle.mjs';
+import { memRoot as resolveMemRoot, seatOf } from './lifecycle-common.mjs';
+import { contentProblems } from './capsule-content-gate.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CURATED_WRITER = path.join(__dirname, 'curated-close-pointer.mjs');
+const HEX_SHA256 = /^[a-f0-9]{64}$/i;
+const CHALLENGE_SHA256 = /^sha256:[a-f0-9]{64}$/i;
+const EFFECT_STATES = new Set([
+  'requested', 'accepted', 'completed', 'failed', 'safe-retry',
+]);
+const REQUIRED_CAPSULE_FIELDS = Object.freeze([
+  'id', 'objective', 'waiting_on', 'next_valid_action',
+]);
+const CYCLE_FIELDS = Object.freeze([
+  'version', 'cycle_id', 'lineage_id', 'runtime_session', 'context_epoch',
+  'state', 'issued_at', 'expires_at', 'challenge_digest',
+  'captured_through_event_id', 'captured_through_offset', 'capsule_id',
+  'capsule_sha256', 'reconcile_digest', 'clear_committed_at', 'cleared_at',
+  'resumed_at', 'abort_reason',
+]);
+
+const sha256 = (value) => createHash('sha256').update(value).digest('hex');
+const own = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+const describe = (error) => String(error?.message || error || 'unknown error');
+const emptyDigests = () => ({
+  capsule_sha256: null,
+  reconcile_digest: null,
+  challenge_digest: null,
+});
+
+function comparablePath(value) {
+  const resolved = path.resolve(value);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function isInside(parent, child) {
+  const relative = path.relative(parent, child);
+  return relative === ''
+    || (!path.isAbsolute(relative)
+      && relative !== '..'
+      && !relative.startsWith(`..${path.sep}`));
+}
+
+export class CapsuleVerbRefusal extends Error {
+  constructor(refusals, result = {}) {
+    const reasons = Array.isArray(refusals) ? refusals : [String(refusals)];
+    super(`[capsule-verb] REFUSED: ${reasons.join('; ')}`);
+    this.name = 'CapsuleVerbRefusal';
+    this.result = {
+      stamped: false,
+      pointerPath: null,
+      digests: emptyDigests(),
+      refusals: reasons,
+      cycleStates: [],
+      ...result,
+      refusals: reasons,
+    };
+  }
+}
+
+function refuse(reasons, digests, extra = {}) {
+  throw new CapsuleVerbRefusal(reasons, {
+    digests: { ...emptyDigests(), ...digests },
+    ...extra,
+  });
+}
+
+// The public API takes a memory root while the landed writers take a project
+// root. aigent-OS's memory root is always <root>/vault/memory (or <root>/memory
+// for forks that skip the vault/ subdirectory — see lifecycle-common.mjs). Only
+// those two shapes are accepted; ambiguity must not stamp.
+export function projectRootFromMemRoot(memRoot) {
+  if (typeof memRoot !== 'string' || memRoot.trim().length === 0) {
+    throw new Error('memRoot must be a non-empty path');
+  }
+  const memory = path.resolve(memRoot);
+  const slash = memory.replace(/\\/g, '/').toLowerCase();
+  if (slash.endsWith('/vault/memory')) return path.resolve(memory, '..', '..');
+  if (path.basename(memory).toLowerCase() === 'memory') return path.dirname(memory);
+  throw new Error(`unsupported memory-root layout: ${memory}`);
+}
+
+function frontmatterOf(text) {
+  const match = String(text).match(/^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/);
+  return match?.[1] ?? null;
+}
+
+function frontmatterScalar(frontmatter, key) {
+  const match = frontmatter.match(new RegExp(`^${key}:[ \\t]*(.*)$`, 'm'));
+  if (!match) return null;
+  let value = match[1].trim();
+  if ((value.startsWith('"') && value.endsWith('"'))
+    || (value.startsWith("'") && value.endsWith("'"))) {
+    value = value.slice(1, -1).trim();
+  } else {
+    value = value.replace(/\s+#.*$/, '').trim();
+  }
+  return value;
+}
+
+function hasUnsupportedInlineComment(frontmatter, key) {
+  const match = frontmatter.match(new RegExp(`^${key}:[ \\t]*(.*)$`, 'm'));
+  if (!match) return false;
+  const raw = match[1];
+  let quote = null;
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (quote === '"') {
+      if (char === '\\') index += 1;
+      else if (char === '"') quote = null;
+      continue;
+    }
+    if (quote === "'") {
+      if (char === "'" && raw[index + 1] === "'") index += 1;
+      else if (char === "'") quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === '#' && index > 0 && /\s/.test(raw[index - 1])) return true;
+  }
+  return false;
+}
+
+function isUnquotedYamlNull(frontmatter, key) {
+  const match = frontmatter.match(new RegExp(`^${key}:[ \\t]*(.*)$`, 'm'));
+  if (!match) return false;
+  let raw = match[1].trim();
+  if (raw.startsWith('"') || raw.startsWith("'")) return false;
+  raw = raw.replace(/\s+#.*$/, '').trim();
+  return /^(?:null|~)$/i.test(raw);
+}
+
+export function validateCapsuleText(text) {
+  const frontmatter = frontmatterOf(text);
+  if (frontmatter === null) {
+    return { fields: {}, problems: ['capsule must begin with a closed YAML frontmatter block'] };
+  }
+  const fields = {};
+  const problems = [];
+  for (const field of REQUIRED_CAPSULE_FIELDS) {
+    fields[field] = frontmatterScalar(frontmatter, field);
+    if (typeof fields[field] !== 'string' || fields[field].length === 0) {
+      problems.push(`capsule frontmatter ${field} must be non-empty`);
+    }
+    if (hasUnsupportedInlineComment(frontmatter, field)) {
+      problems.push(`capsule frontmatter ${field} must not use an inline YAML comment`);
+    }
+  }
+  // YAML null is not a non-empty waiting_on value for the trusted receipt, even
+  // though older curated capsules used it as a shorthand. A quoted "null" remains
+  // an intentional string.
+  if (isUnquotedYamlNull(frontmatter, 'waiting_on')) {
+    problems.push('capsule frontmatter waiting_on must be non-empty (unquoted YAML null is empty)');
+  }
+  // non-null ≠ resumable: field MEANING gate. A capsule whose objective is
+  // harness-injection echo or whose next_valid_action opens with resume ceremony
+  // passed every non-empty check above yet strands a fresh session. Vocabulary
+  // lives in capsule-content-gate.mjs, shared with the stop-writer.
+  problems.push(...contentProblems(fields));
+  return { fields, problems };
+}
+
+function validateBoard(board, problems) {
+  if (board === null) return;
+  if (!board || typeof board !== 'object' || Array.isArray(board)) {
+    problems.push('evidence.board must be an object or null');
+    return;
+  }
+  if (typeof board.query !== 'string' || board.query.length === 0) {
+    problems.push('evidence.board.query must be a non-empty string');
+  }
+  if (!Array.isArray(board.rows)) {
+    problems.push('evidence.board.rows must be an array');
+  } else {
+    board.rows.forEach((row, index) => {
+      if (!row || typeof row !== 'object' || Array.isArray(row)) {
+        problems.push(`evidence.board.rows[${index}] must be an object`);
+        return;
+      }
+      for (const field of ['id', 'version', 'status', 'claimant', 'updated_at']) {
+        if (!own(row, field)) problems.push(`evidence.board.rows[${index}].${field} is required`);
+      }
+      if (own(row, 'id') && (typeof row.id !== 'string' || row.id.length === 0)) {
+        problems.push(`evidence.board.rows[${index}].id must be a non-empty string`);
+      }
+      if (own(row, 'version')
+        && !((typeof row.version === 'string' && row.version.length > 0)
+          || (typeof row.version === 'number' && Number.isFinite(row.version)))) {
+        problems.push(`evidence.board.rows[${index}].version must be a string or finite number`);
+      }
+      if (own(row, 'status')
+        && (typeof row.status !== 'string' || row.status.length === 0)) {
+        problems.push(`evidence.board.rows[${index}].status must be a non-empty string`);
+      }
+      if (own(row, 'claimant') && row.claimant !== null
+        && (typeof row.claimant !== 'string' || row.claimant.length === 0)) {
+        problems.push(`evidence.board.rows[${index}].claimant must be a string or null`);
+      }
+      if (own(row, 'updated_at')
+        && (typeof row.updated_at !== 'string'
+          || !Number.isFinite(Date.parse(row.updated_at)))) {
+        problems.push(`evidence.board.rows[${index}].updated_at must be an ISO8601 string`);
+      }
+    });
+  }
+  if (typeof board.digest !== 'string' || !HEX_SHA256.test(board.digest)) {
+    problems.push('evidence.board.digest must be a sha256 hex digest');
+  } else {
+    try {
+      const computed = sha256(canonicalJson({ query: board.query, rows: board.rows }));
+      if (board.digest !== computed) {
+        problems.push('evidence.board.digest does not match its canonical query and rows');
+      }
+    } catch (error) {
+      problems.push(`evidence.board cannot be canonically digested: ${describe(error)}`);
+    }
+  }
+}
+
+function validateGit(git, problems) {
+  if (!Array.isArray(git) || git.length === 0) {
+    problems.push('evidence.git must contain at least one workspace record');
+    return;
+  }
+  git.forEach((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      problems.push(`evidence.git[${index}] must be an object`);
+      return;
+    }
+    for (const field of ['repo', 'branch', 'head']) {
+      if (typeof entry[field] !== 'string' || entry[field].length === 0) {
+        problems.push(`evidence.git[${index}].${field} must be a non-empty string`);
+      }
+    }
+    if (typeof entry.index_tree !== 'string' || !HEX_SHA256.test(entry.index_tree)) {
+      problems.push(`evidence.git[${index}].index_tree must be a sha256 hex digest`);
+    }
+    if (typeof entry.working_tree_digest !== 'string'
+      || !HEX_SHA256.test(entry.working_tree_digest)) {
+      problems.push(`evidence.git[${index}].working_tree_digest must be a sha256 hex digest`);
+    }
+    if (typeof entry.dirty !== 'boolean') {
+      problems.push(`evidence.git[${index}].dirty must be boolean`);
+    }
+  });
+}
+
+function validateExternalEffects(effects, problems) {
+  if (!Array.isArray(effects)) {
+    problems.push('evidence.external_effects must be an array');
+    return;
+  }
+  effects.forEach((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      problems.push(`evidence.external_effects[${index}] must be an object`);
+      return;
+    }
+    for (const field of ['idempotency_key', 'system', 'state']) {
+      if (typeof entry[field] !== 'string' || entry[field].length === 0) {
+        problems.push(`evidence.external_effects[${index}].${field} must be a non-empty string`);
+      }
+    }
+    if (typeof entry.state === 'string' && !EFFECT_STATES.has(entry.state)) {
+      problems.push(`evidence.external_effects[${index}].state is not a receipt state`);
+    }
+    if (!own(entry, 'external_id')) {
+      problems.push(`evidence.external_effects[${index}].external_id is required (null allowed)`);
+    } else if (entry.external_id !== null && typeof entry.external_id !== 'string') {
+      problems.push(`evidence.external_effects[${index}].external_id must be a string or null`);
+    }
+    if (typeof entry.receipt_digest !== 'string' || !HEX_SHA256.test(entry.receipt_digest)) {
+      problems.push(`evidence.external_effects[${index}].receipt_digest must be a sha256 hex digest`);
+    }
+  });
+}
+
+export function validateEvidence(evidence) {
+  if (!evidence || typeof evidence !== 'object' || Array.isArray(evidence)) {
+    return ['evidence must be an object'];
+  }
+  const problems = [];
+  if (evidence.version !== 1) problems.push('evidence.version must be 1');
+  if (!own(evidence, 'board')) problems.push('evidence.board is required');
+  else validateBoard(evidence.board, problems);
+  validateGit(evidence.git, problems);
+  validateExternalEffects(evidence.external_effects, problems);
+  return problems;
+}
+
+function normalizeCursor(value, problems) {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    problems.push('capturedThroughEventId must be a non-empty string when supplied');
+    return null;
+  }
+  return value;
+}
+
+// Cursor = {event_id, offset}. The offset is the half most easily dropped by
+// accident — verify compares the FULL cursor strictly, so an offset-less receipt
+// can never pass. Shape errors surface here; the receipt-completeness pairing rule
+// (cycle + event id -> offset REQUIRED) is enforced at the cycle block where the
+// cycle is known, so plain curated closes stay unaffected.
+function normalizeCursorOffset(value, cursor, problems) {
+  if (value === undefined || value === null) return null;
+  if (!Number.isInteger(value) || value < 0) {
+    problems.push(`capturedThroughOffset must be a non-negative integer when supplied, got: ${JSON.stringify(value)}`);
+    return null;
+  }
+  if (cursor === null) {
+    problems.push('capturedThroughOffset supplied without capturedThroughEventId (cursor fields travel as a pair)');
+    return null;
+  }
+  return value;
+}
+
+function cycleParts(cycle, problems) {
+  if (!cycle || typeof cycle !== 'object' || Array.isArray(cycle)) {
+    return { record: null, challenge: undefined };
+  }
+  if (own(cycle, 'record')) {
+    for (const key of Object.keys(cycle)) {
+      if (key !== 'record' && key !== 'challenge') {
+        problems.push(`cycle wrapper contains unknown field ${key}`);
+      }
+    }
+    return { record: cycle.record, challenge: cycle.challenge };
+  }
+  return { record: cycle, challenge: undefined };
+}
+
+function normalizeCycleRecord(record, challenge, problems) {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    problems.push('cycle record must be an object');
+    return null;
+  }
+  // Never spread caller data into the persisted record. In particular, reject
+  // likely raw-token properties and rebuild from the schema allowlist below.
+  for (const rawField of ['challenge', 'cycle_token', 'raw_challenge', 'token']) {
+    if (own(record, rawField)) {
+      problems.push(`cycle record must not contain raw token field ${rawField}`);
+    }
+  }
+  for (const key of Object.keys(record)) {
+    if (!CYCLE_FIELDS.includes(key)) problems.push(`cycle record contains unknown field ${key}`);
+  }
+  for (const field of CYCLE_FIELDS) {
+    if (!own(record, field)) problems.push(`cycle record field ${field} is required`);
+  }
+  if (record.version !== 1) problems.push('cycle record version must be 1');
+  for (const field of ['cycle_id', 'lineage_id', 'runtime_session']) {
+    if (typeof record[field] !== 'string' || record[field].length === 0) {
+      problems.push(`cycle record ${field} must be a non-empty string`);
+    }
+  }
+  if (typeof record.runtime_session === 'string'
+    && !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(record.runtime_session)) {
+    problems.push('cycle record runtime_session must be a path-safe identifier');
+  }
+  if (record.state !== 'requested') {
+    problems.push(`cycle record must begin in requested state, got: ${JSON.stringify(record.state)}`);
+  }
+  if (!Number.isInteger(record.context_epoch) || record.context_epoch < 0) {
+    problems.push('cycle record context_epoch must be a non-negative integer');
+  }
+  if (typeof record.issued_at !== 'string' || !Number.isFinite(Date.parse(record.issued_at))) {
+    problems.push('cycle record issued_at must be an ISO8601 string');
+  }
+  for (const field of ['expires_at', 'clear_committed_at', 'cleared_at', 'resumed_at']) {
+    const value = record[field];
+    if (value !== null
+      && (typeof value !== 'string' || !Number.isFinite(Date.parse(value)))) {
+      problems.push(`cycle record ${field} must be an ISO8601 string or null`);
+    }
+  }
+  for (const field of ['captured_through_event_id', 'capsule_id', 'abort_reason']) {
+    const value = record[field];
+    if (value !== null && (typeof value !== 'string' || value.length === 0)) {
+      problems.push(`cycle record ${field} must be a non-empty string or null`);
+    }
+  }
+  if (record.captured_through_offset !== null
+    && (!Number.isInteger(record.captured_through_offset) || record.captured_through_offset < 0)) {
+    problems.push('cycle record captured_through_offset must be a non-negative integer or null');
+  }
+  for (const field of ['capsule_sha256', 'reconcile_digest']) {
+    const value = record[field];
+    if (value !== null && (typeof value !== 'string' || !HEX_SHA256.test(value))) {
+      problems.push(`cycle record ${field} must be a sha256 hex digest or null`);
+    }
+  }
+
+  let challengeDigest = record.challenge_digest ?? null;
+  if (challenge !== undefined) {
+    if (typeof challenge !== 'string' || challenge.length === 0) {
+      problems.push('cycle challenge must be a non-empty string when supplied');
+    } else {
+      const computed = `sha256:${sha256(challenge)}`;
+      if (challengeDigest !== null && challengeDigest !== computed) {
+        problems.push('cycle challenge does not match the supplied challenge_digest');
+      }
+      challengeDigest = computed;
+    }
+  }
+  if (typeof challengeDigest !== 'string' || !CHALLENGE_SHA256.test(challengeDigest)) {
+    problems.push('cycle challenge_digest must be sha256:<64 hex>');
+  }
+
+  const normalized = {};
+  for (const field of CYCLE_FIELDS) normalized[field] = record[field] ?? null;
+  normalized.version = 1;
+  normalized.state = 'requested';
+  normalized.issued_at = record.issued_at;
+  normalized.challenge_digest = challengeDigest;
+  return normalized;
+}
+
+function sameCycleIdentity(left, right) {
+  return left.cycle_id === right.cycle_id
+    && left.lineage_id === right.lineage_id
+    && left.runtime_session === right.runtime_session
+    && left.context_epoch === right.context_epoch;
+}
+
+// aigent-OS is single-operator: the pointer always lives at BODY_STATE.json's
+// state.last_capsule (the same convention the context-capsule skill documents).
+function pointerPathFor(memoryRoot) {
+  return path.join(memoryRoot, 'BODY_STATE.json');
+}
+
+function readStampedPointer(pointerPath) {
+  const parsed = JSON.parse(readFileSync(pointerPath, 'utf8'));
+  return parsed?.state?.last_capsule;
+}
+
+function expectedPointerProblems(pointer, expected) {
+  if (!pointer || typeof pointer !== 'object') return ['writer produced no pointer object'];
+  const problems = [];
+  if (pointer.id !== expected.id) problems.push('stamped pointer id does not match capsule id');
+  if (pointer.path !== expected.path) problems.push('stamped pointer path does not match capsule target');
+  if (pointer.capsule_sha256 !== expected.capsule_sha256) {
+    problems.push('stamped pointer capsule_sha256 does not match capsule bytes');
+  }
+  if (pointer.reconcile_digest !== expected.reconcile_digest) {
+    problems.push('stamped pointer reconcile_digest does not match evidence');
+  }
+  if (pointer.captured_through_event_id !== expected.captured_through_event_id) {
+    problems.push('stamped pointer captured_through_event_id does not match capture cursor');
+  }
+  if ((pointer.captured_through_offset ?? null) !== expected.captured_through_offset) {
+    problems.push('stamped pointer captured_through_offset does not match capture cursor');
+  }
+  if (JSON.stringify(pointer.reconciled) !== JSON.stringify(expected.reconciled)) {
+    problems.push('stamped pointer reconciled proof does not match collected evidence');
+  }
+  if (pointer.cycle_id !== expected.cycle_id) problems.push('stamped pointer cycle_id mismatch');
+  if (pointer.context_epoch !== expected.context_epoch) problems.push('stamped pointer context_epoch mismatch');
+  if (pointer.cycle_token !== null) problems.push('trusted writer must never persist a raw cycle token');
+  return problems;
+}
+
+/**
+ * Collect deterministic evidence, validate the capsule, and stamp through the
+ * existing curated writer. Expected precondition failures throw
+ * CapsuleVerbRefusal and expose the normal return shape at `error.result`.
+ */
+export async function runCapsuleVerb({
+  seatId,
+  memRoot,
+  capsulePath,
+  cycle = null,
+  capturedThroughEventId = null,
+  capturedThroughOffset = null,
+  dryRun = false,
+} = {}) {
+  const digests = emptyDigests();
+  const preflight = [];
+
+  let root;
+  let memoryRoot;
+  try {
+    root = projectRootFromMemRoot(memRoot);
+    memoryRoot = path.resolve(memRoot);
+  } catch (error) {
+    refuse([describe(error)], digests);
+  }
+
+  const resolvedSeat = seatOf(root);
+  const requestedSeat = typeof seatId === 'string' ? seatId.toLowerCase() : null;
+  if (!requestedSeat) preflight.push('seatId must be a non-empty string');
+  else if (resolvedSeat && requestedSeat !== resolvedSeat.toLowerCase()) {
+    preflight.push(`seatId ${seatId} does not match derived identity ${resolvedSeat}`);
+  }
+
+  const writerMemoryRoot = path.resolve(resolveMemRoot(root));
+  if (comparablePath(writerMemoryRoot) !== comparablePath(memoryRoot)) {
+    preflight.push(`memRoot ${memoryRoot} is not the writer-selected memory root ${writerMemoryRoot}`);
+  }
+  let physicalRoot = null;
+  try {
+    physicalRoot = realpathSync(root);
+  } catch (error) {
+    preflight.push(`project root cannot be resolved physically: ${describe(error)}`);
+  }
+
+  let absoluteCapsule = null;
+  if (typeof capsulePath !== 'string' || capsulePath.trim().length === 0) {
+    preflight.push('capsulePath must be a non-empty path');
+  } else {
+    absoluteCapsule = path.isAbsolute(capsulePath)
+      ? path.resolve(capsulePath)
+      : path.resolve(root, capsulePath);
+    if (!isInside(root, absoluteCapsule)) {
+      preflight.push(`capsule must be inside the project root: ${absoluteCapsule}`);
+    } else if (!existsSync(absoluteCapsule)) {
+      preflight.push(`capsule file does not exist: ${absoluteCapsule}`);
+    } else {
+      try {
+        if (!statSync(absoluteCapsule).isFile()) {
+          preflight.push(`capsule path is not a file: ${absoluteCapsule}`);
+        } else if (physicalRoot) {
+          const physicalCapsule = realpathSync(absoluteCapsule);
+          if (!isInside(physicalRoot, physicalCapsule)) {
+            preflight.push(`capsule symlink target must be inside the project root: ${physicalCapsule}`);
+          }
+        }
+      } catch (error) {
+        preflight.push(`capsule cannot be inspected: ${describe(error)}`);
+      }
+    }
+  }
+
+  const cursor = normalizeCursor(capturedThroughEventId, preflight);
+  const cursorOffset = normalizeCursorOffset(capturedThroughOffset, cursor, preflight);
+  if (preflight.length) refuse(preflight, digests);
+
+  let capsuleBytes;
+  try {
+    capsuleBytes = readFileSync(absoluteCapsule);
+  } catch (error) {
+    refuse([`capsule read failed: ${describe(error)}`], digests);
+  }
+  digests.capsule_sha256 = sha256(capsuleBytes);
+  const capsuleValidation = validateCapsuleText(capsuleBytes.toString('utf8'));
+  if (capsuleValidation.problems.length) refuse(capsuleValidation.problems, digests);
+
+  let evidence;
+  try {
+    evidence = await collectEvidence({ seatId: requestedSeat, memRoot: memoryRoot });
+  } catch (error) {
+    refuse([`evidence collection failed: ${describe(error)}`], digests);
+  }
+  const evidenceProblems = validateEvidence(evidence);
+  if (evidenceProblems.length) refuse(evidenceProblems, digests);
+  try {
+    digests.reconcile_digest = reconcileDigest(evidence);
+  } catch (error) {
+    refuse([`reconcile digest failed: ${describe(error)}`], digests);
+  }
+  if (typeof digests.reconcile_digest !== 'string'
+    || !HEX_SHA256.test(digests.reconcile_digest)) {
+    refuse(['reconcileDigest must return a sha256 hex digest'], digests);
+  }
+
+  const reconciled = {
+    board_rows: evidence.board === null ? [] : evidence.board.rows.map((row) => row.id),
+    git_head: evidence.git[0].head,
+  };
+
+  let cycleRecord = null;
+  if (cycle !== undefined && cycle !== null) {
+    const cycleProblems = [];
+    const parts = cycleParts(cycle, cycleProblems);
+    cycleRecord = normalizeCycleRecord(parts.record, parts.challenge, cycleProblems);
+    if (cycleProblems.length) refuse(cycleProblems, digests);
+
+    const existingPath = cycleRecordPath(root, cycleRecord.runtime_session);
+    if (existsSync(existingPath)) {
+      let existing;
+      try {
+        existing = readCycleRecord(root, cycleRecord.runtime_session);
+      } catch (error) {
+        refuse([`cycle record read failed: ${describe(error)}`], digests);
+      }
+      const existingProblems = [];
+      const normalizedExisting = normalizeCycleRecord(existing, parts.challenge, existingProblems);
+      if (existingProblems.length) refuse(existingProblems, digests);
+      if (!sameCycleIdentity(cycleRecord, normalizedExisting)) {
+        refuse(['supplied cycle does not match the persisted cycle identity'], digests);
+      }
+      if (cycleRecord.challenge_digest !== normalizedExisting.challenge_digest) {
+        refuse(['supplied cycle challenge_digest does not match persisted cycle'], digests);
+      }
+      cycleRecord = normalizedExisting;
+    }
+    digests.challenge_digest = cycleRecord.challenge_digest;
+    // Receipt-completeness pairing: verify compares the FULL cursor strictly, so a
+    // cycle receipt stamped with an event id but no offset is guaranteed dead at
+    // verify — refuse loudly at the session instead. Enforced HERE (pre-dryRun) so
+    // dry canaries refuse exactly like live runs. Cursor-less cycles keep their
+    // pre-existing semantics, and plain curated closes (no cycle) never hit this rule.
+    if (cursor !== null && cursorOffset === null) {
+      refuse(['capturedThroughOffset is required for a cycle receipt (an offset-less receipt can never pass verify)'], digests);
+    }
+  }
+
+  // A dry run performs every read and validation, including a persisted cycle
+  // read, but intentionally makes neither pointer nor cycle writes.
+  if (dryRun) {
+    return {
+      stamped: false,
+      pointerPath: null,
+      digests,
+      refusals: [],
+      cycleStates: [],
+    };
+  }
+
+  const cycleStates = [];
+  if (cycleRecord) {
+    cycleStates.push('requested');
+    const capsuling = {
+      ...cycleRecord,
+      state: 'capsuling',
+      challenge_digest: digests.challenge_digest,
+      captured_through_event_id: cursor,
+      captured_through_offset: cursorOffset,
+      capsule_id: capsuleValidation.fields.id,
+      capsule_sha256: digests.capsule_sha256,
+      reconcile_digest: digests.reconcile_digest,
+    };
+    try {
+      writeCycleRecord(root, cycleRecord.runtime_session, capsuling);
+      const back = readCycleRecord(root, cycleRecord.runtime_session);
+      if (back.state !== 'capsuling' || back.cycle_id !== cycleRecord.cycle_id
+        || back.captured_through_event_id !== cursor
+        || back.captured_through_offset !== cursorOffset
+        || back.capsule_id !== capsuleValidation.fields.id
+        || back.capsule_sha256 !== digests.capsule_sha256
+        || back.reconcile_digest !== digests.reconcile_digest
+        || back.challenge_digest !== digests.challenge_digest) {
+        refuse(['cycle record did not persist the capsuling transition'], digests, { cycleStates });
+      }
+    } catch (error) {
+      if (error instanceof CapsuleVerbRefusal) throw error;
+      refuse([`cycle capsuling write failed: ${describe(error)}`], digests, { cycleStates });
+    }
+    cycleStates.push('capsuling');
+  }
+
+  const writerArgs = [
+    CURATED_WRITER,
+    absoluteCapsule,
+    '--reconciled', JSON.stringify(reconciled),
+    '--reconcile-digest', digests.reconcile_digest,
+    '--capsule-sha256', digests.capsule_sha256,
+  ];
+  if (cursor !== null) writerArgs.push('--captured-through-event', cursor);
+  if (cursorOffset !== null) writerArgs.push('--captured-through-offset', String(cursorOffset));
+  if (cycleRecord) {
+    writerArgs.push(
+      '--session', cycleRecord.runtime_session,
+      '--cycle-id', cycleRecord.cycle_id,
+      '--context-epoch', String(cycleRecord.context_epoch),
+    );
+  }
+  // Deliberately no --cycle-token: the raw challenge never enters argv or disk.
+  const child = spawnSync(process.execPath, writerArgs, {
+    cwd: root,
+    env: { ...process.env, AIGENT_ROOT: root, CLAUDE_PROJECT_DIR: root },
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  if (child.error || child.status !== 0) {
+    const detail = child.error
+      ? describe(child.error)
+      : String(child.stderr || child.stdout || '').trim();
+    refuse([`curated pointer writer failed${detail ? `: ${detail}` : ''}`], digests, {
+      cycleStates,
+    });
+  }
+
+  const pointerPath = pointerPathFor(memoryRoot);
+  let pointer;
+  try {
+    pointer = readStampedPointer(pointerPath);
+  } catch (error) {
+    refuse([`stamped pointer read-back failed: ${describe(error)}`], digests, {
+      pointerPath,
+      cycleStates,
+    });
+  }
+  const expectedPath = path.relative(root, absoluteCapsule).replace(/\\/g, '/');
+  const pointerProblems = expectedPointerProblems(pointer, {
+    id: capsuleValidation.fields.id,
+    path: expectedPath,
+    capsule_sha256: digests.capsule_sha256,
+    reconcile_digest: digests.reconcile_digest,
+    captured_through_event_id: cursor,
+    captured_through_offset: cursorOffset,
+    reconciled,
+    cycle_id: cycleRecord?.cycle_id ?? null,
+    context_epoch: cycleRecord?.context_epoch ?? null,
+  });
+  if (pointerProblems.length) {
+    refuse(pointerProblems, digests, { pointerPath, cycleStates });
+  }
+
+  if (cycleRecord) {
+    const prepared = {
+      ...cycleRecord,
+      state: 'prepared',
+      challenge_digest: digests.challenge_digest,
+      captured_through_event_id: cursor,
+      captured_through_offset: cursorOffset,
+      capsule_id: capsuleValidation.fields.id,
+      capsule_sha256: digests.capsule_sha256,
+      reconcile_digest: digests.reconcile_digest,
+    };
+    try {
+      writeCycleRecord(root, cycleRecord.runtime_session, prepared);
+      const back = readCycleRecord(root, cycleRecord.runtime_session);
+      if (back.state !== 'prepared' || back.cycle_id !== cycleRecord.cycle_id
+        || back.capsule_sha256 !== digests.capsule_sha256
+        || back.reconcile_digest !== digests.reconcile_digest
+        || back.challenge_digest !== digests.challenge_digest
+        || back.captured_through_event_id !== cursor
+        || back.captured_through_offset !== cursorOffset
+        || back.capsule_id !== capsuleValidation.fields.id) {
+        refuse(['cycle record did not persist the prepared receipt'], digests, {
+          pointerPath,
+          cycleStates,
+        });
+      }
+    } catch (error) {
+      if (error instanceof CapsuleVerbRefusal) throw error;
+      refuse([`cycle prepared write failed: ${describe(error)}`], digests, {
+        pointerPath,
+        cycleStates,
+      });
+    }
+    cycleStates.push('prepared');
+  }
+
+  return {
+    stamped: true,
+    pointerPath,
+    digests,
+    refusals: [],
+    cycleStates,
+  };
+}

--- a/daemons/capsule-verb.mjs
+++ b/daemons/capsule-verb.mjs
@@ -152,6 +152,24 @@ function isUnquotedYamlNull(frontmatter, key) {
   return /^(?:null|~)$/i.test(raw);
 }
 
+// Skeleton-state predicate (the refresh cycle's READINESS gate — distinct from
+// validateCapsuleText's VALIDITY gate). The stop-writer's skeleton is born with
+// `waiting_on: null` and only the agent's own finalize step ever writes a real
+// value there, so a capsule has "left skeleton state" exactly when waiting_on
+// carries a non-empty scalar outside the null family: missing field, empty,
+// unquoted null/Null/NULL/~, and quoted-empty ""/'' are all still-skeleton.
+// A QUOTED "null" stays an intentional string, same as validateCapsuleText —
+// this predicate reuses the identical parsers so gate and verb can never
+// disagree about the same bytes. Never seed a placeholder instead of gating:
+// a writer-producible waiting_on would destroy the proof that finalize ran.
+export function capsuleLeftSkeleton(text) {
+  const frontmatter = frontmatterOf(text);
+  if (frontmatter === null) return false;
+  const value = frontmatterScalar(frontmatter, 'waiting_on');
+  if (typeof value !== 'string' || value.length === 0) return false;
+  return !isUnquotedYamlNull(frontmatter, 'waiting_on');
+}
+
 export function validateCapsuleText(text) {
   const frontmatter = frontmatterOf(text);
   if (frontmatter === null) {

--- a/daemons/ctx-refresh-sensor.mjs
+++ b/daemons/ctx-refresh-sensor.mjs
@@ -1,0 +1,828 @@
+#!/usr/bin/env node
+// ctx-refresh-sensor.mjs — PreToolUse hook: context-pressure sensor.
+//
+// A SINGLE-SEAT self-refresh reflex — finalize capsule → self-probe QA →
+// /compact. No broadcast, no conductor, no multi-agent coordination: every
+// session self-refreshes independently (a live coordination layer, if a fork
+// wires one, remains a separate, explicit, conductor-owned system).
+//
+// State machine (panel-hardened):
+//   pct < 50            → full re-arm: fired=false, fires=0 (a compact that bought
+//                         real headroom resets the escalation counter — the next
+//                         crossing is an ordinary refresh, not a false "2nd fire").
+//   drop ≥20 while fired, still >50 → compaction ran but didn't buy headroom:
+//                         escalate /clear immediately.
+//   crossing 60 unarmed → fire: route-by-state refresh first time (day-end pause →
+//                         /close + /clear; mid-day pause → /clear; mid-flight →
+//                         /compact), /clear if fires≥2 without a full re-arm in
+//                         between (compact demonstrably not enough).
+//   ≥60 while fired     → re-nudge every +5 points (the dead-zone fix: a partial
+//                         compact that lands at 55 and creeps back up re-alerts at
+//                         the next 5-point step instead of going silent to 90%).
+//
+// The percentage is the ground-truth used_percentage an operator's statusline (or
+// other integration) persists per session to ~/.claude/ctx-refresh/<sid>.json —
+// NOT a token estimate. If nothing writes that file, this sensor is silent by
+// construction (see the pctFile existence check below) — it degrades to a no-op,
+// it does not error.
+//
+// COORDINATION GUARD (pluggable, optional, same seam as sessionstart-reinject.mjs):
+// while AIGENT_COORDINATION_STATE names a file with a non-terminal `phase`, the
+// sensor stays SILENT — a wired conductor owns the lifecycle.
+//
+// INVARIANT: FAIL OPEN — any error exits 0; real failures log to the operator's
+// <memRoot>/.daemon-errors.log, pct-read failures deduped to once per session via
+// the state file.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const FIRE_AT = 60;       // raise to 75-80 ONLY after reinject is proven on one
+                          // live compaction — this is an early-warning threshold.
+const HARD_AT = 75;       // at/above this line the sensor stops advising and
+                          // directs /clear. The 60% reflex stays the early warning
+                          // — this does NOT raise FIRE_AT.
+const REARM_BELOW = 50;   // drop back below this = full re-arm (fired + fires reset)
+const COMPACT_DROP = 20;  // a fall of this many points while fired = a compaction happened
+const RENUDGE_STEP = 5;   // while fired and ≥ FIRE_AT, re-alert every +N points
+const DEFAULT_STILL_POLL_MS = 1500;
+const DEFAULT_STILL_DEADLINE_MS = 60000;
+const DEFAULT_STILL_AGE_FLOOR_MS = 12000; // > the observed harness flush gap
+
+const AUTOFIRE_LOCK_STALE_MS = 30_000;
+const AUTOFIRE_COMPLETION_GRACE_MS = AUTOFIRE_LOCK_STALE_MS + 5_000;
+
+function readStdin() {
+  try { return fs.readFileSync(0, 'utf8'); } catch { return ''; }
+}
+
+function memoryRoot(root) {
+  for (const candidate of ['vault/memory', 'memory']) {
+    const p = path.join(root, ...candidate.split('/'));
+    if (fs.existsSync(p)) return p;
+  }
+  return path.join(root, 'vault', 'memory');
+}
+
+function logErr(msg) {
+  try {
+    const root = String(process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || '');
+    if (!root) return;
+    fs.appendFileSync(path.join(memoryRoot(root), '.daemon-errors.log'),
+      `${new Date().toISOString()} [ctx-refresh-sensor] ${msg}\n`);
+  } catch { /* truly nowhere to log */ }
+}
+
+// aigent-OS is single-operator, so the pointer is always BODY_STATE.json's
+// state.last_capsule — the same convention the context-capsule skill documents.
+function readCuratedPointer(root, memory, sid) {
+  try {
+    const pointer = JSON.parse(fs.readFileSync(path.join(memory, 'BODY_STATE.json'), 'utf8'))
+      ?.state?.last_capsule ?? null;
+    const finalizedAtMs = Date.parse(pointer?.finalized_at);
+    if (pointer?.trigger !== 'curated-close'
+      || pointer.session_id !== sid
+      || !Number.isFinite(finalizedAtMs)
+      || typeof pointer.path !== 'string'
+      || pointer.path.trim() === '') return null;
+    const capsulePath = path.isAbsolute(pointer.path)
+      ? pointer.path
+      : path.resolve(root, pointer.path);
+    if (!fs.existsSync(capsulePath)) return null;
+    return { capsulePath, finalizedAtMs };
+  } catch {
+    return null;
+  }
+}
+
+function durationFromEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, got ${JSON.stringify(raw)}`);
+  }
+  return value;
+}
+
+// Transcript age: ms since the harness last WROTE the transcript file (mtime). Unreadable
+// stat counts as age 0 (not yet still): fail toward waiting, bounded by the deadline refusal.
+function transcriptAgeMs(transcriptPath) {
+  try {
+    const mtime = fs.statSync(transcriptPath).mtimeMs;
+    if (!Number.isFinite(mtime)) return 0;
+    return Math.max(0, Date.now() - mtime);
+  } catch {
+    return 0;
+  }
+}
+
+// FRESH-SEAT DISCRIMINATOR: a missing stop-writer record means one of two very
+// different things — "genuinely fresh, no Stop event has fired yet" (skip
+// quietly, nothing to capsule) or "this session has had real turns and the
+// stop-writer is BROKEN, its record is never coming" (a real failure that must
+// escalate loudly, not vanish into a quiet skip forever). The transcript jsonl is
+// already in the worker payload as the capture-cursor source; its own event count
+// is the cheapest real signal for "how much has this session actually done."
+// Counts up to `cap` parseable lines (capped: this only needs to distinguish
+// near-zero from substantial, never the exact total on a long session).
+function transcriptEventCount(transcriptPath, cap = 50) {
+  try {
+    const raw = fs.readFileSync(transcriptPath, 'utf8');
+    let count = 0;
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      count += 1;
+      if (count >= cap) break;
+    }
+    return count;
+  } catch {
+    return 0;
+  }
+}
+// Below this many transcript events, "no Stop event has fired yet" is the honest
+// read — stop-writer only ever writes on a Stop, so a session with essentially no
+// turns yet cannot have one, by construction. At or above it, absence is anomalous.
+const FRESH_SEAT_EVENT_FLOOR = 6;
+
+async function waitForStillCursor(transcriptPath, readCursor, cursorEqual) {
+  const pollMs = durationFromEnv('CAPSULE_VERB_STILL_POLL_MS', DEFAULT_STILL_POLL_MS);
+  const deadlineMs = durationFromEnv(
+    'CAPSULE_VERB_STILL_DEADLINE_MS', DEFAULT_STILL_DEADLINE_MS,
+  );
+  // AGE FLOOR: the Stop hook fires BEFORE Claude Code flushes the turn's final
+  // assistant text + trailing metadata to the transcript jsonl. Two consecutive
+  // equal reads can fit inside that flush gap, so capture would land pre-flush
+  // and the flush then moves the cursor — a false quiescence violation. The floor
+  // requires the FILE to have been untouched for AGE_FLOOR ms before a still
+  // cursor counts: adaptive (waits exactly until quiet-for-N, wherever the flush
+  // lands), contract-free (mtime only, no record-timestamp parsing), and composed
+  // ON TOP of the consecutive-equal reads (which still guard torn writes and
+  // coarse-mtime filesystems).
+  const ageFloorMs = durationFromEnv(
+    'CAPSULE_VERB_STILL_AGE_FLOOR_MS', DEFAULT_STILL_AGE_FLOOR_MS,
+  );
+  const startedAt = Date.now();
+  const deps = { readFile: fs.readFileSync, stat: fs.statSync };
+  let previous = readCursor(transcriptPath, deps);
+
+  while (Date.now() - startedAt < deadlineMs) {
+    const remainingMs = deadlineMs - (Date.now() - startedAt);
+    if (remainingMs < pollMs) {
+      await new Promise((resolve) => setTimeout(resolve, remainingMs));
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+    const current = readCursor(transcriptPath, deps);
+    if (cursorEqual(previous, current) && transcriptAgeMs(transcriptPath) >= ageFloorMs) {
+      return current;
+    }
+    previous = current;
+  }
+
+  throw new Error(`transcript never went quiet within ${deadlineMs}ms; cycle refused`);
+}
+
+// Pluggable coordination guard — same seam as sessionstart-reinject.mjs. Absence
+// of the env var (the default) means no coordination layer is wired.
+function coordinationActive() {
+  const statePath = process.env.AIGENT_COORDINATION_STATE;
+  if (!statePath) return false;
+  try {
+    const raw = fs.readFileSync(statePath, 'utf8');
+    return !/"phase"\s*:\s*"(done|cancelled|canceled|closed|complete|aborted)"/i.test(raw);
+  } catch {
+    return false;
+  }
+}
+
+// Route-by-state: compaction cost scales with transcript length — minutes on a
+// heavy day, progress invisible — while capsule+/clear is constant-time. The
+// right route depends on WHERE the fire lands, and only the operator at the
+// keystroke moment knows that, so the routing lives in the message text.
+function msgRefresh(pct) {
+  return `[CONTEXT-REFRESH] You are at ${Math.round(pct)}% context — past the 60% mark. `
+    + `Self-refresh, single session, NO announce. First, at your next CLEAN pause point (finish `
+    + `the current action — never mid-tool-call): FINALIZE your active capsule — fill `
+    + `waiting_on, resume_trigger, expires, and any early-constraints — then run the `
+    + `self-probe QA: "could a fresh instance execute next_valid_action from this file `
+    + `alone?" — fix the capsule until yes. ACK-VERIFY: after writing, `
+    + `RE-READ the capsule file and confirm waiting_on is actually non-null on disk — the `
+    + `finalize is NOT done until you have SEEN it landed (a silent edit-miss can leave a `
+    + `session believing it capsuled while waiting_on stayed null, stranding it). Then ROUTE BY STATE: `
+    + `[DAY-END pause: day closing, lanes blocked] run the full /close ritual, then request `
+    + `/clear — the close IS the day-end memory commit; skip /compact entirely. `
+    + `[MID-DAY pause: lanes blocked, day continuing] request /clear only — no close `
+    + `ceremony; the capsule + SessionStart reinject re-ground the fresh session. `
+    + `[MID-FLIGHT: task in motion] request /compact — it preserves the live working `
+    + `thread. WARN the operator first: compaction time scales with transcript length, `
+    + `minutes on a heavy day with NO progress indicator — it is not hung, do not cancel. `
+    + `Capsule contract: docs/two-verb-lifecycle.md.`;
+}
+
+function msgClear(pct, why) {
+  return `[CONTEXT-REFRESH] ${why} (${Math.round(pct)}% now). ESCALATE: finalize your active `
+    + `capsule (same steps incl. the ACK-verify re-read), then run /clear instead of /compact — state is on disk, `
+    + `and the SessionStart reinject re-grounds the fresh session from the capsule pointer `
+    + `table. Single session, NO announce.`;
+}
+
+// Optional capsule-verb integration point. This path is deliberately absent from
+// the default sensor behavior: no module is loaded and no extra I/O occurs unless
+// the exact opt-in flag is present. The first armed threshold crossing calls the
+// trusted verb in dry-run mode by default, records the capture cursor when the
+// hook payload supplies one, and logs only (it never clears, injects, or gates).
+function logAutofire(root, entry) {
+  try {
+    const memory = memoryRoot(root);
+    const runtime = path.join(memory, 'runtime');
+    fs.mkdirSync(runtime, { recursive: true });
+    fs.appendFileSync(path.join(runtime, 'capsule-verb-autofire.jsonl'),
+      JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n');
+  } catch (e) {
+    logErr(`autofire outcome log failed: ${e?.message || e}`);
+  }
+}
+
+async function runAutofireWorker(payload) {
+  const root = String(payload?.root || '');
+  const sid = payload?.sid;
+  const transcriptPath = typeof payload?.transcriptPath === 'string' && payload.transcriptPath
+    ? payload.transcriptPath
+    : null;
+  let capsulePath = null;
+  let capsuleSource = null;
+  try {
+    if (!root || typeof sid !== 'string' || sid.length === 0) {
+      throw new Error('worker payload lacks root/session id');
+    }
+    const [{ runCapsuleVerb }, lifecycle, { readRequest }, { readCursor, cursorEqual },
+      { createCycleRecord, readCycleRecord, cycleRecordPath }] =
+      await Promise.all([
+        import('./capsule-verb.mjs'),
+        import('./lifecycle-common.mjs'),
+        import('./refresh-request.mjs'),
+        import('./refresh-cursor.mjs'),
+        import('./refresh-cycle.mjs'),
+      ]);
+    const seatId = lifecycle.seatOf(root);
+    const memory = lifecycle.memRoot(root);
+
+    const curatedPointer = readCuratedPointer(root, memory, sid);
+    if (curatedPointer !== null) {
+      capsulePath = curatedPointer.capsulePath;
+      capsuleSource = 'curated-pointer';
+    }
+    if (capsulePath === null) {
+      capsuleSource = 'stop-writer';
+      const stopStatePath = path.join(memory, 'runtime', 'stop-writer', `${sid}.json`);
+      // FRESH-SEAT FIX: a brand-new session's first turn(s) have not produced a
+      // Stop event yet, so this file genuinely does not exist -- not a
+      // torn/corrupt state, a structurally EXPECTED one. The curated-pointer
+      // branch above already correctly excludes the PRIOR session's stale close
+      // (readCuratedPointer requires pointer.session_id === sid), so there is no
+      // other legitimate capsule source at this moment when the session is
+      // GENUINELY fresh.
+      //
+      // But "missing" alone conflated two very different situations: a session
+      // with ZERO turns yet (nothing to capsule, quiet skip is correct) and a
+      // session with MANY turns whose stop-writer is simply broken and will
+      // NEVER produce a record (a real, ongoing failure that a quiet skip would
+      // mask forever). The transcript's own event count discriminates: below the
+      // floor, genuinely fresh; at or above it, the absence is anomalous and must
+      // escalate loudly (logErr, not just an autofire log line) rather than
+      // silently re-skip on every future poll.
+      if (!fs.existsSync(stopStatePath)) {
+        const eventCount = transcriptPath ? transcriptEventCount(transcriptPath) : 0;
+        if (eventCount < FRESH_SEAT_EVENT_FLOOR) {
+          logAutofire(root, {
+            sid,
+            outcome: 'skipped_fresh_seat',
+            mode: transcriptPath ? 'cycle' : 'legacy',
+            reason: `no stop-writer record yet at ${stopStatePath} (transcript_events=${eventCount} < floor ${FRESH_SEAT_EVENT_FLOOR}; pre-first-Stop, nothing to capsule)`,
+          });
+          return;
+        }
+        logErr(`stop-writer record missing for a NON-fresh session: sid=${sid} transcript_events=${eventCount} `
+          + `(>= floor ${FRESH_SEAT_EVENT_FLOOR}) path=${stopStatePath} -- the stop-writer may be broken, `
+          + `this is NOT a fresh-seat skip`);
+        throw new Error(`stop-writer record missing for a non-fresh session (${eventCount} transcript events, `
+          + `floor ${FRESH_SEAT_EVENT_FLOOR}) at ${stopStatePath}`);
+      }
+      const stopState = JSON.parse(fs.readFileSync(stopStatePath, 'utf8'));
+      if (typeof stopState?.capsule_path !== 'string' || stopState.capsule_path.trim() === '') {
+        throw new Error(`active capsule path missing from ${stopStatePath}`);
+      }
+      capsulePath = path.isAbsolute(stopState.capsule_path)
+        ? stopState.capsule_path
+        : path.resolve(root, stopState.capsule_path);
+    }
+    const dryRun = process.env.CAPSULE_VERB_AUTOFIRE_DRY_RUN !== '0';
+
+    // CHALLENGE CROSSING. A transcript path in the worker payload is the
+    // controller's request-gated cycle signal: the controller has dropped a
+    // RefreshRequest carrying the nonce, and the raw transcript is what the
+    // capture cursor is read from. In this mode a valid, UNEXPIRED request is
+    // MANDATORY — an absent / expired / torn request is a fail-closed refusal,
+    // never a bare stamp. Without a transcript path the legacy no-cycle autofire
+    // runs unchanged, preserving that path's behavior byte-for-byte.
+    if (transcriptPath) {
+      const req = readRequest(memory, sid);
+      if (!req) throw new Error('refresh request absent, torn, or unreadable — cycle refused');
+      const expiresMs = Date.parse(req.expires_at);
+      if (!Number.isFinite(expiresMs) || expiresMs <= Date.now()) {
+        throw new Error(`refresh request expired at ${req.expires_at}; cycle refused`);
+      }
+      // SUPERSEDE: a controller abort + re-mint leaves the persisted seat record
+      // on the DEAD cycle (e.g. state=prepared), and the verb's begin-in-requested
+      // guard would then refuse every NEW cycle forever; the session never hears
+      // about controller aborts directly. The controller's supersede signal is
+      // IMPLICIT in the request file it already writes: a valid, unexpired
+      // request bearing a DIFFERENT cycle_id than the persisted record is the
+      // controller's current intent, and the stale record yields to it. Fail
+      // closed on everything else: same cycle_id (the verb owns its own cycle's
+      // progression), or a request NOT strictly newer than the record
+      // (replay/clock corner): refuse loudly, delete nothing. Absent record =
+      // normal first cycle, nothing to supersede. A PRESENT but torn/unreadable
+      // record makes readCycleRecord throw -> the catch refuses the cycle loudly
+      // (never blind-delete a record we could not verify).
+      const staleRecord = fs.existsSync(cycleRecordPath(root, sid))
+        ? readCycleRecord(root, sid)
+        : null;
+      if (staleRecord && staleRecord.cycle_id !== req.cycle_id) {
+        const staleIssuedMs = Date.parse(staleRecord.issued_at);
+        const reqIssuedMs = Date.parse(req.issued_at);
+        const strictlyNewer = Number.isFinite(reqIssuedMs)
+          && (!Number.isFinite(staleIssuedMs) || reqIssuedMs > staleIssuedMs);
+        if (!strictlyNewer) {
+          throw new Error(`stale seat cycle ${staleRecord.cycle_id} (state=${staleRecord.state}) `
+            + `not superseded: request ${req.cycle_id} issued_at ${req.issued_at} is not strictly `
+            + `newer than record issued_at ${staleRecord.issued_at}; cycle refused`);
+        }
+        fs.rmSync(cycleRecordPath(root, sid), { force: true });
+        logAutofire(root, {
+          sid,
+          outcome: 'superseded_stale_seat_record',
+          mode: 'cycle',
+          superseded_cycle: staleRecord.cycle_id,
+          superseded_state: staleRecord.state,
+          by_cycle: req.cycle_id,
+        });
+      }
+      // Wait for two identical cursor reads before handing the capture boundary to
+      // the verb. The request hint remains the fallback for a quiet null cursor.
+      const cursor = await waitForStillCursor(transcriptPath, readCursor, cursorEqual);
+      if (expiresMs <= Date.now()) {
+        throw new Error(`refresh request expired at ${req.expires_at}; cycle refused`);
+      }
+      // The capture anchor travels as a PAIR — event id AND offset from the SAME
+      // source (still cursor, else the request hint). Taking event_id alone here
+      // is the drop point that would kill every still-seat verify: the pointer
+      // stamps @undefined and strict cursorEqual can never pass on a half cursor.
+      const captureAnchor = cursor ?? req.captured_through_hint ?? null;
+      const capturedThroughEventId = captureAnchor?.event_id ?? null;
+      const capturedThroughOffset = captureAnchor?.offset ?? null;
+      // The session authors NO nonce: the raw challenge from the request is
+      // handed to runCapsuleVerb, which alone computes the sha256:<hex> digest.
+      // lineage_id and context_epoch are session-side defaults here (a real
+      // controller owns lineage); this unit only proves the crossing lands a
+      // well-formed cycle.
+      const record = createCycleRecord({
+        cycle_id: req.cycle_id,
+        lineage_id: req.cycle_id,
+        runtime_session: sid,
+        context_epoch: 0,
+        issued_at: req.issued_at,
+        expires_at: req.expires_at,
+      });
+      const result = await runCapsuleVerb({
+        seatId,
+        memRoot: memory,
+        capsulePath,
+        cycle: { record, challenge: req.challenge },
+        capturedThroughEventId,
+        capturedThroughOffset,
+        dryRun,
+      });
+      // A successful live worker stamps the pointer after the pre-spawn claim.
+      // Advance the same claim past that self-stamp so only a later stamp re-arms.
+      const completedPointer = readCuratedPointer(root, memory, sid);
+      await recordCompletedAutofire(sid, req.cycle_id, completedPointer?.finalizedAtMs);
+      logAutofire(root, {
+        sid,
+        outcome: 'completed',
+        mode: 'cycle',
+        dry_run: dryRun,
+        stamped: result.stamped === true,
+        cycle_states: result.cycleStates ?? [],
+        refusal_count: result.refusals?.length ?? 0,
+        capsule_source: capsuleSource,
+        capsule_path: capsulePath,
+      });
+      return;
+    }
+
+    const result = await runCapsuleVerb({
+      seatId,
+      memRoot: memory,
+      capsulePath,
+      capturedThroughEventId: payload?.eventId ?? null,
+      capturedThroughOffset: payload?.offset ?? null,
+      dryRun,
+    });
+    logAutofire(root, {
+      sid,
+      outcome: 'completed',
+      dry_run: dryRun,
+      stamped: result.stamped === true,
+      refusal_count: result.refusals?.length ?? 0,
+    });
+  } catch (e) {
+    logAutofire(root, {
+      sid: typeof sid === 'string' ? sid : null,
+      outcome: 'refused',
+      error: String(e?.message || e),
+      ...(transcriptPath ? {
+        mode: 'cycle',
+        capsule_source: capsuleSource,
+        capsule_path: capsulePath,
+      } : {}),
+    });
+  }
+}
+
+function launchAutofire(payload, sid) {
+  if (process.env.CAPSULE_VERB_AUTOFIRE !== '1') return false;
+  try {
+    const root = String(process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || payload?.cwd || '');
+    if (!root) throw new Error('project root unavailable');
+    const workerPayload = Buffer.from(JSON.stringify({
+      root,
+      sid,
+      eventId: payload?.event_id ?? null,
+      // The raw transcript path is the request-gated cycle signal + the
+      // capture-cursor source. Absent in older payloads -> null -> the worker
+      // keeps the legacy no-cycle path.
+      transcriptPath: payload?.transcript_path ?? null,
+    }), 'utf8').toString('base64url');
+    const child = spawn(process.execPath, [
+      fileURLToPath(import.meta.url), '--autofire-worker', workerPayload,
+    ], {
+      detached: true,
+      env: process.env,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    // spawn() reports many launch failures asynchronously. A missing pid is the
+    // synchronous refusal signal available before this short-lived hook exits.
+    if (!child.pid) throw new Error('autofire worker did not receive a process id');
+    child.once('error', (error) => {
+      logErr(`autofire worker error sid=${sid}: ${error?.message || error}`);
+    });
+    child.unref();
+    return true;
+  } catch (e) {
+    logErr(`autofire launch failed sid=${sid}: ${e?.message || e}`);
+    return false;
+  }
+}
+
+// Atomic-ish state write — a torn state file re-fires spurious alerts.
+function writeState(file, obj) {
+  const tmp = `${file}.${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(obj));
+    try { fs.renameSync(tmp, file); } catch {
+      fs.rmSync(file, { force: true });
+      fs.renameSync(tmp, file);
+    }
+    return true;
+  } catch (e) {
+    // A state write that never lands re-fires the same alert next call — visible
+    // spam beats invisible breakage, and the log names the cause.
+    logErr(`state write failed for ${file}: ${e?.message || e}`);
+    try { fs.rmSync(tmp, { force: true }); } catch {}
+    return false;
+  }
+}
+
+function acquireAutofireLock(stateFile) {
+  const file = `${stateFile}.autofire.lock`;
+  try {
+    return { fd: fs.openSync(file, 'wx'), file };
+  } catch {
+    try {
+      if (Date.now() - fs.statSync(file).mtimeMs <= AUTOFIRE_LOCK_STALE_MS) return null;
+      fs.rmSync(file, { force: true });
+      return { fd: fs.openSync(file, 'wx'), file };
+    } catch {
+      return null;
+    }
+  }
+}
+
+function releaseAutofireLock(lock) {
+  if (lock === null) return;
+  try { fs.closeSync(lock.fd); } catch {}
+  try { fs.rmSync(lock.file, { force: true }); } catch {}
+}
+
+function writeSensorState(stateFile, state) {
+  if (process.env.CAPSULE_VERB_AUTOFIRE !== '1') return writeState(stateFile, state);
+  const lock = acquireAutofireLock(stateFile);
+  if (lock === null) return false;
+  try {
+    if (fs.existsSync(stateFile)) {
+      let current;
+      try {
+        current = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+      } catch (e) {
+        logErr(`state merge failed for ${stateFile}: ${e?.message || e}`);
+        return false;
+      }
+      const hasCycle = Object.hasOwn(current, 'last_autofire_cycle_id');
+      const hasLaunchedAt = Object.hasOwn(current, 'last_autofire_launched_at');
+      if (hasCycle || hasLaunchedAt) {
+        if (typeof current.last_autofire_cycle_id !== 'string'
+          || current.last_autofire_cycle_id.length === 0
+          || typeof current.last_autofire_launched_at !== 'number'
+          || !Number.isFinite(current.last_autofire_launched_at)) {
+          logErr(`state merge refused malformed launch claim in ${stateFile}`);
+          return false;
+        }
+        state.last_autofire_cycle_id = current.last_autofire_cycle_id;
+        state.last_autofire_launched_at = current.last_autofire_launched_at;
+      }
+    }
+    return writeState(stateFile, state);
+  } finally {
+    releaseAutofireLock(lock);
+  }
+}
+
+async function waitForAutofireLock(
+  stateFile,
+  timeoutMs = AUTOFIRE_LOCK_STALE_MS + 1_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const lock = acquireAutofireLock(stateFile);
+    if (lock !== null) return lock;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  } while (Date.now() < deadline);
+  return null;
+}
+
+async function recordCompletedAutofire(sid, cycleId, finalizedAtMs) {
+  if (process.env.CAPSULE_VERB_AUTOFIRE !== '1') return;
+  const stateFile = path.join(os.homedir(), '.claude', 'ctx-refresh', `${sid}.state`);
+  const lock = await waitForAutofireLock(stateFile);
+  if (lock === null) {
+    logErr(`completed launch claim timed out waiting for state lock sid=${sid}`);
+    return;
+  }
+  try {
+    let state = {};
+    if (fs.existsSync(stateFile)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          throw new Error('launch state is not an object');
+        }
+        state = parsed;
+      } catch (e) {
+        logErr(`completed launch claim rebuilding unreadable state sid=${sid}: ${e?.message || e}`);
+        state = {};
+      }
+    }
+    if (state?.last_autofire_cycle_id
+      && state.last_autofire_cycle_id !== cycleId) return;
+    state.last_autofire_cycle_id = cycleId;
+    state.last_autofire_launched_at = Math.max(
+      Date.now(),
+      Number.isFinite(finalizedAtMs) ? finalizedAtMs : 0,
+    );
+    if (!writeState(stateFile, state)) {
+      logErr(`completed launch claim write failed sid=${sid}`);
+    }
+  } catch (e) {
+    logErr(`completed launch claim failed sid=${sid}: ${e?.message || e}`);
+  } finally {
+    releaseAutofireLock(lock);
+  }
+}
+
+async function launchRequestedAutofire(payload, sid, state, stateFile) {
+  if (process.env.CAPSULE_VERB_AUTOFIRE !== '1') return;
+  const root = String(process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || payload?.cwd || '');
+  if (!root) {
+    logErr(`request intake failed sid=${sid}: project root unavailable`);
+    return;
+  }
+  const memory = memoryRoot(root);
+  const requestFile = path.join(memory, 'runtime', `refresh-request-${sid}.json`);
+  if (!fs.existsSync(requestFile)) return;
+
+  let readRequest;
+  let lifecycle;
+  try {
+    [{ readRequest }, lifecycle] = await Promise.all([
+      import('./refresh-request.mjs'),
+      import('./lifecycle-common.mjs'),
+    ]);
+  } catch (e) {
+    logErr(`request intake failed sid=${sid}: ${e?.message || e}`);
+    return;
+  }
+  const request = readRequest(memory, sid);
+  if (!request) return;
+  const expiresMs = Date.parse(request.expires_at);
+  if (!Number.isFinite(expiresMs) || expiresMs <= Date.now()) return;
+  const seatId = lifecycle.seatOf(root);
+
+  const lock = acquireAutofireLock(stateFile);
+  if (lock === null) return;
+  try {
+    let launchState = { ...state };
+    if (fs.existsSync(stateFile)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          throw new Error('launch state is not an object');
+        }
+        launchState = { ...launchState, ...parsed };
+      } catch (e) {
+        logErr(`request intake failed sid=${sid}: launch state unreadable: ${e?.message || e}`);
+        return;
+      }
+    }
+
+    if (request.cycle_id === launchState.last_autofire_cycle_id) {
+      const curatedPointer = readCuratedPointer(root, memory, sid);
+      const launchedAt = launchState.last_autofire_launched_at;
+      if (curatedPointer === null
+        || typeof launchedAt !== 'number'
+        || !Number.isFinite(launchedAt)
+        || curatedPointer.finalizedAtMs <= launchedAt) return;
+    }
+
+    launchState.last_autofire_cycle_id = request.cycle_id;
+    launchState.last_autofire_launched_at = Date.now();
+    if (!writeState(stateFile, launchState)) return;
+    Object.assign(state, launchState);
+    launchAutofire(payload, sid);
+  } finally {
+    releaseAutofireLock(lock);
+  }
+}
+
+if (process.argv[2] === '--autofire-worker') {
+  let deadline = null;
+  try {
+    const encoded = process.argv[3];
+    if (!encoded) throw new Error('missing encoded worker payload');
+    const payload = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+    // The worker is detached from the 3s hook budget, but it is not immortal:
+    // a wedged optional adapter must not accumulate orphan processes.
+    const configuredStillDeadline = Number(process.env.CAPSULE_VERB_STILL_DEADLINE_MS);
+    const stillDeadlineMs = Number.isInteger(configuredStillDeadline)
+      && configuredStillDeadline > 0
+      ? configuredStillDeadline
+      : DEFAULT_STILL_DEADLINE_MS;
+    const timeoutMs = payload?.transcriptPath
+      ? Math.max(
+        AUTOFIRE_COMPLETION_GRACE_MS,
+        stillDeadlineMs + AUTOFIRE_COMPLETION_GRACE_MS,
+      )
+      : 30_000;
+    deadline = setTimeout(() => {
+      logAutofire(String(payload?.root || ''), {
+        sid: typeof payload?.sid === 'string' ? payload.sid : null,
+        outcome: 'timed_out',
+        timeout_ms: timeoutMs,
+      });
+      process.exit(0);
+    }, timeoutMs);
+    await runAutofireWorker(payload);
+  } catch (e) {
+    logErr(`autofire worker bootstrap failed: ${e?.message || e}`);
+  } finally {
+    if (deadline !== null) clearTimeout(deadline);
+  }
+  process.exit(0);
+}
+
+try {
+  const raw = readStdin();
+  if (!raw) process.exit(0);
+
+  let payload;
+  try { payload = JSON.parse(raw); } catch { process.exit(0); }
+  const sid = payload && payload.session_id;
+  if (!sid) process.exit(0);
+
+  const dir = path.join(os.homedir(), '.claude', 'ctx-refresh');
+  const pctFile = path.join(dir, sid + '.json');
+  const stateFile = path.join(dir, sid + '.state');
+
+  let state = { fired: false, fires: 0, last_pct: null, last_emit_pct: 0, pct_read_failed: false };
+  try {
+    const s = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    state = { ...state, ...s, fired: s.fired === true, fires: Number(s.fires) || 0 };
+  } catch { /* fresh session */ }
+
+  let pct;
+  if (!fs.existsSync(pctFile)) {
+    // Normal when nothing writes a per-session percentage file (no statusline
+    // integration wired), and also normal at session start before the first
+    // render of one that is — silent either way.
+    process.exit(0);
+  }
+  try {
+    pct = JSON.parse(fs.readFileSync(pctFile, 'utf8')).used_percentage;
+    if (typeof pct !== 'number' || Number.isNaN(pct)) throw new Error('used_percentage missing/NaN');
+  } catch (e) {
+    // The file EXISTS but is unreadable/malformed — the integration writing it
+    // broke, which silently kills the whole 60% reflex. Log ONCE per session
+    // (deduped via state) — this fires on every tool call otherwise.
+    if (!state.pct_read_failed) {
+      state.pct_read_failed = true;
+      try { fs.mkdirSync(dir, { recursive: true }); } catch {}
+      await writeSensorState(stateFile, state);
+      logErr(`pct file exists but unreadable for ${sid}: ${e?.message || e} — 60% reflex is BLIND this session`);
+    }
+    process.exit(0);
+  }
+  if (state.pct_read_failed) {
+    state.pct_read_failed = false; // recovered — re-arm the one-shot logger
+  }
+
+  // A live coordination cycle (if a fork wires one) owns the lifecycle.
+  if (coordinationActive()) process.exit(0);
+
+  try { fs.mkdirSync(dir, { recursive: true }); } catch {}
+  await launchRequestedAutofire(payload, sid, state, stateFile);
+  const emit = (msg) => {
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: { hookEventName: 'PreToolUse', additionalContext: msg },
+    }));
+  };
+  const prevPct = typeof state.last_pct === 'number' ? state.last_pct : pct;
+  state.last_pct = pct;
+
+  // 1. Full re-arm: real headroom recovered → escalation counter resets too.
+  if (pct < REARM_BELOW) {
+    state.fired = false;
+    state.fires = 0;
+    state.last_emit_pct = 0;
+    await writeSensorState(stateFile, state);
+    process.exit(0);
+  }
+
+  // 2. Compaction detected (big single-step drop while fired) but still >50 —
+  //    the compact didn't buy enough headroom. Escalate to /clear immediately.
+  if (state.fired && pct <= prevPct - COMPACT_DROP) {
+    state.fires += 1;
+    state.last_emit_pct = pct;
+    await writeSensorState(stateFile, state);
+    emit(msgClear(pct, 'Compaction just ran but context is still above 50%'));
+    process.exit(0);
+  }
+
+  // 3. Upward crossing while unarmed. fires≥2 means a prior crossing this
+  //    session never fully re-armed — compact wasn't enough, go /clear.
+  if (!state.fired && pct >= FIRE_AT) {
+    state.fired = true;
+    state.fires += 1;
+    state.last_emit_pct = pct;
+    await writeSensorState(stateFile, state);
+    emit(pct >= HARD_AT
+      ? msgClear(pct, `Past the ${HARD_AT}% hard line — refresh is mandatory now`)
+      : state.fires >= 2
+        ? msgClear(pct, 'Second 60% crossing without a full re-arm — /compact was not enough')
+        : msgRefresh(pct));
+    await launchRequestedAutofire(payload, sid, state, stateFile);
+    process.exit(0);
+  }
+
+  // 4. Dead-zone re-nudge: fired, still ≥60, climbing — re-alert every +5
+  //    points instead of going silent to 90%.
+  if (state.fired && pct >= FIRE_AT && pct >= state.last_emit_pct + RENUDGE_STEP) {
+    state.last_emit_pct = pct;
+    await writeSensorState(stateFile, state);
+    emit(pct >= HARD_AT
+      ? msgClear(pct, `Past the ${HARD_AT}% hard line — refresh is mandatory now`)
+      : state.fires >= 2
+        ? msgClear(pct, 'Context still climbing after escalation')
+        : msgRefresh(pct));
+    process.exit(0);
+  }
+
+  await writeSensorState(stateFile, state);
+  process.exit(0);
+} catch (e) {
+  logErr(`outer: ${e?.stack || e}`);
+  process.exit(0);
+}

--- a/daemons/ctx-refresh-sensor.mjs
+++ b/daemons/ctx-refresh-sensor.mjs
@@ -258,7 +258,7 @@ async function runAutofireWorker(payload) {
     if (!root || typeof sid !== 'string' || sid.length === 0) {
       throw new Error('worker payload lacks root/session id');
     }
-    const [{ runCapsuleVerb }, lifecycle, { readRequest }, { readCursor, cursorEqual },
+    const [{ runCapsuleVerb, capsuleLeftSkeleton }, lifecycle, { readRequest }, { readCursor, cursorEqual },
       { createCycleRecord, readCycleRecord, cycleRecordPath }] =
       await Promise.all([
         import('./capsule-verb.mjs'),
@@ -318,6 +318,32 @@ async function runAutofireWorker(payload) {
       capsulePath = path.isAbsolute(stopState.capsule_path)
         ? stopState.capsule_path
         : path.resolve(root, stopState.capsule_path);
+    }
+    // SKELETON GATE (readiness, before every validity check below): a fresh
+    // autosave capsule still carries the writer skeleton's null-family
+    // waiting_on — the agent's finalize step has not run yet. Handing it to the
+    // verb can only produce a refusal, and that refusal reads like a failure
+    // (the exact known-issue this gate closes: refresh cycles refused against
+    // brand-new capsules until real state lands). Defer QUIETLY instead; a
+    // later poll fires once the capsule has left skeleton state. Never seed a
+    // placeholder — a writer-producible waiting_on would destroy the proof
+    // that the agent's own finalize ran. Read failures fall THROUGH to the
+    // verb: an unreadable capsule is not "still skeleton", it is the verb's
+    // loud refusal to make.
+    let leftSkeleton = true;
+    try {
+      leftSkeleton = capsuleLeftSkeleton(fs.readFileSync(capsulePath, 'utf8'));
+    } catch { /* fall through to the verb's own refusal machinery */ }
+    if (!leftSkeleton) {
+      logAutofire(root, {
+        sid,
+        outcome: 'skipped_skeleton',
+        mode: transcriptPath ? 'cycle' : 'legacy',
+        capsule_source: capsuleSource,
+        capsule_path: capsulePath,
+        reason: 'capsule has not left skeleton state (waiting_on is null-family; finalize has not run) — deferred, not refused',
+      });
+      return;
     }
     const dryRun = process.env.CAPSULE_VERB_AUTOFIRE_DRY_RUN !== '0';
 

--- a/daemons/curated-close-pointer.mjs
+++ b/daemons/curated-close-pointer.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// curated-close-pointer.mjs — the ONE write path for a curated-close pointer
+// stamp. The capsule verb calls this instead of hand-writing the pointer, so
+// every curated close carries the schema the clear-barrier verifies and the
+// stop-writer's precedence check respects: trigger=curated-close + finalized_at +
+// session_id.
+//
+//   node curated-close-pointer.mjs <capsule-path> [--session <sid>] \
+//        [--cycle-token <tok>] [--reconciled <json>] \
+//        [--cycle-id <uuid>] [--context-epoch <n>] [--captured-through-event <id>] \
+//        [--capsule-sha256 <hex>] [--reconcile-digest <hex>]
+//   (capsule-path is POSITIONAL and must come FIRST; flags follow.)
+//
+// Pointer schema (v3): additive, default-null fields — no behavior change when
+// unset.
+//   --cycle-token <tok>  → cycle_token: per-refresh nonce; the CLEAR gate reads
+//                          this. null outside a supervisor refresh (a fresh stamp
+//                          with null OVERWRITES any prior token — no lingering replay).
+//   --reconciled <json>  → reconciled: {board_rows:[], git_head} proof the reconcile
+//                          ran (populated by the capsule verb). null until then.
+//   --cycle-id <uuid>             → cycle_id: echoes the refresh-cycle record.
+//   --context-epoch <n>           → context_epoch: integer, increments per clear.
+//   --captured-through-event <id> → captured_through_event_id: monotonic capture
+//                                    cursor for the quiescence barrier.
+//   --capsule-sha256 <hex>        → capsule_sha256: evidence integrity.
+//   --reconcile-digest <hex>      → reconcile_digest: canonical evidence-object digest.
+// Nothing gates on any of these fields yet — this module only stamps schema.
+//
+// Pointer shape: aigent-OS is single-operator, so the pointer always lives at
+// <memRoot>/BODY_STATE.json's state.last_capsule — the same convention the
+// context-capsule skill already documents. Session id: --session wins; else the
+// newest <memRoot>/runtime/stop-writer/<sid>.json by mtime (the live session's
+// state file — the stop-writer touches it every turn). No session resolvable ->
+// stamps session_id:null and says so loudly (the barrier treats a null-session
+// curated pointer as NOT satisfying the invariant).
+//
+// INVARIANT: fail LOUD, exit non-zero on a bad stamp — unlike the fire-and-forget
+// Stop hook, this runs in a deliberate close sequence where the operator must see
+// a failed precondition, not proceed-and-hope.
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { memRoot, seatOf } from './lifecycle-common.mjs';
+
+function fail(msg) {
+  console.error(`[curated-close-pointer] REFUSED: ${msg}`);
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const capArg = args.find((a) => !a.startsWith('--'));
+const sessFlag = args.indexOf('--session');
+const sessArg = sessFlag !== -1 ? args[sessFlag + 1] : null;
+
+// Additive flags (default null). flagVal returns the value only when it is a real
+// value (not another flag / not missing), so `--cycle-token` alone stays null.
+const flagVal = (name) => {
+  const i = args.indexOf(name);
+  if (i === -1) return null;
+  const v = args[i + 1];
+  return v && !v.startsWith('--') ? v : null;
+};
+const cycleToken = flagVal('--cycle-token');
+let reconciled = null;
+const recRaw = flagVal('--reconciled');
+if (recRaw) {
+  try { reconciled = JSON.parse(recRaw); }
+  catch { fail('--reconciled must be valid JSON, e.g. \'{"board_rows":["<id>"],"git_head":"<sha>"}\''); }
+}
+
+const cycleId = flagVal('--cycle-id');
+const capturedThroughEventId = flagVal('--captured-through-event');
+const capsuleSha256 = flagVal('--capsule-sha256');
+const reconcileDigest = flagVal('--reconcile-digest');
+let contextEpoch = null;
+const epochRaw = flagVal('--context-epoch');
+if (epochRaw !== null) {
+  const n = Number(epochRaw);
+  if (!Number.isInteger(n)) fail(`--context-epoch must be an integer, got: ${epochRaw}`);
+  contextEpoch = n;
+}
+// Cursor fields travel as a PAIR ({event_id, offset}). The offset is the half most
+// easily dropped by accident, and a receipt stamped without it can never verify.
+// Additive, default null.
+let capturedThroughOffset = null;
+const ctoRaw = flagVal('--captured-through-offset');
+if (ctoRaw !== null) {
+  const n = Number(ctoRaw);
+  if (!Number.isInteger(n) || n < 0) fail(`--captured-through-offset must be a non-negative integer, got: ${ctoRaw}`);
+  capturedThroughOffset = n;
+}
+
+if (!capArg) fail('usage: curated-close-pointer.mjs <capsule-path> [--session <sid>] [--cycle-token <tok>] [--reconciled <json>] [--cycle-id <uuid>] [--context-epoch <n>] [--captured-through-event <id>] [--captured-through-offset <n>] [--capsule-sha256 <hex>] [--reconcile-digest <hex>]');
+
+const root = String(process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || process.cwd());
+const seat = seatOf(root);
+const MEM = memRoot(root);
+
+const capPath = path.resolve(root, capArg);
+if (!existsSync(capPath)) fail(`capsule not found: ${capPath}`);
+
+// Frontmatter: id + objective + status. A curated capsule without an id is a
+// malformed close — refuse rather than stamp a pointer at an unaddressable anchor.
+const fm = readFileSync(capPath, 'utf8').split(/^---\s*$/m)[1] || '';
+const fmField = (k) => ((fm.match(new RegExp(`^${k}:\\s*(.+?)\\s*$`, 'm')) || [])[1] || '').replace(/^["']|["']$/g, '');
+const id = fmField('id') || path.basename(capPath, '.md');
+const objective = fmField('objective') || '(curated close)';
+const status = fmField('status') || 'complete';
+
+// Session id: explicit flag, else the newest stop-writer state file (the live session).
+let sid = sessArg || null;
+if (!sid) {
+  try {
+    const dir = path.join(MEM, 'runtime', 'stop-writer');
+    const newest = readdirSync(dir)
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => ({ f, m: statSync(path.join(dir, f)).mtimeMs }))
+      .sort((a, b) => b.m - a.m)[0];
+    if (newest) sid = path.basename(newest.f, '.json');
+  } catch { /* falls through to the loud null warning */ }
+}
+if (!sid) console.error('[curated-close-pointer] WARN: no session id resolvable — stamping session_id:null; the clear-barrier will NOT accept this pointer as a curated close for any session');
+
+const pointer = {
+  id,
+  path: path.relative(root, capPath).replace(/\\/g, '/'),
+  objective: objective.slice(0, 300),
+  status,
+  created_at: new Date().toISOString(),
+  trigger: 'curated-close',
+  finalized_at: new Date().toISOString(),
+  session_id: sid,
+  // Additive, default null. Explicit null on a fresh stamp OVERWRITES any prior
+  // token (freshness-overwrite invariant). No gate reads these yet — cycle_token
+  // gating and reconciled population are follow-on work.
+  cycle_token: cycleToken,
+  reconciled,
+  cycle_id: cycleId,
+  context_epoch: contextEpoch,
+  captured_through_event_id: capturedThroughEventId,
+  captured_through_offset: capturedThroughOffset,
+  capsule_sha256: capsuleSha256,
+  reconcile_digest: reconcileDigest,
+};
+
+const bsPath = path.join(MEM, 'BODY_STATE.json');
+let bs;
+try { bs = JSON.parse(readFileSync(bsPath, 'utf8')); } catch (e) { fail(`BODY_STATE.json unreadable: ${e?.message || e}`); }
+if (!bs?.state) fail('BODY_STATE.json has no .state — pointer not stamped');
+bs.state.last_capsule = { ...bs.state.last_capsule, ...pointer };
+writeFileSync(bsPath, JSON.stringify(bs, null, 2));
+
+console.log(`[curated-close-pointer] STAMPED ${seat}: ${id} (session ${sid ?? 'null'}, finalized ${pointer.finalized_at}, cycle_token ${cycleToken ?? 'null'}, cycle_id ${cycleId ?? 'null'}, context_epoch ${contextEpoch ?? 'null'}, captured_through_event_id ${capturedThroughEventId ?? 'null'}, captured_through_offset ${capturedThroughOffset ?? 'null'}, capsule_sha256 ${capsuleSha256 ?? 'null'}, reconcile_digest ${reconcileDigest ?? 'null'})`);

--- a/daemons/effect-receipts.mjs
+++ b/daemons/effect-receipts.mjs
@@ -1,0 +1,246 @@
+// effect-receipts.mjs — append-only external-effect receipt ledger.
+//
+// File: <memRoot>/runtime/effect-receipts-<seatId>.jsonl. This module defines the
+// business-OS seam only; it is not wired to any live effect-producing path out of
+// the box — a fork wires its own effect producers (payments, deploys, sends...) to
+// call appendReceipt() when they resolve.
+
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { memRoot as resolveMemRoot, seatOf } from './lifecycle-common.mjs';
+
+const RECEIPT_STATES = Object.freeze([
+  'requested',
+  'accepted',
+  'completed',
+  'failed',
+  'safe-retry',
+]);
+
+const RECEIPT_FIELDS = new Set([
+  'idempotency_key',
+  'system',
+  'external_id',
+  'state',
+  'ts',
+]);
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+// Accept UTC ISO-8601 with zero to three fractional-second digits, while
+// rejecting Date.parse's rollover of impossible dates (for example Feb 30).
+function isStrictIsoTimestamp(value) {
+  if (typeof value !== 'string') return false;
+  const match = value.match(
+    /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,3}))?Z$/,
+  );
+  if (!match) return false;
+  const normalized = match[1] + '.' + (match[2] ?? '').padEnd(3, '0') + 'Z';
+  const epoch = Date.parse(normalized);
+  return Number.isFinite(epoch) && new Date(epoch).toISOString() === normalized;
+}
+
+// Validate and project onto the exact ledger shape. external_id is explicit
+// null because the reconcile evidence schema always carries that field.
+function normalizeReceipt(entry) {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    throw new Error('effect-receipts: receipt must be an object');
+  }
+  const unknown = Object.keys(entry).filter((key) => !RECEIPT_FIELDS.has(key));
+  if (unknown.length) {
+    throw new Error('effect-receipts: unknown receipt field(s): ' + unknown.sort().join(', '));
+  }
+  if (!isNonEmptyString(entry.idempotency_key)) {
+    throw new Error('effect-receipts: idempotency_key must be a non-empty string');
+  }
+  if (!isNonEmptyString(entry.system)) {
+    throw new Error('effect-receipts: system must be a non-empty string');
+  }
+  if (entry.external_id !== undefined && entry.external_id !== null
+    && !isNonEmptyString(entry.external_id)) {
+    throw new Error('effect-receipts: external_id must be a non-empty string or null when present');
+  }
+  if (!RECEIPT_STATES.includes(entry.state)) {
+    throw new Error(
+      'effect-receipts: state must be one of [' + RECEIPT_STATES.join('|')
+        + '], got: ' + JSON.stringify(entry.state),
+    );
+  }
+  if (!isStrictIsoTimestamp(entry.ts)) {
+    throw new Error(
+      'effect-receipts: ts must be a valid UTC ISO-8601 timestamp, got: '
+        + JSON.stringify(entry.ts),
+    );
+  }
+  return {
+    idempotency_key: entry.idempotency_key,
+    system: entry.system,
+    external_id: entry.external_id ?? null,
+    state: entry.state,
+    ts: entry.ts,
+  };
+}
+
+// Canonical JSON sorts object keys recursively and preserves array order.
+function canonicalJson(value) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error('effect-receipts: canonical JSON rejects non-finite numbers');
+    }
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map((item) => canonicalJson(item)).join(',') + ']';
+  }
+  if (value && typeof value === 'object') {
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) {
+      throw new Error('effect-receipts: canonical JSON accepts plain objects only');
+    }
+    return '{' + Object.keys(value).sort().map((key) => (
+      JSON.stringify(key) + ':' + canonicalJson(value[key])
+    )).join(',') + '}';
+  }
+  throw new Error('effect-receipts: canonical JSON cannot encode ' + typeof value);
+}
+
+function resolveScope(scope = {}) {
+  if (!scope || typeof scope !== 'object' || Array.isArray(scope)) {
+    throw new Error('effect-receipts: scope must be an object when provided');
+  }
+  const root = String(process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || process.cwd());
+  const memory = scope.memRoot ?? resolveMemRoot(root);
+  const seatId = scope.seatId ?? seatOf(root);
+  if (!isNonEmptyString(memory)) throw new Error('effect-receipts: memRoot is required');
+  if (!isNonEmptyString(seatId)) throw new Error('effect-receipts: seatId is required');
+  // seatId becomes a filename component; forbid traversal and separators.
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(seatId)) {
+    throw new Error('effect-receipts: unsafe seatId: ' + JSON.stringify(seatId));
+  }
+  return { memRoot: path.resolve(memory), seatId };
+}
+
+function ledgerPath(scope) {
+  const resolved = resolveScope(scope);
+  return path.join(
+    resolved.memRoot,
+    'runtime',
+    'effect-receipts-' + resolved.seatId + '.jsonl',
+  );
+}
+
+export function receiptDigest(entry) {
+  const normalized = normalizeReceipt(entry);
+  return createHash('sha256').update(canonicalJson(normalized), 'utf8').digest('hex');
+}
+
+export function appendReceipt(entry, scope) {
+  // Validate and serialize before creating or opening the ledger: a refused
+  // entry must leave no partial file or line behind.
+  const normalized = normalizeReceipt(entry);
+  const file = ledgerPath(scope);
+  const line = Buffer.from(JSON.stringify(normalized) + '\n', 'utf8');
+  mkdirSync(path.dirname(file), { recursive: true });
+
+  let fd;
+  let failure = null;
+  try {
+    fd = openSync(
+      file,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND,
+      0o600,
+    );
+    // Exactly one append write per receipt. O_APPEND couples end-position
+    // selection to this write rather than a racy stat/seek/write sequence.
+    const written = writeSync(fd, line, 0, line.length, null);
+    if (written !== line.length) {
+      throw new Error(
+        'short append (' + written + '/' + line.length + ' bytes) to ' + file,
+      );
+    }
+    fsyncSync(fd);
+  } catch (error) {
+    failure = error;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch (error) {
+        if (!failure) failure = error;
+      }
+    }
+  }
+
+  if (failure) {
+    throw new Error(
+      'effect-receipts: append failed for ' + file + ': '
+        + (failure?.message || failure),
+    );
+  }
+  return normalized;
+}
+
+export function readReceipts(scope) {
+  const file = ledgerPath(scope);
+  if (!existsSync(file)) return [];
+
+  let raw;
+  try {
+    raw = readFileSync(file, 'utf8');
+  } catch (error) {
+    throw new Error(
+      'effect-receipts: read failed for ' + file + ': '
+        + (error?.message || error),
+    );
+  }
+  if (raw.length === 0) return [];
+
+  const lines = raw.split('\n');
+  // Ignore only the split artifact from one normal terminal newline. Interior
+  // blank lines remain malformed ledger records and fail closed below.
+  if (lines.at(-1) === '') lines.pop();
+
+  return lines.map((line, index) => {
+    const lineNumber = index + 1;
+    if (line.trim().length === 0) {
+      throw new Error(
+        'effect-receipts: malformed line ' + lineNumber + ' in ' + file
+          + ': blank line',
+      );
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      throw new Error(
+        'effect-receipts: malformed JSON at line ' + lineNumber + ' in '
+          + file + ': ' + (error?.message || error),
+      );
+    }
+
+    try {
+      return normalizeReceipt(parsed);
+    } catch (error) {
+      throw new Error(
+        'effect-receipts: malformed receipt at line ' + lineNumber + ' in '
+          + file + ': ' + (error?.message || error),
+      );
+    }
+  });
+}

--- a/daemons/lifecycle-common.mjs
+++ b/daemons/lifecycle-common.mjs
@@ -1,0 +1,153 @@
+// lifecycle-common.mjs — shared identity/vault resolution for the two-verb lifecycle.
+//
+// aigent-OS is single-operator by default: one vault, one BODY_STATE.json, one
+// active-capsule pointer. `seatId` stays a first-class concept (not stripped) so a
+// fork that dispatches persistent sub-agents — each with its own vault root — can
+// still tag evidence/receipts per-identity; out of the box it resolves to the
+// single 'operator' identity via AIGENT_SEAT_ID (or the default). Keep this file
+// dependency-free and side-effect-free — everything downstream imports from here.
+
+import { readFileSync, writeFileSync, existsSync, appendFileSync, writeSync } from 'node:fs';
+import path from 'node:path';
+
+// seatId resolution: env override first (multi-instance forks), else the fixed
+// single-operator default. No path-based regex table — a single vault has nothing
+// to disambiguate.
+export function seatOf(root) {
+  const override = process.env.AIGENT_SEAT_ID;
+  if (typeof override === 'string' && override.trim().length > 0) return override.trim();
+  return 'operator';
+}
+
+// Memory root: aigent-OS's documented convention is <AIGENT_ROOT>/vault/memory
+// (see daemons/memory-heat/compute-heat.js). 'memory' at the root is kept as a
+// fallback for forks that skip the vault/ subdirectory.
+export function memRoot(root) {
+  for (const candidate of ['vault/memory', 'memory']) {
+    const p = path.join(String(root), ...candidate.split('/'));
+    if (existsSync(p)) return p;
+  }
+  return path.join(String(root), 'vault', 'memory');
+}
+
+// null = the read itself THREW (a real failure, log it); '' = genuinely empty.
+// The lifecycle legs need the distinction — an unreadable stdin must not read the
+// same as "no input".
+export function readStdin() {
+  try { return readFileSync(0, 'utf8'); } catch { return null; }
+}
+
+export function logErr(root, tag, msg) {
+  const line = `${new Date().toISOString()} [${tag}] ${msg}\n`;
+  try {
+    appendFileSync(path.join(memRoot(String(root || process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || ''))
+      , '.daemon-errors.log'), line);
+  } catch {
+    // Last resort: stderr is visible to an operator tailing hook output and is NOT
+    // injected into model context on exit 0 — better than truly silent. writeSync
+    // is synchronous even on pipes.
+    try { writeSync(2, line); } catch { /* truly nowhere to log */ }
+  }
+}
+
+// flipCapsuleToResumed — the ONE shared implementation the SessionStart hook calls
+// so a bug in the flip is fixed once, not per-caller.
+//
+// What this guards against: the capsule template pre-seeds a `resumed_at: null` /
+// `resumed_by_session: null` PLACEHOLDER PAIR in the frontmatter. A naive flip that
+// just replaces `status: active` -> `status: resumed\nresumed_at: <ts>\n...` never
+// removes that pre-existing placeholder pair sitting a few lines later in the SAME
+// frontmatter block — duplicate YAML keys, and a last-key-wins reader sees the NULL
+// placeholder, silently erasing the flip's own work on next read. This function
+// DEDUPES: any existing resumed_at/resumed_by_session line (placeholder or stale
+// real value) is stripped before the fresh pair is inserted, so exactly one of each
+// survives.
+//
+// Also closes two adjacent CRLF hazards:
+//   - a naive `doc.split(/^---\s*$/m)` + `join('---')` round-trip on a CRLF file
+//     consumes each delimiter line's own \r into the match (\s spans \r; the regex
+//     backtracks to let the multiline $ land right before the \n) and re-inserts a
+//     bare '---' with no terminator of its own — mixed line endings on write.
+//   - a trailing greedy `\s*$` on an inserted VALUE line has the same failure mode.
+// Fixed by detecting the file's dominant EOL once (before any mutation) and never
+// reconstructing the delimiter lines at all: a single regex captures the OPENING
+// delimiter LINE (bytes, terminator included), the frontmatter BODY, and the
+// CLOSING delimiter LINE (bytes, terminator included) as three groups; only the
+// body group is ever rewritten, and the delimiter bytes are spliced back verbatim.
+//
+// An already-'resumed' status is STEADY-STATE (a zero-turn restart observing its
+// own earlier flip is not drift and not an error) — silently a no-op.
+//
+// TOCTOU-safe: the read is wrapped in try/catch; a read failure (including ENOENT)
+// classifies as 'dangling' rather than throwing, so a pointer whose target file
+// vanished between the caller's own existence check and this call is not an
+// uncaught exception. NEVER throws and NEVER logs itself — callers decide what is
+// user-visible for each outcome.
+//
+// Returns { outcome, detail }:
+//   'flipped'      — status was active; now resumed, stamps written, dedupe applied.
+//   'steady_state' — status was already 'resumed'; untouched, not an error.
+//   'dangling'     — the capsule file could not be read (gone, permissions, etc).
+//   'drift'        — frontmatter malformed (no closing delimiter) or status is
+//                     neither active nor resumed when the caller expected active
+//                     (leave a trail instead of a silent no-op).
+//   'error'        — the write itself failed after a successful flip computation.
+//
+// Captures (1) the OPENING delimiter LINE with its own terminator, (2) the
+// frontmatter BODY (lazy — stops at the first line that is bare '---'), (3) the
+// CLOSING delimiter LINE with its own terminator (or no terminator, if the file
+// ends exactly there). Only group 2 is ever rewritten; groups 1 and 3 are spliced
+// back byte-for-byte, so there is no reconstruction step that could lose or alter
+// a delimiter line's line ending.
+const FRONTMATTER_RE = /^(---[ \t]*\r?\n)([\s\S]*?)(^---[ \t]*(?:\r?\n|$))/m;
+
+export function flipCapsuleToResumed(capsulePath, sessionId, { readFile = readFileSync, writeFile = writeFileSync } = {}) {
+  let doc;
+  try {
+    doc = readFile(capsulePath, 'utf8');
+  } catch (e) {
+    return { outcome: 'dangling', detail: `capsule unreadable: ${e?.message || e}` };
+  }
+  // Detect the file's dominant line-ending style ONCE, before any mutation, so
+  // every newly inserted line matches it — CRLF files never end up with bare-LF
+  // lines mixed in.
+  const eol = doc.includes('\r\n') ? '\r\n' : '\n';
+  const match = doc.match(FRONTMATTER_RE);
+  if (!match) {
+    return { outcome: 'drift', detail: 'frontmatter has no closing delimiter (block not found)' };
+  }
+  const [whole, openDelim, block, closeDelim] = match;
+  // [ \t]* NOT \s* at the trailing edge: \s spans \r AND \n, so a greedy \s*$ on a
+  // CRLF line consumes the line's OWN \r into the match (backtracking to let $ land
+  // right before the \n) — the replace below would then swap in text with no
+  // trailing terminator of its own, orphaning that \n with no \r partner. A
+  // trailing value can only legitimately carry spaces/tabs, never a line
+  // terminator, so [ \t]* can never consume across the CRLF boundary.
+  if (/^status:[ \t]*['"]?resumed['"]?[ \t]*$/m.test(block)) {
+    return { outcome: 'steady_state', detail: 'capsule frontmatter already reads status: resumed' };
+  }
+  if (!/^status:[ \t]*['"]?active['"]?[ \t]*$/m.test(block)) {
+    return { outcome: 'drift', detail: 'frontmatter status is neither active nor resumed (regex miss)' };
+  }
+  // Dedupe FIRST (strip any pre-existing resumed_at/resumed_by_session line —
+  // placeholder null or stale real value), THEN insert the fresh pair. Order
+  // matters: inserting first would just recreate the duplicate-key bug this
+  // function exists to fix.
+  const deduped = block
+    .replace(/^resumed_at:.*(?:\r?\n|$)/gm, '')
+    .replace(/^resumed_by_session:.*(?:\r?\n|$)/gm, '');
+  const stamped = deduped.replace(
+    /^status:[ \t]*['"]?active['"]?[ \t]*$/m,
+    `status: resumed${eol}resumed_at: ${new Date().toISOString()}${eol}resumed_by_session: ${String(sessionId || '').slice(0, 8)}`,
+  );
+  // Splice the rewritten body back between the VERBATIM delimiter bytes — no
+  // join('---') step exists to reconstruct (and potentially corrupt) the
+  // delimiter lines.
+  const newDoc = doc.slice(0, match.index) + openDelim + stamped + closeDelim + doc.slice(match.index + whole.length);
+  try {
+    writeFile(capsulePath, newDoc);
+  } catch (e) {
+    return { outcome: 'error', detail: `write failed: ${e?.message || e}` };
+  }
+  return { outcome: 'flipped', detail: 'status flipped active -> resumed, stamps written, any duplicate placeholder removed' };
+}

--- a/daemons/reconcile-collector.mjs
+++ b/daemons/reconcile-collector.mjs
@@ -1,0 +1,349 @@
+// reconcile-collector.mjs — deterministic, model-free capsule evidence.
+//
+// Three evidence classes, always in this shape: { version: 1, board, git,
+// external_effects }.
+//
+//   - git   is READ-ONLY and always present: index_tree is a SHA-256 digest of
+//     normalized `git ls-files --stage`, working_tree_digest is a SHA-256 digest
+//     of normalized porcelain status. `git write-tree` is never used.
+//     GIT_OPTIONAL_LOCKS=0 prevents status from taking optional refresh locks.
+//     Global/system Git config is disabled for these subprocesses so machine-wide
+//     excludes cannot change dirty evidence; repository-local config still applies.
+//
+//   - board is a PLUGGABLE evidence class. aigent-OS ships no task-board
+//     integration out of the box, so this degrades honestly to `null` unless the
+//     operator points AIGENT_BOARD_ADAPTER at a module. See collectBoard() below
+//     for the adapter contract.
+//
+//   - external_effects reads the append-only ledger in effect-receipts.mjs.
+//     Also absent any wiring by default (an empty array), and fills in once a
+//     fork calls appendReceipt() from its own effect-producing code.
+
+import { createHash } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { readReceipts, receiptDigest } from './effect-receipts.mjs';
+
+const execFileAsync = promisify(execFile);
+const GIT_TIMEOUT_MS = 15_000;
+const GIT_NULL_DEVICE = process.platform === 'win32' ? 'NUL' : '/dev/null';
+
+class EvidenceAdapterError extends Error {
+  constructor(message) {
+    super('board evidence adapter integrity failure: ' + message);
+    this.name = 'EvidenceAdapterError';
+  }
+}
+
+function compareText(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function canonicalValue(value, seen = new Set()) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('canonical JSON refuses non-finite numbers');
+    return value;
+  }
+  if (value instanceof Date) {
+    if (!Number.isFinite(value.getTime())) throw new TypeError('canonical JSON refuses invalid Dates');
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) throw new TypeError('canonical JSON refuses cyclic arrays');
+    seen.add(value);
+    const result = value.map((item) => {
+      if (item === undefined || typeof item === 'function' || typeof item === 'symbol') {
+        throw new TypeError('canonical JSON refuses non-JSON array values');
+      }
+      return canonicalValue(item, seen);
+    });
+    seen.delete(value);
+    return result;
+  }
+  if (typeof value === 'object') {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError('canonical JSON accepts plain objects only');
+    }
+    if (seen.has(value)) throw new TypeError('canonical JSON refuses cyclic objects');
+    seen.add(value);
+    const result = {};
+    for (const key of Object.keys(value).sort(compareText)) {
+      const item = value[key];
+      if (item === undefined || typeof item === 'function' || typeof item === 'symbol') {
+        throw new TypeError('canonical JSON refuses non-JSON value at key ' + key);
+      }
+      result[key] = canonicalValue(item, seen);
+    }
+    seen.delete(value);
+    return result;
+  }
+  throw new TypeError('canonical JSON refuses value of type ' + typeof value);
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(canonicalValue(value));
+}
+
+export function reconcileDigest(evidence) {
+  return sha256(canonicalJson(evidence));
+}
+
+function normalizeText(value) {
+  return String(value).replace(/\r\n?/g, '\n').replace(/\n+$/g, '');
+}
+
+function normalizeDate(value, field) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw new EvidenceAdapterError('board row ' + field + ' is not a valid date');
+  }
+  return date.toISOString();
+}
+
+function normalizeBoardRow(row) {
+  if (!row || typeof row !== 'object') throw new EvidenceAdapterError('board row is not an object');
+  if (typeof row.id !== 'string' || row.id.length === 0) {
+    throw new EvidenceAdapterError('board row id is missing');
+  }
+  if (typeof row.status !== 'string' || row.status.length === 0) {
+    throw new EvidenceAdapterError('board row ' + row.id + ' status is missing');
+  }
+  if (row.claimant !== null && row.claimant !== undefined && typeof row.claimant !== 'string') {
+    throw new EvidenceAdapterError('board row ' + row.id + ' claimant has an invalid type');
+  }
+  const updatedAt = normalizeDate(row.updated_at, 'updated_at');
+  let version = row.version;
+  if (version === undefined || version === null || version === '') {
+    // Adapters whose backing store exposes no native version column can use
+    // updated_at as a documented surrogate rather than fabricating a counter.
+    version = updatedAt;
+  } else if (version instanceof Date) {
+    version = normalizeDate(version, 'version');
+  } else if (typeof version !== 'string' && typeof version !== 'number') {
+    throw new EvidenceAdapterError('board row ' + row.id + ' version has an invalid type');
+  } else if (typeof version === 'number' && !Number.isFinite(version)) {
+    throw new EvidenceAdapterError('board row ' + row.id + ' version is not finite');
+  }
+  return {
+    id: row.id,
+    version,
+    status: row.status,
+    claimant: row.claimant ?? null,
+    updated_at: updatedAt,
+  };
+}
+
+function moduleHref(file) {
+  return /^file:/i.test(file) ? file : pathToFileURL(path.resolve(file)).href;
+}
+
+// PLUGGABLE EVIDENCE HOOK. aigent-OS ships no task-board of its own, so board
+// evidence degrades honestly to `null` by default (a valid, documented state —
+// capsule-verb.mjs's validateBoard() accepts board:null).
+//
+// To wire a real task-board integration, point AIGENT_BOARD_ADAPTER at a module
+// (absolute path or file:// URL) exporting:
+//
+//   export async function collectBoardEvidence({ seatId, boardRowIds }) {
+//     // boardRowIds is null when the caller wants "everything this identity
+//     // created or claimed"; otherwise an explicit array of row ids to fetch.
+//     // Return { query: string, rows: BoardRow[] } or null (board unavailable).
+//     // BoardRow = { id, status, claimant: string|null, updated_at, version? }
+//   }
+//
+// This collector computes the canonical digest itself (sha256 of the canonical
+// {query, rows} JSON) — adapters never need to compute or trust their own digest.
+// A thrown error from the adapter, or a malformed row it returns, is an
+// EvidenceAdapterError (loud, refuses the capsule) rather than a silent null —
+// silent degrade is reserved for "no adapter configured" / "adapter says
+// unavailable", never for "adapter returned garbage".
+async function collectBoard(seatId, boardRowIds) {
+  const adapterPath = process.env.AIGENT_BOARD_ADAPTER;
+  if (!adapterPath) return null; // no integration wired — honest, expected default
+
+  const explicitIds = boardRowIds === undefined
+    ? null
+    : [...new Set(boardRowIds.map((id) => String(id).trim()).filter(Boolean))].sort(compareText);
+  const query = explicitIds === null
+    ? 'created_or_claimed_rows_for_seat:' + seatId
+    : 'board_rows_by_id:' + explicitIds.join(',');
+
+  let raw;
+  try {
+    const adapter = await import(moduleHref(adapterPath));
+    if (typeof adapter.collectBoardEvidence !== 'function') {
+      throw new Error('adapter module has no collectBoardEvidence export');
+    }
+    raw = await adapter.collectBoardEvidence({ seatId, boardRowIds: explicitIds });
+  } catch (error) {
+    // Adapter load/call failure degrades honestly to null (matches "no adapter"
+    // behavior) — a misconfigured or offline adapter must not block the capsule
+    // verb, only reduce evidence richness.
+    return null;
+  }
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'object' || typeof raw.query !== 'string' || !Array.isArray(raw.rows)) {
+    throw new EvidenceAdapterError('collectBoardEvidence must return { query, rows } or null');
+  }
+
+  const rows = raw.rows.map(normalizeBoardRow).sort((a, b) => compareText(a.id, b.id));
+  if (explicitIds !== null) {
+    const found = new Set(rows.map((row) => row.id));
+    const missing = explicitIds.filter((id) => !found.has(id));
+    if (missing.length) {
+      throw new EvidenceAdapterError('requested board rows were not returned: ' + missing.join(','));
+    }
+  }
+  const effectiveQuery = raw.query || query;
+  return {
+    query: effectiveQuery,
+    rows,
+    digest: sha256(canonicalJson({ query: effectiveQuery, rows })),
+  };
+}
+
+function workspaceSpec(entry) {
+  if (typeof entry === 'string') {
+    if (entry.trim().length === 0) throw new TypeError('workspace path must be non-empty');
+    return { directory: entry, label: null };
+  }
+  if (entry && typeof entry === 'object' && typeof entry.path === 'string') {
+    if (entry.path.trim().length === 0) throw new TypeError('workspace path must be non-empty');
+    const rawLabel = entry.repo ?? entry.path_id ?? null;
+    if (rawLabel !== null
+      && (typeof rawLabel !== 'string' || rawLabel.trim().length === 0)) {
+      throw new TypeError('workspace repo label must be a non-empty string');
+    }
+    return { directory: entry.path, label: rawLabel?.trim() ?? null };
+  }
+  throw new TypeError('workspaces entries must be paths or { path, repo? } objects');
+}
+
+async function gitRaw(args) {
+  const { stdout } = await execFileAsync('git', args, {
+    encoding: 'buffer',
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: GIT_TIMEOUT_MS,
+    windowsHide: true,
+    env: {
+      ...process.env,
+      GIT_OPTIONAL_LOCKS: '0',
+      GIT_CONFIG_GLOBAL: GIT_NULL_DEVICE,
+      GIT_CONFIG_NOSYSTEM: '1',
+    },
+  });
+  return Buffer.isBuffer(stdout) ? stdout : Buffer.from(stdout);
+}
+
+async function gitText(args) {
+  return normalizeText((await gitRaw(args)).toString('utf8'));
+}
+
+async function collectGit(memRoot, workspaces) {
+  const requested = workspaces === undefined ? [memRoot] : workspaces;
+  if (!Array.isArray(requested) || requested.length === 0) {
+    throw new TypeError('workspaces must be a non-empty array when supplied');
+  }
+
+  const byRoot = new Map();
+  for (const entry of requested) {
+    const spec = workspaceSpec(entry);
+    const root = path.resolve(
+      await gitText(['-C', path.resolve(spec.directory), 'rev-parse', '--show-toplevel']),
+    );
+    const key = root.replace(/\\/g, '/');
+    const current = byRoot.get(key);
+    if (current?.label && spec.label && current.label !== spec.label) {
+      throw new Error('one workspace resolved to conflicting repo labels: '
+        + current.label + ' and ' + spec.label);
+    }
+    if (!current || (!current.label && spec.label)) byRoot.set(key, { root, label: spec.label });
+  }
+
+  const repositories = [];
+  const emittedNames = new Set();
+  for (const { root, label } of [...byRoot.values()].sort((a, b) => {
+    const aKey = String(a.label ?? path.basename(a.root)).replace(/\\/g, '/');
+    const bKey = String(b.label ?? path.basename(b.root)).replace(/\\/g, '/');
+    return compareText(aKey, bKey);
+  })) {
+    // The default identifier is the top-level directory name, not an absolute
+    // machine path, so otherwise-identical evidence hashes across machines.
+    // Callers with colliding basenames can pass { path, repo } labels.
+    const repo = String(label ?? path.basename(root)).replace(/\\/g, '/');
+    if (emittedNames.has(repo)) {
+      throw new Error('duplicate repo label ' + JSON.stringify(repo)
+        + '; pass distinct { path, repo } labels');
+    }
+    emittedNames.add(repo);
+    const [branch, head, indexListing, status] = await Promise.all([
+      gitText(['-C', root, 'rev-parse', '--abbrev-ref', 'HEAD']),
+      gitText(['-C', root, 'rev-parse', 'HEAD']),
+      gitRaw(['-c', 'core.quotepath=false', '-C', root, 'ls-files', '--stage', '-z']),
+      gitRaw([
+        '-c', 'core.quotepath=false', '-C', root,
+        'status', '--porcelain=v1', '-z', '--untracked-files=all',
+      ]),
+    ]);
+    repositories.push({
+      repo,
+      branch,
+      head,
+      index_tree: sha256(indexListing),
+      working_tree_digest: sha256(status),
+      dirty: status.length > 0,
+    });
+  }
+  repositories.sort((a, b) => compareText(a.repo, b.repo));
+  return repositories;
+}
+
+async function collectEffects(seatId, memRoot) {
+  const receipts = await readReceipts({ seatId, memRoot });
+  if (!Array.isArray(receipts)) throw new Error('effect receipt reader returned a non-array');
+  const effects = receipts.map((entry) => ({
+    idempotency_key: entry.idempotency_key,
+    system: entry.system,
+    external_id: entry.external_id ?? null,
+    state: entry.state,
+    receipt_digest: receiptDigest(entry),
+  }));
+  effects.sort((a, b) => compareText(canonicalJson(a), canonicalJson(b)));
+  return effects;
+}
+
+export async function collectEvidence({ seatId, memRoot, boardRowIds, workspaces } = {}) {
+  if (typeof seatId !== 'string' || seatId.trim().length === 0) {
+    throw new TypeError('collectEvidence: seatId must be a non-empty string');
+  }
+  if (typeof memRoot !== 'string' || memRoot.trim().length === 0) {
+    throw new TypeError('collectEvidence: memRoot must be a non-empty path');
+  }
+  if (boardRowIds !== undefined && !Array.isArray(boardRowIds)) {
+    throw new TypeError('collectEvidence: boardRowIds must be an array when supplied');
+  }
+  if (boardRowIds?.some((id) => typeof id !== 'string' || id.trim().length === 0)) {
+    throw new TypeError('collectEvidence: boardRowIds entries must be non-empty strings');
+  }
+
+  const normalizedSeat = seatId.trim();
+  const [board, git, externalEffects] = await Promise.all([
+    collectBoard(normalizedSeat, boardRowIds),
+    collectGit(path.resolve(memRoot), workspaces),
+    collectEffects(normalizedSeat, path.resolve(memRoot)),
+  ]);
+  return {
+    version: 1,
+    board,
+    git,
+    external_effects: externalEffects,
+  };
+}

--- a/daemons/refresh-cursor.mjs
+++ b/daemons/refresh-cursor.mjs
@@ -1,0 +1,118 @@
+// refresh-cursor.mjs — the capture-cursor primitive for the two-verb lifecycle.
+//
+// The single source of truth for "how far has this session been captured
+// through." Pure, dependency-injected, PTY-free.
+//
+// Source of truth = the session TRANSCRIPT jsonl, NOT the stop-writer state file
+// (whose offset only advances on Stop events — proven stale mid-turn).
+//
+//   Cursor = { event_id: string, offset: number }
+//     offset   = byte index just PAST the terminating newline of the last COMPLETE
+//                jsonl line = the cumulative "captured-through" byte boundary.
+//     event_id = that line's `uuid` (or its assistant message id).
+//   readCursor(transcriptPath, {readFile, stat}) -> Cursor | null
+//   cursorEqual(a, b)         -> event_id AND offset both equal
+//   cursorAdvanced(prev, cur) -> cur strictly beyond prev
+
+import { readFileSync, statSync } from 'node:fs';
+const defaultReadFile = (p) => readFileSync(p);           // Buffer (no encoding)
+const defaultStat = (p) => statSync(p);                   // Stats (.size)
+
+// Works entirely in BYTES (Buffer), never JS-string chars, so the offset is a true
+// byte boundary regardless of multibyte UTF-8 content in the transcript.
+
+const NEWLINE = 0x0a; // '\n'
+const CR = 0x0d;      // '\r'
+
+// event_id for a parsed transcript record: the line's own `uuid`, else the
+// assistant message id (message.id).
+function cursorEventId(obj) {
+  if (obj && typeof obj.uuid === 'string' && obj.uuid) return obj.uuid;
+  if (obj && obj.message && typeof obj.message.id === 'string' && obj.message.id) return obj.message.id;
+  return null;
+}
+
+// Parse ONE physical line's bytes (terminating newline already excluded). Strips
+// a single trailing CR so CRLF transcripts parse. Returns {ok:true,obj}|{ok:false}.
+function parseLineBytes(bytes) {
+  let end = bytes.length;
+  if (end > 0 && bytes[end - 1] === CR) end -= 1;
+  if (end === 0) return { ok: false };
+  try {
+    return { ok: true, obj: JSON.parse(bytes.toString('utf8', 0, end)) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+// Scan `buf` for the last COMPLETE (newline-terminated) line that parses AND
+// carries an event identity (uuid or message.id). offset = byte index just PAST
+// that line's terminating newline = cumulative boundary (monotonic as complete
+// lines are appended). Bytes after the final newline are the torn/mid-write
+// trailing segment and are NEVER counted (race-safe: a partial append can neither
+// over- nor under-count). Two backward-fallback rules compose:
+//   torn-line rule: a newline-terminated line that fails to parse falls back to
+//     the previous complete line's boundary;
+//   cursor-neutral rule: a line that parses but has NO identity (uuid-less harness
+//     metadata) is skipped the same way. Real transcript tails end with such
+//     records constantly; anchoring the cursor to the last IDENTITY-bearing line
+//     keeps metadata churn from moving the cursor. A transcript with no
+//     identity-bearing line at all -> null (not-ready; the caller retries per its
+//     own null-cursor rule).
+function scanCursor(buf) {
+  let searchEnd = buf.length; // exclusive upper bound for this line's newline hunt
+  while (searchEnd > 0) {
+    const nl = buf.lastIndexOf(NEWLINE, searchEnd - 1);
+    if (nl === -1) break; // no (more) newline-terminated line -> nothing complete
+    const lineStart = nl > 0 ? buf.lastIndexOf(NEWLINE, nl - 1) + 1 : 0;
+    const res = parseLineBytes(buf.subarray(lineStart, nl));
+    if (res.ok) {
+      const eventId = cursorEventId(res.obj);
+      if (eventId !== null) return { event_id: eventId, offset: nl + 1 };
+    }
+    searchEnd = nl; // corrupt or identity-less -> previous newline boundary
+  }
+  return null;
+}
+
+// readCursor(transcriptPath, {readFile, stat}) -> Cursor | null. deps default to
+// real fs; a torn/absent/empty file is fail-soft -> null (never throws).
+function readCursor(transcriptPath, deps) {
+  const d = deps || {};
+  const readFile = d.readFile || defaultReadFile;
+  const stat = d.stat || defaultStat;
+  let size = null;
+  try {
+    const st = stat(transcriptPath);
+    size = st && typeof st.size === 'number' ? st.size : null;
+  } catch {
+    return null;
+  }
+  if (size === 0) return null;
+  let buf;
+  try {
+    buf = readFile(transcriptPath);
+  } catch {
+    return null;
+  }
+  if (buf == null) return null;
+  if (!Buffer.isBuffer(buf)) buf = Buffer.from(buf); // byte-exactness if a string slipped in
+  if (buf.length === 0) return null;
+  return scanCursor(buf);
+}
+
+// cursorEqual(a,b): event_id AND offset both equal (null == null -> equal).
+function cursorEqual(a, b) {
+  if (a == null || b == null) return a == null && b == null;
+  return a.event_id === b.event_id && a.offset === b.offset;
+}
+
+// cursorAdvanced(prev,cur): cur strictly beyond prev by byte boundary. A first
+// cursor (prev null) with any real cur is an advance; a null cur never advances.
+function cursorAdvanced(prev, cur) {
+  if (cur == null) return false;
+  if (prev == null) return true;
+  return cur.offset > prev.offset;
+}
+
+export { readCursor, cursorEqual, cursorAdvanced };

--- a/daemons/refresh-cycle.mjs
+++ b/daemons/refresh-cycle.mjs
@@ -1,0 +1,150 @@
+// refresh-cycle.mjs — the CYCLE RECORD: a passive data-shape landing.
+//
+// Two objects, not one: the capsule POINTER (daemons/curated-close-pointer.mjs)
+// stays a concise audit echo; the transactional state of ONE refresh attempt lives
+// here, in its own ephemeral file, SEPARATE from the pointer.
+//
+// THIS MODULE DOES NOT IMPLEMENT (deliberately out of scope for this port):
+//   - CAS (compare-and-swap) consume on `state`
+//   - clear-gating (no gate reads this file to authorize a clear)
+//   - TTL/expiry enforcement (expires_at is a plain field, unchecked)
+//   - quiescence-barrier enforcement of captured_through_event_id
+// It only creates a well-formed record, writes it atomically (tmp+rename, same
+// pattern as curated-close-pointer.mjs's writeState), and reads it back with a
+// LOUD fail-closed on a malformed file — never a silent null/undefined.
+//
+// File location: <memRoot>/runtime/refresh-cycle-<sid>.json (one per session/cycle).
+//
+// Reuses lifecycle-common.mjs for memRoot/seatOf/logErr — no re-copied identity table.
+
+import {
+  readFileSync, writeFileSync, renameSync, rmSync, mkdirSync,
+} from 'node:fs';
+import path from 'node:path';
+import { memRoot, seatOf, logErr } from './lifecycle-common.mjs';
+
+// State machine for the expanded lifecycle. This module lands the enum as a value
+// set only — no transition enforcement.
+export const CYCLE_STATES = Object.freeze([
+  'requested', 'capsuling', 'prepared', 'clear_committed', 'cleared', 'resumed', 'aborted',
+]);
+
+const REQUIRED_STRING_FIELDS = ['cycle_id', 'lineage_id', 'runtime_session'];
+
+export function cycleRecordPath(root, sid) {
+  if (!sid) throw new Error('refresh-cycle: session id (sid) is required to locate the record path');
+  return path.join(memRoot(String(root)), 'runtime', `refresh-cycle-${sid}.json`);
+}
+
+// Loud, specific problems — never a bare "invalid". Empty array = valid.
+function validateRecord(record) {
+  const problems = [];
+  if (!record || typeof record !== 'object') return ['record is not an object'];
+  if (record.version !== 1) problems.push(`version must be 1, got: ${JSON.stringify(record.version)}`);
+  for (const f of REQUIRED_STRING_FIELDS) {
+    if (typeof record[f] !== 'string' || record[f].length === 0) {
+      problems.push(`${f} must be a non-empty string, got: ${JSON.stringify(record[f])}`);
+    }
+  }
+  if (!CYCLE_STATES.includes(record.state)) {
+    problems.push(`state must be one of [${CYCLE_STATES.join('|')}], got: ${JSON.stringify(record.state)}`);
+  }
+  if (record.captured_through_offset !== undefined && record.captured_through_offset !== null
+    && (!Number.isInteger(record.captured_through_offset) || record.captured_through_offset < 0)) {
+    problems.push(`captured_through_offset must be a non-negative integer or null, got: ${JSON.stringify(record.captured_through_offset)}`);
+  }
+  return problems;
+}
+
+// Pure constructor — no disk I/O. Fills defaults (all optional fields null, version
+// 1, state 'requested', issued_at now) then validates. Throws loud on a malformed
+// input (e.g. missing cycle_id) rather than returning a half-built record.
+export function createCycleRecord(fields = {}) {
+  const now = new Date().toISOString();
+  const record = {
+    version: 1,
+    cycle_id: fields.cycle_id ?? null,
+    lineage_id: fields.lineage_id ?? null,
+    runtime_session: fields.runtime_session ?? null,
+    context_epoch: fields.context_epoch ?? null,
+    state: fields.state ?? 'requested',
+    issued_at: fields.issued_at ?? now,
+    expires_at: fields.expires_at ?? null,
+    challenge_digest: fields.challenge_digest ?? null,
+    captured_through_event_id: fields.captured_through_event_id ?? null,
+    // Cursor fields travel as a PAIR ({event_id, offset}) — offset is the half most
+    // easily dropped by accident, and a receipt missing it can never verify.
+    captured_through_offset: fields.captured_through_offset ?? null,
+    capsule_id: fields.capsule_id ?? null,
+    capsule_sha256: fields.capsule_sha256 ?? null,
+    reconcile_digest: fields.reconcile_digest ?? null,
+    clear_committed_at: fields.clear_committed_at ?? null,
+    cleared_at: fields.cleared_at ?? null,
+    resumed_at: fields.resumed_at ?? null,
+    abort_reason: fields.abort_reason ?? null,
+  };
+  const problems = validateRecord(record);
+  if (problems.length) {
+    throw new Error(`refresh-cycle: cannot create malformed record: ${problems.join('; ')}`);
+  }
+  return record;
+}
+
+// Atomic tmp+rename write (mirrors curated-close-pointer.mjs's writeState). Refuses
+// to persist a malformed record rather than writing a bad file that reads back ugly.
+export function writeCycleRecord(root, sid, record) {
+  const problems = validateRecord(record);
+  if (problems.length) {
+    const msg = `refresh-cycle: refusing to write malformed record for sid=${sid}: ${problems.join('; ')}`;
+    logErr(root, 'refresh-cycle', msg);
+    throw new Error(msg);
+  }
+  const file = cycleRecordPath(root, sid);
+  mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify(record, null, 1));
+  try {
+    renameSync(tmp, file);
+  } catch {
+    try {
+      rmSync(file, { force: true });
+      renameSync(tmp, file);
+    } catch {
+      writeFileSync(file, JSON.stringify(record, null, 1));
+      try { rmSync(tmp, { force: true }); } catch { /* tmp orphan is harmless */ }
+    }
+  }
+  return file;
+}
+
+// Loud fail-closed read: an unreadable file, unparsable JSON, or a record missing
+// required fields / carrying an invalid `state` all THROW with a specific message —
+// never a silent null. Callers that want "no cycle yet" must check existence
+// themselves before calling read (this module has no existsCycleRecord — deliberately
+// minimal; add one when a real caller needs it).
+export function readCycleRecord(root, sid) {
+  const file = cycleRecordPath(root, sid);
+  let raw;
+  try {
+    raw = readFileSync(file, 'utf8');
+  } catch (e) {
+    const msg = `refresh-cycle: read failed for ${file}: ${e?.message || e}`;
+    logErr(root, 'refresh-cycle', msg);
+    throw new Error(msg);
+  }
+  let record;
+  try {
+    record = JSON.parse(raw);
+  } catch (e) {
+    const msg = `refresh-cycle: malformed JSON in ${file}: ${e?.message || e}`;
+    logErr(root, 'refresh-cycle', msg);
+    throw new Error(msg);
+  }
+  const problems = validateRecord(record);
+  if (problems.length) {
+    const msg = `refresh-cycle: malformed record in ${file} (seat ${seatOf(root) ?? 'unknown'}): ${problems.join('; ')}`;
+    logErr(root, 'refresh-cycle', msg);
+    throw new Error(msg);
+  }
+  return record;
+}

--- a/daemons/refresh-request.mjs
+++ b/daemons/refresh-request.mjs
@@ -1,0 +1,170 @@
+// refresh-request.mjs — the controller-to-session request-intake primitive.
+//
+// The controller->session CHALLENGE CROSSING. The controller mints a 32-byte
+// base64url nonce and drops a short-lived RefreshRequest file into the session's
+// runtime dir; the session's deterministic autofire worker reads it and hands the
+// RAW challenge to runCapsuleVerb (which computes the sha256:<hex> digest). The raw
+// nonce is NEVER persisted in the pointer / cycle record / capsule / vault — only
+// this transient request file carries it, and only until the cycle consumes it.
+//
+//   RefreshRequest = {
+//     version: 1,
+//     cycle_id: string,
+//     challenge: string,                 // raw base64url nonce — transient ONLY
+//     captured_through_hint: { event_id: string|null, offset: number },  // Cursor
+//     expires_at: string,                // ISO8601 — worker refuses past this
+//     issued_at: string,                 // ISO8601
+//   }
+//   writeRequest(seatMemRoot, sid, req) -> path        // atomic tmp+rename, loud
+//   readRequest(seatMemRoot, sid)       -> req | null  // fail-closed (absent/torn -> null)
+//   createRequest(fields)               -> req         // pure constructor, loud on bad input
+//
+// File location: <seatMemRoot>/runtime/refresh-request-<sid>.json (one per session).
+// Same atomic write discipline as refresh-cycle.mjs / curated-close-pointer.mjs.
+
+import {
+  readFileSync, writeFileSync, renameSync, rmSync, mkdirSync, writeSync,
+} from 'node:fs';
+import path from 'node:path';
+
+// Loud-but-non-fatal diagnostic. readRequest fails CLOSED (returns null) rather
+// than handing a half-trusted request to the cycle, but a PRESENT-yet-broken file
+// is a real anomaly the operator must see — stderr is visible to a hook tail and is
+// never injected into model context. ENOENT (no request yet) stays quiet: absence
+// is the normal steady state, not a failure.
+function warn(msg) {
+  try { writeSync(2, `${new Date().toISOString()} [refresh-request] ${msg}\n`); } catch { /* nowhere to log */ }
+}
+
+function requestPath(seatMemRoot, sid) {
+  if (typeof seatMemRoot !== 'string' || seatMemRoot.trim().length === 0) {
+    throw new Error('refresh-request: seatMemRoot must be a non-empty path');
+  }
+  if (typeof sid !== 'string' || sid.trim().length === 0) {
+    throw new Error('refresh-request: session id (sid) is required to locate the request path');
+  }
+  return path.join(path.resolve(seatMemRoot), 'runtime', `refresh-request-${sid}.json`);
+}
+
+// Loud, specific problems — never a bare "invalid". Empty array = valid shape.
+// Shape validation only: expiry is a POLICY the worker applies against its own
+// clock (so a past expires_at is a well-formed request the reader still surfaces —
+// the worker, not the reader, decides it is too old to fire).
+function validateRequest(req) {
+  if (!req || typeof req !== 'object' || Array.isArray(req)) return ['request is not an object'];
+  const problems = [];
+  if (req.version !== 1) {
+    problems.push(`version must be 1, got: ${JSON.stringify(req.version)}`);
+  }
+  for (const f of ['cycle_id', 'challenge']) {
+    if (typeof req[f] !== 'string' || req[f].length === 0) {
+      problems.push(`${f} must be a non-empty string, got: ${JSON.stringify(req[f])}`);
+    }
+  }
+  for (const f of ['issued_at', 'expires_at']) {
+    if (typeof req[f] !== 'string' || !Number.isFinite(Date.parse(req[f]))) {
+      problems.push(`${f} must be an ISO8601 string, got: ${JSON.stringify(req[f])}`);
+    }
+  }
+  const hint = req.captured_through_hint;
+  if (!hint || typeof hint !== 'object' || Array.isArray(hint)) {
+    problems.push('captured_through_hint must be an object');
+  } else {
+    if (hint.event_id !== null
+      && (typeof hint.event_id !== 'string' || hint.event_id.length === 0)) {
+      problems.push(`captured_through_hint.event_id must be a non-empty string or null, got: ${JSON.stringify(hint.event_id)}`);
+    }
+    if (!Number.isInteger(hint.offset) || hint.offset < 0) {
+      problems.push(`captured_through_hint.offset must be a non-negative integer, got: ${JSON.stringify(hint.offset)}`);
+    }
+  }
+  return problems;
+}
+
+// Pure constructor — no disk I/O. Fills version 1, issued_at now, and a zeroed
+// hint when absent, then validates. Throws loud on malformed input rather than
+// returning a half-built request.
+export function createRequest(fields = {}) {
+  const now = new Date().toISOString();
+  const hint = fields.captured_through_hint || {};
+  const req = {
+    version: 1,
+    cycle_id: fields.cycle_id ?? null,
+    challenge: fields.challenge ?? null,
+    captured_through_hint: {
+      event_id: hint.event_id ?? null,
+      offset: hint.offset ?? 0,
+    },
+    expires_at: fields.expires_at ?? null,
+    issued_at: fields.issued_at ?? now,
+  };
+  const problems = validateRequest(req);
+  if (problems.length) {
+    throw new Error(`refresh-request: cannot create malformed request: ${problems.join('; ')}`);
+  }
+  return req;
+}
+
+// Atomic tmp+rename write (mirrors refresh-cycle.mjs's writeCycleRecord). Refuses
+// to persist a malformed request — a partial/garbage challenge must never reach the
+// session, so the failure is loud (throw) not a silently-written bad file.
+export function writeRequest(seatMemRoot, sid, req) {
+  const problems = validateRequest(req);
+  if (problems.length) {
+    throw new Error(`refresh-request: refusing to write malformed request for sid=${sid}: ${problems.join('; ')}`);
+  }
+  const file = requestPath(seatMemRoot, sid);
+  mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify(req, null, 1));
+  try {
+    renameSync(tmp, file);
+  } catch {
+    try {
+      rmSync(file, { force: true });
+      renameSync(tmp, file);
+    } catch {
+      writeFileSync(file, JSON.stringify(req, null, 1));
+      try { rmSync(tmp, { force: true }); } catch { /* tmp orphan is harmless */ }
+    }
+  }
+  return file;
+}
+
+// Fail-closed read: an absent file (normal — no request yet), an unreadable file,
+// unparsable JSON (a torn mid-write rename), or a shape-invalid record ALL return
+// null — never a throw, never a half-trusted request. The worker treats null as a
+// hard refusal of the cycle: no /clear, no injection fires on a challenge it could
+// not fully verify. This is the safe direction under a concurrent controller write.
+export function readRequest(seatMemRoot, sid) {
+  let file;
+  try {
+    file = requestPath(seatMemRoot, sid);
+  } catch (e) {
+    warn(`bad request path (seatMemRoot=${JSON.stringify(seatMemRoot)}, sid=${JSON.stringify(sid)}): ${e?.message || e}`);
+    return null;
+  }
+  let raw;
+  try {
+    raw = readFileSync(file, 'utf8');
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return null; // no request yet — steady state, quiet
+    warn(`request unreadable at ${file}: ${e?.message || e}`);
+    return null;
+  }
+  let req;
+  try {
+    req = JSON.parse(raw);
+  } catch (e) {
+    warn(`torn/malformed request JSON at ${file}: ${e?.message || e}`);
+    return null;
+  }
+  const problems = validateRequest(req);
+  if (problems.length) {
+    warn(`invalid request shape at ${file}: ${problems.join('; ')}`);
+    return null;
+  }
+  return req;
+}
+
+export { requestPath };

--- a/daemons/resume-verb.mjs
+++ b/daemons/resume-verb.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// resume-verb.mjs — the resume verb container.
+//
+// The DETERMINISTIC half of the resume verb: resolve the pointer, load the
+// capsule frontmatter, and emit the session-facing procedure — the authored
+// content of docs/two-verb-lifecycle.md's resume procedure with its slot bindings
+// resolved:
+//   SLOT-1  pointer = BODY_STATE.json's state.last_capsule (aigent-OS is
+//           single-operator, so there is exactly one pointer shape).
+//   SLOT-2  definition_hash is recomputed HERE from the live capsule frontmatter —
+//           sha256(objective + next_valid_action) first 12 hex. The pointer
+//           carries no precomputed comparison value.
+//   SLOT-3  the live resume trigger is whatever put the session into `clear` —
+//           an operator-run /clear, or an automated refresh cycle. THIS daemon is
+//           the SessionStart(clear) hook that delivers the procedure content.
+//
+// Container discipline (mirrors the capsule verb): the model executes the
+// procedure; this module only loads state and emits text. It never touches
+// cycle_token, never verifies the clear, never reads the refresh machinery.
+// INVARIANT (same as every SessionStart leg): never break session start — any
+// error degrades to the re-derive-from-memory prompt and exits 0; real failures
+// append to <memRoot>/.daemon-errors.log.
+//
+// Fires on source=clear ONLY: startup/resume boots are warm starts that
+// sessionstart-reinject.mjs already grounds; compact continues the same session.
+// The post-clear boot is the one context wipe where the operator must be walked
+// through load → re-ground → ACT → ACK.
+
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { memRoot, readStdin, logErr } from './lifecycle-common.mjs';
+
+function frontmatterScalar(doc, key) {
+  const fmMatch = String(doc).match(/^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/);
+  if (!fmMatch) return null;
+  const m = fmMatch[1].match(new RegExp(`^${key}:[ \\t]*(.*)$`, 'm'));
+  if (!m) return null;
+  let v = m[1].trim();
+  try { const parsed = JSON.parse(v); if (typeof parsed === 'string') return parsed; } catch { /* raw scalar */ }
+  return v.replace(/^['"]|['"]$/g, '');
+}
+
+// SLOT-1: pointer resolution. Distinguishes absent from dangling (both degrade,
+// but a dangling pointer is a real signal worth its own log line).
+function loadCapsule(projectRoot) {
+  const mem = memRoot(projectRoot);
+  let pointer = null;
+  try {
+    const bs = JSON.parse(readFileSync(path.join(mem, 'BODY_STATE.json'), 'utf8'));
+    pointer = bs?.state?.last_capsule ?? null;
+  } catch (e) {
+    if (e?.code !== 'ENOENT') logErr(projectRoot, 'resume-verb', `pointer unreadable: ${e?.message || e}`);
+    return null;
+  }
+  if (!pointer?.path) return null;
+  const capPath = path.isAbsolute(pointer.path) ? pointer.path : path.join(projectRoot, pointer.path);
+  if (!existsSync(capPath)) {
+    logErr(projectRoot, 'resume-verb', `dangling pointer: ${capPath} no longer exists`);
+    return null;
+  }
+  let doc;
+  try { doc = readFileSync(capPath, 'utf8'); } catch (e) {
+    logErr(projectRoot, 'resume-verb', `capsule unreadable: ${e?.message || e}`);
+    return null;
+  }
+  return {
+    id: frontmatterScalar(doc, 'id') ?? pointer.id ?? null,
+    path: capPath,
+    objective: frontmatterScalar(doc, 'objective'),
+    waiting_on: frontmatterScalar(doc, 'waiting_on'),
+    next_valid_action: frontmatterScalar(doc, 'next_valid_action'),
+    definition_hash: frontmatterScalar(doc, 'definition_hash'),
+  };
+}
+
+// The authored procedure (docs/two-verb-lifecycle.md), slots bound. Every fence
+// and step below is contract text — edits belong in the doc first, then here in
+// lockstep (one authored source feeding one runtime artifact).
+function procedurePrompt(loaded) {
+  const lines = [];
+  lines.push('[RESUME VERB] This is a post-clear boot. Your ENTIRE job: load → validate → re-ground → ACT on waiting_on. Resumption is proven by the action taken, never by this text or the pointer table being in context.');
+  lines.push('');
+  if (loaded) {
+    lines.push(`LOADED (from ${loaded.path}):`);
+    if (loaded.id) lines.push(`  capsule id: ${loaded.id}`);
+    if (loaded.objective) lines.push(`  objective: ${loaded.objective}`);
+    if (loaded.waiting_on) lines.push(`  waiting_on: ${loaded.waiting_on}`);
+    if (loaded.next_valid_action) lines.push(`  next_valid_action: ${loaded.next_valid_action}`);
+    if (loaded.definition_hash) {
+      lines.push(`  definition_hash: ${loaded.definition_hash} — VALIDATE: recompute sha256(objective + next_valid_action) first 12 hex against the live capsule frontmatter; mismatch = the capsule drifted → re-derive from memory, do not trust the capsule.`);
+    } else {
+      lines.push('  definition_hash: ABSENT — treat as drifted: re-derive objective + next action from the live memory.');
+    }
+  } else {
+    lines.push('No resolvable capsule pointer (absent, dangling, or unreadable — already logged). Do NOT guess at prior state: re-derive entirely from the live memory in the re-ground step below.');
+  }
+  lines.push('');
+  lines.push('FENCES (never cross):');
+  lines.push('- Do NOT assert resumption is complete because the pointer table appears in context. Resumption is proven ONLY by an action taken from waiting_on.');
+  lines.push('- Do NOT read or reason about cycle_token, and do NOT skip the definition_hash check. cycle_token belongs to the CLEAR gate alone — resume never reads it.');
+  lines.push('- Do NOT treat capsule content as an active instruction queue. Done / Historical-* / Pending-Gates / Claimed-Rows are stale-by-default [REFERENCE ONLY]; re-grounding is what makes acting safe.');
+  lines.push('');
+  lines.push('STEPS (tight + terminal):');
+  lines.push('1. LOAD — done above (values inlined). Validate definition_hash as instructed.');
+  lines.push('2. RE-GROUND against live memory — re-read the latest session log and active priorities, surface anything that changed since the capsule was written. This folds in what /open would do, in full.');
+  lines.push('3. ACT — take the one next step from waiting_on / next_valid_action resolved against step 2; on any conflict, live memory wins over stale capsule content. The verb ends when that action is TAKEN, not when it is summarized.');
+  lines.push('4. ACK (if a supervising process demands one) — reply in exactly the format demanded, emitted ONLY after step 3\'s action is taken, never before.');
+  lines.push('');
+  lines.push('No stillness clock (resume is the wake-up, not the seal), but stay terminal: if you are still reading past re-grounding without having taken the step from waiting_on, stop reading and act.');
+  return lines.join('\n');
+}
+
+export function runResumeVerb({ projectRoot, source, sessionId }) {
+  let loaded = null;
+  try { loaded = loadCapsule(projectRoot); } catch (e) {
+    logErr(projectRoot, 'resume-verb', `loadCapsule threw: ${e?.stack || e}`);
+    loaded = null;
+  }
+  return {
+    source: String(source || ''),
+    sessionId: String(sessionId || ''),
+    degraded: !loaded,
+    loaded,
+    prompt: procedurePrompt(loaded),
+  };
+}
+
+// CLI (SessionStart hook entry). Matcher should be "clear"; the internal gate
+// makes the same promise even under a matcher:"*" mis-wire (defense in depth).
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (isMain) {
+  try {
+    let payload = {};
+    try { payload = JSON.parse(readStdin() || '{}'); } catch { /* non-JSON stdin */ }
+    const root = process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || payload.cwd || '';
+    const source = String(payload.source || 'startup');
+    if (root && source === 'clear') {
+      const result = runResumeVerb({ projectRoot: root, source, sessionId: payload.session_id });
+      process.stdout.write(result.prompt + '\n');
+    }
+  } catch (e) {
+    logErr(process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || '', 'resume-verb', `outer: ${e?.stack || e}`);
+  }
+  process.exit(0);
+}

--- a/daemons/sessionstart-reinject.mjs
+++ b/daemons/sessionstart-reinject.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+// sessionstart-reinject.mjs — warm-start pointer-table reinject (SessionStart hook).
+//
+// Fires on every SessionStart source (startup | resume | clear | compact) — a
+// single hook for a single operator. (The private origin of this port ran two
+// separate scripts because its multi-agent SessionStart matchers were wired
+// per-agent; that split doesn't apply to a single-operator install, so it is
+// merged into this one file — see docs/two-verb-lifecycle.md for the note.)
+// Prints, in order:
+//   1. CLOCK line — ground the waking session in real day/time before any orientation.
+//   2. identity line — <vault root>/identity-core.md if present, else a fallback.
+//   3. active-capsule POINTER TABLE — id / objective / next_valid_action /
+//      waiting_on + exact section pointers. NEVER full content.
+//   4. top-N heat-ranked wikilinks from HEAT_INDEX.json (token-budgeted)
+//   5. the latest SESSION_LOG.md heading, as a cold-start seed
+//
+// CLEAR-BARRIER: on source=clear, verify the JUST-CLEARED session ended with a
+// curated close. /clear itself cannot be pre-blocked at the hook layer
+// (SessionStart fires after; SessionEnd cannot block), so this makes the failure
+// DETERMINISTIC instead of recoverable-by-luck: it names the violated precondition
+// and pins the mandatory recovery (the rolling auto-capsule the stop-writer
+// guarantees) as the REQUIRED first action.
+//
+// COORDINATION GUARD (pluggable, optional): if a fork wires a multi-agent
+// coordination layer, point AIGENT_COORDINATION_STATE at a JSON file carrying a
+// `phase` field; a non-terminal phase means a conducted cycle is live and this
+// hook defers to it, injecting only a pointer at the conductor. Unset by default —
+// no coordination layer ships in the box.
+//
+// STALE-FINALIZE-LOCK RELEASE: anchoring on startup/resume/clear IS the resume —
+// flip the capsule's frontmatter status active→resumed so the stop-writer's
+// finalize-guard actually releases and rolling repoints re-arm for this session.
+// Compact is NOT a resume (mid-cycle flip would disarm an auto-refresh watcher's
+// capsule-ready gate, if one is wired) — excluded.
+//
+// INVARIANT: never break session start — any error exits 0; real failures append
+// to <memRoot>/.daemon-errors.log.
+
+import { readFileSync, existsSync, appendFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { memRoot as resolveMemRoot, flipCapsuleToResumed } from './lifecycle-common.mjs';
+
+const TOP_LINKS = 5;
+
+function memRoot(root) {
+  return resolveMemRoot(root);
+}
+
+function readStdin() {
+  try { return readFileSync(0, 'utf8'); } catch { return ''; }
+}
+
+function logErr(root, msg) {
+  try {
+    appendFileSync(path.join(memRoot(String(root)), '.daemon-errors.log'),
+      `${new Date().toISOString()} [sessionstart-reinject] ${msg}\n`);
+  } catch { /* truly nowhere to log */ }
+}
+
+// Pluggable coordination guard — see header. Absence of the env var (the default)
+// means no coordination layer is wired, so this always returns false.
+function coordinationActive() {
+  const statePath = process.env.AIGENT_COORDINATION_STATE;
+  if (!statePath) return false;
+  try {
+    const raw = readFileSync(statePath, 'utf8');
+    // Regex on raw text (never JSON.parse): a mid-write partial file must not
+    // throw, and an ambiguous read defaults to "live" — the safe direction.
+    return !/"phase"\s*:\s*"(done|cancelled|canceled|closed|complete|aborted)"/i.test(raw);
+  } catch {
+    return false;
+  }
+}
+
+// Distinguishes "no pointer" from a DANGLING pointer.
+function activeCapsule(root) {
+  const MEM = memRoot(root);
+  try {
+    const bs = JSON.parse(readFileSync(path.join(MEM, 'BODY_STATE.json'), 'utf8'));
+    const c = bs?.state?.last_capsule;
+    const cap = c && c.status === 'active' ? c : null;
+    if (!cap?.path) return { path: null, dangling: false };
+    const p = path.isAbsolute(cap.path) ? cap.path : path.join(root, cap.path);
+    if (existsSync(p)) return { path: p, dangling: false };
+    return { path: p, dangling: true };
+  } catch {
+    return { path: null, dangling: false };
+  }
+}
+
+function fm(doc, field) {
+  const m = doc.match(new RegExp(`^${field}: (.*)$`, 'm'));
+  if (!m) return null;
+  try { return JSON.parse(m[1]); } catch { return m[1].trim(); }
+}
+
+// CLEAR-BARRIER (enforcement-of-last-resort layer): on source=clear, verify the
+// JUST-CLEARED session ended with a curated close — pointer trigger=curated-close
+// (manual-close = legacy spelling), session_id = the cleared session, finalized_at
+// present. Cleared-session id = newest stop-writer state file that is NOT the new
+// session (the stop-writer touches <sid>.json every turn, so mtime order is
+// reliable). Returns null when the invariant holds or nothing is resolvable
+// (fresh install).
+function clearBarrier(root, newSid) {
+  const MEM = memRoot(root);
+
+  let prevSid = null;
+  let rollingCapsule = null;
+  try {
+    const dir = path.join(MEM, 'runtime', 'stop-writer');
+    const newest = readdirSync(dir)
+      .filter((f) => f.endsWith('.json') && path.basename(f, '.json') !== newSid)
+      .map((f) => ({ sid: path.basename(f, '.json'), full: path.join(dir, f), m: statSync(path.join(dir, f)).mtimeMs }))
+      .sort((a, b) => b.m - a.m)[0];
+    if (newest) {
+      prevSid = newest.sid;
+      try { rollingCapsule = JSON.parse(readFileSync(newest.full, 'utf8'))?.capsule_path || null; } catch { /* state torn */ }
+    }
+  } catch { /* no stop-writer dir — nothing to guard */ }
+  if (!prevSid) return null; // fresh install / no prior session: invariant vacuously holds
+
+  let cur = null;
+  try {
+    cur = JSON.parse(readFileSync(path.join(MEM, 'BODY_STATE.json'), 'utf8'))?.state?.last_capsule ?? null;
+  } catch { /* unreadable pointer = violation, reported below */ }
+
+  const missing = [];
+  if (!cur) missing.push('pointer unreadable/absent');
+  else {
+    if (cur.trigger !== 'curated-close' && cur.trigger !== 'manual-close') missing.push(`pointer trigger is '${cur.trigger ?? 'unset'}' (need curated-close)`);
+    if (String(cur.session_id || '') !== prevSid) missing.push(`pointer session_id '${cur.session_id ?? 'unset'}' != cleared session '${prevSid.slice(0, 8)}…'`);
+    if (!Number.isFinite(Date.parse(String(cur.finalized_at || '')))) missing.push('finalized_at absent/unparseable');
+  }
+  if (missing.length === 0) return { ok: true, id: cur.id };
+
+  logErr(root, `CLEAR-BARRIER VIOLATED: session ${prevSid} cleared without curated close — ${missing.join('; ')}`);
+  return { ok: false, prevSid, missing, rollingCapsule: rollingCapsule ? path.relative(root, rollingCapsule).replace(/\\/g, '/') : null };
+}
+
+try {
+  let payload = {};
+  try { payload = JSON.parse(readStdin() || '{}'); } catch { /* non-JSON */ }
+  const root = process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || payload.cwd || '';
+  if (!root) process.exit(0);
+  const source = String(payload.source || 'startup');
+
+  // CLOCK — ground the waking session in real day/time BEFORE any orientation. A
+  // bare wake fires no UserPromptSubmit, so a prompt-time clock injection can't
+  // cover it — this is the SessionStart half of "the session always knows the
+  // date." Unconditional, first, before the coordination-guard branch.
+  process.stdout.write(`[CLOCK] ${new Date().toString()}\n`);
+
+  // CLEAR-BARRIER: fires on every clear, INCLUDING during a live coordination
+  // cycle (a conducted clear-without-close is exactly the no-capsule-no-clear
+  // violation — surface it, never swallow it).
+  if (source === 'clear') {
+    const barrier = clearBarrier(root, String(payload.session_id || ''));
+    if (barrier && !barrier.ok) {
+      process.stdout.write(
+        `⛔ CLEAR-BARRIER VIOLATED: session ${barrier.prevSid.slice(0, 8)}… was cleared WITHOUT a curated close.\n`
+        + `   Missing precondition(s): ${barrier.missing.join('; ')}.\n`
+        + `   REQUIRED FIRST ACTION (deterministic recovery, not optional): its rolling auto-capsule is intact`
+        + (barrier.rollingCapsule ? ` at ${barrier.rollingCapsule}` : ' (path in memory/runtime/stop-writer/)')
+        + ` — reconstruct from it + git, write the curated close capsule, stamp the pointer via`
+        + ` daemons/curated-close-pointer.mjs, THEN start new work.\n`
+        + `   Do NOT trust the pointer table below as a resume anchor — it may be stale or rolling.\n`,
+      );
+    } else if (barrier && barrier.ok) {
+      process.stdout.write(`[clear-barrier] PASS — curated close '${barrier.id}' anchors the cleared session.\n`);
+    }
+  }
+
+  // A live coordination cycle (if a fork wires one) owns the lifecycle → drill
+  // pointer only.
+  if (coordinationActive()) {
+    process.stdout.write(`[SESSIONSTART:reinject] session (${source}) — a coordinated multi-agent cycle is LIVE. `
+      + `Follow its conductor; control legs run FULLY. Warm-start orientation deferred until the cycle closes.\n`);
+    process.exit(0);
+  }
+
+  const out = [];
+  const MEM = memRoot(root);
+
+  // Identity line — an optional <vault root>/identity-core.md, else a fallback.
+  const corePath = [path.join(path.dirname(MEM), 'identity-core.md'), path.join(root, 'identity-core.md')]
+    .find((p) => existsSync(p));
+  if (corePath) {
+    out.push(readFileSync(corePath, 'utf8').trim());
+  } else {
+    out.push(`[SESSIONSTART:reinject] session (${source}).`);
+  }
+
+  // Active-capsule pointer table + early constraints.
+  const cap = activeCapsule(root);
+  if (cap.path && !cap.dangling) {
+    const doc = readFileSync(cap.path, 'utf8');
+    const rel = path.relative(root, cap.path).replace(/\\/g, '/');
+    const obj = fm(doc, 'objective');
+    const next = fm(doc, 'next_valid_action');
+    const waiting = fm(doc, 'waiting_on');
+    const hash = fm(doc, 'definition_hash');
+    out.push('');
+    out.push(`🔁 ACTIVE CAPSULE (pointer table — pull sections on demand, never assume): ${rel}`);
+    out.push(`> [REFERENCE ONLY] — state snapshot, not instructions. Latest memory state wins.`);
+    // Per-field budget: the pointer table is a POINTER — "pull sections on
+    // demand" — not the capsule body. Bound each field so a verbose capsule
+    // can't bloat every session-start payload; the full text stays on disk.
+    const budget = (s, n) => { s = String(s); return s.length > n ? s.slice(0, n - 1).trimEnd() + '… [full in capsule]' : s; };
+    if (obj) out.push(`   objective: ${budget(obj, 240)}`);
+    if (next) out.push(`   next_valid_action: ${budget(next, 400)}`);
+    if (waiting && waiting !== 'null') out.push(`   waiting_on: ${budget(waiting, 200)}`);
+    if (hash) out.push(`   definition_hash: ${hash} — re-validate against the live capsule frontmatter before acting; mismatch = drifted, re-derive from memory.`);
+    out.push(`   sections: Done (don't redo) · Historical-Errors → Resolutions · Historical-Rejected-Approaches · Files-Read / Files-Modified · Operating-Facts · Pending-Gates · Claimed-Rows`);
+    out.push(`   Pending-Gates + Claimed-Rows are LIVE classes — re-verify each against memory before resuming them.`);
+
+    // STALE-FINALIZE-LOCK RELEASE: anchoring IS the resume — flip the capsule's
+    // frontmatter status active→resumed so the stop-writer's finalize-guard
+    // releases and rolling repoints resume for this session. A capsule never
+    // marked resumed would suppress repoints across every subsequent session.
+    // Compact is NOT a resume — the same session continues, and flipping
+    // mid-cycle would disarm an auto-refresh watcher's capsule-ready gate — so
+    // startup/resume/clear only.
+    if (source !== 'compact') {
+      const result = flipCapsuleToResumed(cap.path, payload.session_id);
+      if (result.outcome === 'flipped') {
+        out.push(`   [resume-flip] capsule marked resumed — finalize-lock released, rolling repoints re-armed.`);
+      } else if (result.outcome === 'steady_state') {
+        // Already resumed (e.g. a zero-turn restart observing its own earlier
+        // flip) — not drift, not an error, nothing to say.
+      } else if (result.outcome === 'dangling') {
+        // Should be unreachable here (activeCapsule() already gated on
+        // !cap.dangling above), but a TOCTOU window between that check and this
+        // call is real.
+        logErr(root, `resume-flip: capsule unreadable at ${cap.path}: ${result.detail}`);
+      } else if (result.outcome === 'drift') {
+        logErr(root, `resume-flip skipped for ${cap.path}: ${result.detail}`);
+      } else {
+        logErr(root, `resume-flip failed for ${cap.path}: ${result.detail}`);
+      }
+    }
+  } else if (cap.dangling) {
+    logErr(root, `DANGLING capsule pointer: ${cap.path} is gone (deleted under an active pointer)`);
+    out.push('');
+    out.push(`⚠ Active-capsule pointer targets ${cap.path} which no longer exists (deleted externally — a real signal, logged). Orient from the latest session log; run /open for full orientation.`);
+  } else {
+    out.push('');
+    out.push(`No active capsule. Run /open to orient.`);
+  }
+
+  // Heat-ranked wikilinks (token-budgeted: names only).
+  try {
+    const heat = JSON.parse(readFileSync(path.join(MEM, 'HEAT_INDEX.json'), 'utf8'));
+    const top = (heat.hot_top_20 ?? heat.hot ?? []).slice(0, TOP_LINKS)
+      .map((e) => (typeof e === 'string' ? e : e.name ?? e.note ?? e.path)).filter(Boolean);
+    if (top.length) out.push(`Hot notes: ${top.map((n) => `[[${n}]]`).join(' · ')}`);
+  } catch { /* no heat index yet — fine */ }
+
+  // Latest session-log hint (folds in the private origin's separate cold-start
+  // seed): first meaningful heading in SESSION_LOG.md after the title.
+  try {
+    const lines = readFileSync(path.join(MEM, 'SESSION_LOG.md'), 'utf8').split('\n');
+    for (const l of lines) {
+      const t = l.trim();
+      if (t.startsWith('## ') || t.startsWith('### ')) {
+        out.push(`Last session-log entry: ${t.replace(/^#+\s*/, '').slice(0, 160)}`);
+        break;
+      }
+    }
+  } catch { /* no session log yet — fine */ }
+
+  process.stdout.write(out.join('\n').slice(0, 8000) + '\n');
+} catch (e) {
+  logErr(process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || '', `outer: ${e?.stack || e}`);
+}
+process.exit(0);

--- a/daemons/stop-capsule-writer.mjs
+++ b/daemons/stop-capsule-writer.mjs
@@ -1,0 +1,664 @@
+#!/usr/bin/env node
+// stop-capsule-writer.mjs — every-turn capsule delta writer.
+//
+// Stop hook. Parses the transcript delta since the last turn and anchored-merges
+// it into the operator's ONE active capsule, so disk state is never more than one
+// turn stale (compaction = RAM, capsule = disk).
+//
+// Fire-and-forget: the parent process re-spawns itself detached+unref with the
+// hook payload and exits 0 immediately — the turn is never blocked, whatever the
+// transcript size. All real work happens in the child (--worker).
+//
+// CONCURRENCY: one writer at a time per session — a lock file under the runtime
+// dir serializes concurrent workers (fast consecutive turns, or a PreCompact flush
+// running this same worker synchronously). A loser exits WITHOUT advancing the
+// offset, so its delta is simply picked up next turn — deferred, never lost.
+//
+// Kill-switch: LIFECYCLE_KILL_STOP_WRITER=1 disables (test runners + emergencies).
+// INVARIANT: fail open — any error exits 0. Never blocks a turn. Never silent:
+// real failures append to <memRoot>/.daemon-errors.log.
+
+import {
+  readFileSync, writeFileSync, mkdirSync, existsSync, openSync, readSync,
+  closeSync, statSync, renameSync, rmSync, appendFileSync, writeSync,
+} from 'node:fs';
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { memRoot as resolveMemRoot } from './lifecycle-common.mjs';
+
+const SELF = fileURLToPath(import.meta.url);
+
+function memRoot(root) {
+  return resolveMemRoot(root);
+}
+
+function sha12(s) {
+  return createHash('sha256').update(s).digest('hex').slice(0, 12);
+}
+
+function readStdin() {
+  try { return readFileSync(0, 'utf8'); } catch { return ''; }
+}
+
+function logErr(root, msg) {
+  try {
+    appendFileSync(path.join(memRoot(String(root || process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || ''))
+      , '.daemon-errors.log'), `${new Date().toISOString()} [stop-capsule-writer] ${msg}\n`);
+  } catch { /* truly nowhere to log */ }
+}
+
+// ── parent: detach the worker and get out of the way ─────────────────────────
+if (process.argv[2] !== '--worker') {
+  try {
+    if (process.env.LIFECYCLE_KILL_STOP_WRITER === '1') process.exit(0);
+    const raw = readStdin();
+    if (!raw) process.exit(0);
+    let payload = {};
+    try { payload = JSON.parse(raw); } catch { process.exit(0); }
+    // stop_hook_active = this Stop fired because a previous Stop hook continued
+    // the turn — never re-enter.
+    if (payload.stop_hook_active === true) process.exit(0);
+    const root = process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || payload.cwd || '';
+    if (!root) process.exit(0);
+    const child = spawn(process.execPath, [SELF, '--worker', JSON.stringify({ ...payload, __root: root })], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    // spawn() failures (ENOENT/EMFILE/AV-block) surface async on a later tick —
+    // listen, then exit on the NEXT tick so the listener can fire.
+    child.on('error', (e) => logErr(root, `spawn failed: ${e?.message || e}`));
+    child.unref();
+    setImmediate(() => process.exit(0));
+  } catch (e) {
+    logErr(process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR, `parent: ${e?.stack || e}`);
+    process.exit(0);
+  }
+} else {
+// ── worker: parse transcript delta, anchored-merge into the active capsule ───
+let lockFd = null;
+let lockPath = null;
+let workerRoot = '';
+// Machine-readable outcome for a synchronous invoker (a precompact flush, if a
+// fork wires one) — exit-0 alone must never read as "flushed" (no-transcript /
+// no-delta / lock-defer all exit 0). fs.writeSync on fd 1 is synchronous even on
+// pipes, and 'exit' fires for explicit process.exit(), so every path below reports.
+let outcome = 'noop:early';
+process.on('exit', () => { try { writeSync(1, `SWE_OUTCOME:${outcome}\n`); } catch { /* stdio ignored (detached Stop path) */ } });
+try {
+  // The kill-switch must hold at the worker chokepoint too, for any caller that
+  // invokes the worker directly and bypasses the Stop parent.
+  if (process.env.LIFECYCLE_KILL_STOP_WRITER === '1') { outcome = 'noop:killed'; process.exit(0); }
+  const payload = JSON.parse(process.argv[3] || '{}');
+  const root = String(payload.__root || '');
+  workerRoot = root;
+  const sid = String(payload.session_id || '');
+  const transcriptPath = String(payload.transcript_path || '');
+  if (!root || !sid) { outcome = 'noop:bad-payload'; process.exit(0); }
+  if (!transcriptPath || !existsSync(transcriptPath)) { outcome = 'noop:no-transcript'; process.exit(0); }
+
+  // Content gate — lazy + fail-open, zero deps: the ONE vocabulary for
+  // injection-echo/ceremony, shared with capsule-verb's validateCapsuleText.
+  // Import failure degrades to pre-gate behavior (logged, never blocks a turn).
+  let gate = null;
+  try { gate = await import('./capsule-content-gate.mjs'); }
+  catch (e) { logErr(root, `content-gate import failed (gate skipped): ${e?.message || e}`); }
+
+  const MEM = memRoot(root);
+  const RUNTIME = path.join(MEM, 'runtime', 'stop-writer');
+  mkdirSync(RUNTIME, { recursive: true });
+
+  // Single-writer lock per session. Loser defers to next turn (offset untouched =
+  // no data loss). Stale locks (>30s — a killed worker) are stolen.
+  lockPath = path.join(RUNTIME, `${sid}.lock`);
+  try {
+    lockFd = openSync(lockPath, 'wx');
+  } catch {
+    try {
+      const age = Date.now() - statSync(lockPath).mtimeMs;
+      if (age > 30_000) {
+        rmSync(lockPath, { force: true });
+        lockFd = openSync(lockPath, 'wx');
+      } else {
+        outcome = 'noop:lock-defer';
+        process.exit(0); // live writer holds it — defer, don't lose
+      }
+    } catch { outcome = 'noop:lock-defer'; process.exit(0); }
+  }
+  // process.exit() SKIPS finally blocks — release the lock on the 'exit' event,
+  // which fires even for explicit exits (all early-exit paths below leak the
+  // lock otherwise, deferring every later writer to the 30s stale-steal).
+  process.on('exit', () => {
+    try { closeSync(lockFd); } catch {}
+    try { rmSync(lockPath, { force: true }); } catch {}
+  });
+
+  const stateFile = path.join(RUNTIME, `${sid}.json`);
+  let state = { offset: 0, capsule_path: null, last_delta_sha: null };
+  try { state = { ...state, ...JSON.parse(readFileSync(stateFile, 'utf8')) }; } catch { /* fresh */ }
+
+  const size = statSync(transcriptPath).size;
+  if (size === state.offset) { outcome = 'noop:no-delta'; process.exit(0); } // true no-op
+  if (size < state.offset) {
+    // Transcript replaced/rotated shorter — a stale offset here would stall the
+    // writer for the rest of the session. Reset + reprocess; normalized dedup
+    // below absorbs re-seen bullets.
+    logErr(root, `transcript shrank (${state.offset} -> ${size}) for ${sid} — offset reset to 0`);
+    state.offset = 0;
+  }
+  const fd = openSync(transcriptPath, 'r');
+  const buf = Buffer.alloc(size - state.offset);
+  readSync(fd, buf, 0, buf.length, state.offset);
+  closeSync(fd);
+  const chunk = buf.toString('utf8');
+
+  // ── extract the delta ──────────────────────────────────────────────────────
+  const filesRead = new Set();
+  const filesModified = new Set();
+  const errors = [];
+  const claimedRows = new Set();
+  const utterances = [];
+  let latestRequest = null;
+  let lastAssistantText = null;
+
+  // Speaker-aware classification. A close-time sweep can grep [OPERATOR] for
+  // unbanked human directives, so [OPERATOR] must be PRECISE — over-tagging agent
+  // chatter as [OPERATOR] makes the grep useless. Every bullet gets its true
+  // source: RELAY:x for a cross-session relay message (a live multi-agent mesh, if
+  // one is wired), PEER:x for a same-harness teammate/subagent envelope
+  // ("Another Claude session sent a message: <teammate-message ...>"),
+  // INJECT:harness for a harness/supervisor injection (gated centrally in
+  // capsule-content-gate.mjs), and OPERATOR only for a genuine human utterance.
+  // `human` also gates the objective so it can never be a peer envelope.
+  const classify = (s) => {
+    const t = s.replace(/\s+/g, ' ').trim(); // collapse first (raw "\n## " would corrupt section parsing)
+    let m;
+    // [^\]]*\] consumes any "@ <timestamp>" suffix a relay might add before the ]
+    if ((m = t.match(/^\[room from ([\w-]+)[^\]]*\]\s*/i))) return { who: `RELAY:${m[1].toLowerCase()}`, human: false, t: t.slice(m[0].length) };
+    if (/^\[inbox\b/i.test(t)) return { who: 'RELAY:inbox', human: false, t };
+    // Peer ONLY when the message IS the teammate envelope (starts with the known
+    // preamble or the tag). An UNANCHORED teammate_id match would downgrade a
+    // HUMAN message that merely quotes teammate_id="x" to PEER — losing the
+    // objective + the [OPERATOR] sweep.
+    if (/^Another Claude session sent a message/i.test(t) || /^<teammate-message\b/i.test(t)) {
+      const pm = t.match(/teammate_id="([\w-]+)"/i);
+      return { who: pm ? `PEER:${pm[1].toLowerCase()}` : 'PEER:agent', human: false, t };
+    }
+    // Harness/supervisor injections ([supervisor-resume], [refresh-cycle],
+    // [auto-pull], loop ticks, ...) arrive as PLAIN user strings and would
+    // otherwise fall through to [OPERATOR] — which makes injected instruction
+    // text the capsule OBJECTIVE verbatim. Gate them out of human-hood; they stay
+    // recoverable as tagged utterances under Done.
+    if (gate && gate.isInjectionEcho(t)) return { who: 'INJECT:harness', human: false, t };
+    return { who: 'OPERATOR', human: true, t };
+  };
+  const tagUtterance = (cl) => {
+    if (utterances.length >= 12) return; // bound a paste-bomb turn
+    utterances.push(`[${cl.who}] ${cl.t.slice(0, 240)}`);
+  };
+
+  // Harness wrapper blocks pollute the objective if left in (reminders are
+  // frequently APPENDED after real user text, not prepended).
+  const stripMeta = (s) => s
+    .replace(/<system-reminder>[\s\S]*?(<\/system-reminder>|$)/gi, '')
+    .replace(/<local-command-[\s\S]*?>/gi, '')
+    .trim();
+
+  for (const line of chunk.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    let ev;
+    try { ev = JSON.parse(t); } catch { continue; } // partial trailing lines are normal
+
+    if (ev.type === 'user' && !ev.isMeta) {
+      const c = ev.message?.content;
+      if (typeof c === 'string') {
+        const clean = stripMeta(c);
+        if (clean && !clean.startsWith('<')) { const cl = classify(clean); if (cl.human) latestRequest = clean.slice(0, 300); tagUtterance(cl); }
+      } else if (Array.isArray(c)) {
+        for (const b of c) {
+          if (b.type === 'text' && b.text) {
+            const clean = stripMeta(b.text);
+            if (clean && !clean.startsWith('<')) { const cl = classify(clean); if (cl.human) latestRequest = clean.slice(0, 300); tagUtterance(cl); }
+          }
+          if (b.type === 'tool_result' && b.is_error) {
+            const txt = typeof b.content === 'string'
+              ? b.content
+              : Array.isArray(b.content) ? b.content.filter((x) => x.type === 'text').map((x) => x.text).join(' ') : '';
+            if (txt) errors.push(txt.replace(/\s+/g, ' ').slice(0, 200));
+          }
+        }
+      }
+    } else if (ev.type === 'assistant') {
+      for (const b of ev.message?.content ?? []) {
+        if (b.type === 'text' && b.text?.trim()) lastAssistantText = b.text.trim();
+        if (b.type !== 'tool_use') continue;
+        const input = b.input ?? {};
+        if (b.name === 'Read' || b.name === 'Grep' || b.name === 'Glob') {
+          const p = input.file_path || input.path;
+          if (p) filesRead.add(String(p));
+        } else if (b.name === 'Edit' || b.name === 'Write' || b.name === 'NotebookEdit') {
+          if (input.file_path) filesModified.add(String(input.file_path));
+        } else if (/(^|_)board_claim$/i.test(String(b.name || '')) && input.task_id) {
+          // Generic match on any *_board_claim tool (an optional task-board MCP,
+          // whatever it is named) rather than one hardcoded server name.
+          claimedRows.add(String(input.task_id));
+        }
+      }
+    }
+  }
+
+  const deltaSig = sha12(JSON.stringify({
+    r: latestRequest, fr: [...filesRead].sort(), fm: [...filesModified].sort(),
+    e: errors, c: [...claimedRows].sort(), a: lastAssistantText?.slice(0, 200) ?? null,
+    u: utterances,
+  }));
+  // SHA-256 dedup: identical delta (a pure-conversation turn) → advance the
+  // offset, skip the write.
+  if (deltaSig === state.last_delta_sha) {
+    writeState(stateFile, { ...state, offset: size });
+    outcome = 'noop:no-delta';
+    process.exit(0);
+  }
+
+  // ── locate or create the operator's ONE active capsule ────────────────────
+  const capDir = path.join(MEM, 'capsules');
+  mkdirSync(capDir, { recursive: true });
+  const dateStr = new Date().toISOString().slice(0, 10);
+  let capPath = state.capsule_path;
+  if (capPath && !existsSync(capPath)) {
+    // Pointed-to capsule vanished (external delete / archive pass). Recreating
+    // silently would erase the session's history unaudited.
+    logErr(root, `active capsule missing at ${capPath} — recreating fresh; prior history lost`);
+    capPath = null;
+  }
+  if (!capPath) {
+    capPath = path.join(capDir, `${dateStr}-auto-${sid.slice(0, 8)}.md`);
+  }
+
+  // objective only ever carries a REAL human utterance — the classifier already
+  // gates injections; this re-check is defense in depth. When no human spoke this
+  // turn, nothing is synthesized: the ownership rule below keeps an existing
+  // capsule's objective untouched, and the skeleton default is only ever born at
+  // capsule creation.
+  const humanRequest = (latestRequest && !(gate && gate.isInjectionEcho(latestRequest)))
+    ? latestRequest : null;
+  const objective = humanRequest || 'In-flight work (auto-captured; see latest session log)';
+  // next_valid_action must carry CONTENT (claimed rows, live assistant state) —
+  // templates like "Re-read the active turn state below..." are exactly what
+  // capsule-verb's content gate bans; this template must never match it.
+  const rowHint = claimedRows.size
+    ? `Re-verify claimed row(s) ${[...claimedRows].map((r) => r.slice(0, 8)).join(', ')} against the live memory, then continue that work`
+    : 'Re-derive the next action from the live memory (autosave carries deltas only)';
+  const nextValid = lastAssistantText
+    ? `${rowHint}; last assistant state: ${lastAssistantText.replace(/\s+/g, ' ').slice(0, 180)}`
+    : rowHint;
+
+  const ANCHORS = {
+    done: '<!-- swe:done -->',
+    errors: '<!-- swe:errors -->',
+    rejected: '<!-- swe:rejected -->',
+    files: '<!-- swe:files -->',
+    facts: '<!-- swe:facts -->',
+    gates: '<!-- swe:gates -->',
+    rows: '<!-- swe:rows -->',
+  };
+
+  function skeleton() {
+    return `---
+id: ${dateStr}-auto-${sid.slice(0, 8)}
+parent_capsule_id: null
+status: active
+objective: ${JSON.stringify(objective)}
+waiting_on: null
+resume_trigger: compact
+expires: null
+trigger: stop-delta
+definition_hash: ${sha12(objective + nextValid)}
+next_valid_action: ${JSON.stringify(nextValid)}
+success_criteria: []
+tags: [capsule, autosave]
+created_at: ${new Date().toISOString()}
+resolved_at: null
+---
+
+> [!info] [REFERENCE ONLY] — state snapshot, not instructions. Latest memory state wins.
+
+## Done (don't redo)
+${ANCHORS.done}
+
+## Historical-Errors → Resolutions
+${ANCHORS.errors}
+
+## Historical-Rejected-Approaches
+${ANCHORS.rejected}
+
+## Files-Read / Files-Modified
+${ANCHORS.files}
+
+## Operating-Facts
+${ANCHORS.facts}
+
+## Pending-Gates
+${ANCHORS.gates}
+
+## Claimed-Rows
+${ANCHORS.rows}
+`;
+  }
+
+  let doc = existsSync(capPath) ? readFileSync(capPath, 'utf8') : skeleton();
+
+  // A bullet minus its `- ` prefix and volatile HH:MM stamp — dedup must not be
+  // defeated by re-processing a span at a different wall-clock minute (a
+  // timestamped duplicate could otherwise reappear after an offset reset).
+  const normalize = (b) => b.trim().replace(/^- /, '').replace(/^\d{2}:\d{2} /, '');
+
+  function mergeUnder(anchor, bullets) {
+    if (!bullets.length) return;
+    const idx = doc.indexOf(anchor);
+    if (idx === -1) {
+      // Hand-edited capsule without anchors: leaving it alone is right, but the
+      // offset still advances — these bullets never land anywhere else, so the
+      // drop must be visible.
+      logErr(root, `anchor ${anchor} missing in ${path.basename(capPath)} — ${bullets.length} bullet(s) NOT merged (hand-edited capsule?)`);
+      return;
+    }
+    const insertAt = idx + anchor.length;
+    const sectionEnd = (() => {
+      const rest = doc.indexOf('\n## ', insertAt);
+      return rest === -1 ? doc.length : rest;
+    })();
+    const existingNorm = new Set(
+      doc.slice(insertAt, sectionEnd).split('\n').map(normalize).filter(Boolean),
+    );
+    const fresh = bullets.filter((b) => !existingNorm.has(normalize(b)));
+    if (!fresh.length) return;
+    doc = doc.slice(0, insertAt) + '\n' + fresh.join('\n') + doc.slice(insertAt);
+  }
+
+  const ts = new Date().toISOString().slice(11, 16);
+  // Speaker-tagged utterances land under Done — a sweep can grep `[OPERATOR]` there.
+  mergeUnder(ANCHORS.done, utterances.map((u) => `- ${ts} ${u}`));
+  mergeUnder(ANCHORS.files, [
+    ...[...filesModified].map((f) => `- MODIFIED ${f}`),
+    ...[...filesRead].filter((f) => !filesModified.has(f)).map((f) => `- read ${f}`),
+  ]);
+  mergeUnder(ANCHORS.errors, errors.map((e) => `- ${ts} ${e} → (unresolved at capture; check next Done bullet)`));
+  mergeUnder(ANCHORS.rows, [...claimedRows].map((r) => `- ${r} (claimed this session — re-verify against memory at reinject)`));
+  if (lastAssistantText) {
+    mergeUnder(ANCHORS.done, [`- ${ts} ${lastAssistantText.replace(/\s+/g, ' ').slice(0, 240)}`]);
+  }
+
+  // Refresh live frontmatter fields — the rolling writer only RAISES content,
+  // never downgrades it. objective moves only on a real human utterance, and the
+  // contract fields are touched at all ONLY on the writer's own autosave capsules
+  // (tags carry `autosave`) — deliberate/curated capsules own their frontmatter
+  // outright. Body bullets can never match (always `- `-prefixed) and .replace is
+  // leftmost-first so frontmatter wins.
+  const docTags = ((doc.match(/^tags:\s*(.+)\s*$/m) || [])[1] || '').toLowerCase();
+  if (/\bautosave\b/.test(docTags)) {
+    let effObjective = objective;
+    if (humanRequest) {
+      doc = doc.replace(/^objective: .*$/m, `objective: ${JSON.stringify(objective)}`);
+    } else {
+      const m = doc.match(/^objective: (.*)$/m);
+      if (m) { try { effObjective = JSON.parse(m[1]); } catch { effObjective = m[1]; } }
+    }
+    doc = doc
+      .replace(/^next_valid_action: .*$/m, `next_valid_action: ${JSON.stringify(nextValid)}`)
+      .replace(/^definition_hash: .*$/m, `definition_hash: ${sha12(effObjective + nextValid)}`);
+  }
+
+  // Write the capsule. tmp+rename first; if rename can't land (AV lock etc.),
+  // fall back to a direct write — non-atomicity beats data loss. If NOTHING
+  // lands, exit WITHOUT advancing state so next turn retries this same delta.
+  const tmp = capPath + '.tmp';
+  let committed = false;
+  writeFileSync(tmp, doc);
+  try { renameSync(tmp, capPath); committed = true; } catch {
+    try { rmSync(capPath, { force: true }); renameSync(tmp, capPath); committed = true; } catch {
+      try { writeFileSync(capPath, doc); committed = true; rmSync(tmp, { force: true }); } catch (e3) {
+        logErr(root, `capsule write failed (tmp+rename AND direct): ${e3?.message || e3} — state NOT advanced, will retry next turn`);
+      }
+    }
+  }
+  if (!committed) { outcome = 'error:write-failed'; process.exit(0); }
+
+  // Pointer: aigent-OS is single-operator, so the pointer always lives at
+  // BODY_STATE.json's state.last_capsule.
+  //
+  // FINALIZE-GUARD: if the pointer already aims at a DIFFERENT capsule that is
+  // finalize-live (status: active + real waiting_on — the exact predicate an
+  // auto-refresh watcher would gate on), the operator deliberately finalized and
+  // the pointer must NOT be re-pointed at this session's auto-capsule (whose
+  // skeleton waiting_on is null) — that swap strands the session: a watcher reads
+  // "not finalized" and refuses to auto-clear forever. The auto-capsule content
+  // above still lands; only the pointer move is skipped. The lock self-releases
+  // when the fresh session marks the capsule resumed (status != active). Fail-open:
+  // any read/parse error falls back to the old re-point behavior.
+  function pointerLockedByFinalize() {
+    try {
+      const cur = JSON.parse(readFileSync(path.join(MEM, 'BODY_STATE.json'), 'utf8'))?.state?.last_capsule;
+      if (!cur?.path) return false;
+      const curAbs = path.resolve(root, cur.path);
+      if (curAbs === path.resolve(capPath)) return false; // same file — frontmatter refresh never touches waiting_on
+      const fm = readFileSync(curAbs, 'utf8').split(/^---\s*$/m)[1] || '';
+      const status = (fm.match(/^status:\s*(\S+)/m) || [])[1]?.trim() || '';
+      const w = ((fm.match(/^waiting_on:\s*(.+)\s*$/m) || [])[1] || '').trim().toLowerCase();
+      const waitingReal = !!w && w !== 'null' && w !== '~' && w !== '""' && w !== "''";
+      // A deliberate /context-capsule READY capsule can carry waiting_on:null
+      // (nothing blocks its resume) yet must NOT be clobbered. Discriminate the
+      // disposable auto-writers by the `autosave` TAG: only skeleton() here (and
+      // any other auto-writer a fork adds) emits it — hand/close/context-capsule
+      // capsules never do. Tag-based covers every future auto-writer by
+      // construction; a literal-trigger allowlist would blindside the next one.
+      const tags = ((fm.match(/^tags:\s*(.+)\s*$/m) || [])[1] || '').toLowerCase();
+      const isAutoSkeleton = /\bautosave\b/.test(tags);
+      return status === 'active' && (waitingReal || !isAutoSkeleton);
+    } catch { return false; }
+  }
+  // CURATED-CLOSE PRECEDENCE (the two-writer pointer race): a curated close
+  // (trigger curated-close; manual-close accepted as the legacy spelling) stamped
+  // for THIS session and finalized inside the race window ALWAYS keeps the
+  // pointer — the stop-delta tail of a close sequence (the close-summary turn's
+  // own Stop hook, post-close "anything to add" chatter) must never clobber it.
+  // WINDOW-BOUNDED (SCW_CURATED_WIN_MS, default 45 min): a session that genuinely
+  // RESUMES work after a curated close re-earns its rolling anchor once the
+  // window lapses — an unbounded curated freeze would strand the resumed work on
+  // a "session complete" anchor. Fail-open on any read/parse error, like every
+  // guard in this daemon.
+  function curatedPointerWins() {
+    try {
+      const cur = JSON.parse(readFileSync(path.join(MEM, 'BODY_STATE.json'), 'utf8'))?.state?.last_capsule;
+      if (!cur) return false;
+      if (cur.trigger !== 'curated-close' && cur.trigger !== 'manual-close') return false;
+      if (String(cur.session_id || '') !== sid) return false;
+      const fin = Date.parse(String(cur.finalized_at || ''));
+      if (!Number.isFinite(fin)) return false;
+      const win = Number(process.env.SCW_CURATED_WIN_MS) > 0
+        ? Number(process.env.SCW_CURATED_WIN_MS) : 45 * 60 * 1000;
+      return (Date.now() - fin) < win;
+    } catch { return false; }
+  }
+  const pointer = {
+    id: path.basename(capPath, '.md'),
+    path: path.relative(root, capPath).replace(/\\/g, '/'),
+    objective,
+    status: 'active',
+    created_at: new Date().toISOString(),
+    trigger: 'stop-delta',
+    session_id: sid,
+  };
+  // Distinguish a CLOBBER (this session's skeleton auto-capsule, waiting_on:null —
+  // repointing to it would strand a deliberately-finalized pointer) from a
+  // legitimate FINALIZE-ADVANCE (the operator finalized THIS session's OWN
+  // capsule — waiting_on real — and the pointer SHOULD move to it). The base
+  // guard blocks BOTH, freezing the pointer on the previous finalized capsule
+  // until a human advances it by hand. Allow the repoint when this session's
+  // capsule (the `doc` just written) is itself finalize-live — same
+  // status:active + real-waiting_on predicate the guard uses.
+  const thisFm = doc.split(/^---\s*$/m)[1] || '';
+  const thisStatus = (thisFm.match(/^status:\s*(\S+)/m) || [])[1]?.trim() || '';
+  const thisW = ((thisFm.match(/^waiting_on:\s*(.+)\s*$/m) || [])[1] || '').trim().toLowerCase();
+  const thisFinalized = thisStatus === 'active' && !!thisW && thisW !== 'null' && thisW !== '~' && thisW !== '""' && thisW !== "''";
+  if (curatedPointerWins()) {
+    // this session was curated-closed inside the race window — pointer stays on
+    // the curated capsule; the rolling auto-capsule content above is still saved
+  } else if (pointerLockedByFinalize() && !thisFinalized) {
+    // a DIFFERENT capsule is deliberately finalized and this session has NOT
+    // finalized its own yet — pointer stays; auto-capsule content already saved
+  } else {
+    try {
+      const bsPath = path.join(MEM, 'BODY_STATE.json');
+      const bs = JSON.parse(readFileSync(bsPath, 'utf8'));
+      if (bs?.state) {
+        bs.state.last_capsule = { ...bs.state.last_capsule, ...pointer };
+        writeFileSync(bsPath, JSON.stringify(bs, null, 2));
+      } else {
+        logErr(root, 'BODY_STATE.json has no .state — capsule pointer not updated (reinject will miss it)');
+      }
+    } catch (e) {
+      logErr(root, `BODY_STATE pointer update failed: ${e?.message || e}`);
+    }
+  }
+
+  writeState(stateFile, { offset: size, capsule_path: capPath, last_delta_sha: deltaSig });
+  outcome = 'flushed';
+} catch (e) {
+  outcome = 'error:worker';
+  logErr(workerRoot, `worker: ${e?.stack || e}`);
+} finally {
+  if (lockFd !== null) { try { closeSync(lockFd); } catch {} }
+  if (lockPath) { try { rmSync(lockPath, { force: true }); } catch {} }
+}
+if (outcome === 'flushed') await launchStopAutofire();
+process.exit(0);
+}
+
+// Atomic-ish JSON state write (tmp+rename, direct-write fallback) — the same
+// discipline as the capsule doc; a torn state file causes duplicate-merge noise.
+function writeState(file, obj) {
+  const tmp = file + '.tmp';
+  writeFileSync(tmp, JSON.stringify(obj, null, 1));
+  try { renameSync(tmp, file); } catch {
+    try { rmSync(file, { force: true }); renameSync(tmp, file); } catch {
+      try { writeFileSync(file, JSON.stringify(obj, null, 1)); rmSync(tmp, { force: true }); } catch { /* next read falls back to defaults */ }
+    }
+  }
+}
+
+async function launchStopAutofire() {
+  let root = '';
+  let sid = '';
+  let lockFd = null;
+  let lockFile = null;
+  // FAIL-OPEN: the writer contract is fail-open, so this optional tail launch is
+  // contained and reports failures through the writer's existing error sink.
+  try {
+    if (process.env.CAPSULE_VERB_AUTOFIRE !== '1') return;
+    const payload = JSON.parse(process.argv[3] || '{}');
+    root = String(payload.__root || '');
+    sid = String(payload.session_id || '');
+    if (!root || !sid) return;
+
+    const memory = memRoot(root);
+    const requestFile = path.join(memory, 'runtime', `refresh-request-${sid}.json`);
+    if (!existsSync(requestFile)) return;
+    const { readRequest } = await import('./refresh-request.mjs');
+    const request = readRequest(memory, sid);
+    if (!request) throw new Error('refresh request present but unreadable or invalid');
+    const expiresMs = Date.parse(request.expires_at);
+    if (!Number.isFinite(expiresMs) || expiresMs <= Date.now()) return;
+
+    const { homedir } = await import('node:os');
+    const home = homedir();
+    const stateDir = path.join(home, '.claude', 'ctx-refresh');
+    mkdirSync(stateDir, { recursive: true });
+    const launchStateFile = path.join(stateDir, `${sid}.state`);
+    lockFile = `${launchStateFile}.autofire.lock`;
+    const lockDeadline = Date.now() + 1_000;
+    while (existsSync(lockFile)) {
+      if (Date.now() - statSync(lockFile).mtimeMs > 30_000) {
+        rmSync(lockFile, { force: true });
+        break;
+      }
+      if (Date.now() >= lockDeadline) {
+        throw new Error('timed out waiting for autofire state lock');
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    lockFd = openSync(lockFile, 'wx');
+
+    const launchState = existsSync(launchStateFile)
+      ? JSON.parse(readFileSync(launchStateFile, 'utf8'))
+      : {};
+    if (!launchState || typeof launchState !== 'object' || Array.isArray(launchState)) {
+      throw new Error('launch state is not an object');
+    }
+
+    let shouldLaunch = request.cycle_id !== launchState.last_autofire_cycle_id;
+    if (!shouldLaunch) {
+      const pointer = JSON.parse(readFileSync(path.join(memory, 'BODY_STATE.json'), 'utf8'))
+        ?.state?.last_capsule ?? null;
+      const finalizedAtMs = Date.parse(pointer?.finalized_at);
+      const launchedAt = launchState.last_autofire_launched_at;
+      const capsulePath = typeof pointer?.path === 'string' && pointer.path.trim() !== ''
+        ? (path.isAbsolute(pointer.path) ? pointer.path : path.resolve(root, pointer.path))
+        : null;
+      shouldLaunch = pointer?.trigger === 'curated-close'
+        && pointer.session_id === sid
+        && Number.isFinite(finalizedAtMs)
+        && capsulePath !== null
+        && existsSync(capsulePath)
+        && typeof launchedAt === 'number'
+        && Number.isFinite(launchedAt)
+        && finalizedAtMs > launchedAt;
+    }
+    if (!shouldLaunch) return;
+
+    const launchedAt = Date.now();
+    const nextState = {
+      ...launchState,
+      last_autofire_cycle_id: request.cycle_id,
+      last_autofire_launched_at: launchedAt,
+    };
+    writeState(launchStateFile, nextState);
+    const recorded = JSON.parse(readFileSync(launchStateFile, 'utf8'));
+    if (recorded?.last_autofire_cycle_id !== request.cycle_id
+      || recorded.last_autofire_launched_at !== launchedAt) {
+      throw new Error('launch state did not persist before spawn');
+    }
+
+    const normalizedRoot = path.resolve(root).replace(/\\/g, '/');
+    const projectSlug = normalizedRoot.replace(/[^A-Za-z0-9]/g, '-');
+    const transcriptPath = String(payload.transcript_path || '')
+      || path.join(home, '.claude', 'projects', projectSlug, `${sid}.jsonl`);
+    const workerPayload = Buffer.from(JSON.stringify({
+      root,
+      sid,
+      eventId: null,
+      transcriptPath,
+    }), 'utf8').toString('base64url');
+    const sensorPath = path.resolve(path.dirname(SELF), 'ctx-refresh-sensor.mjs');
+    const child = spawn(process.execPath, [sensorPath, '--autofire-worker', workerPayload], {
+      detached: true,
+      env: process.env,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    if (!child.pid) throw new Error('autofire worker did not receive a process id');
+    child.once('error', (error) => {
+      logErr(root, `autofire worker error sid=${sid}: ${error?.message || error}`);
+    });
+    child.unref();
+    await new Promise((resolve) => setImmediate(resolve));
+  } catch (e) {
+    logErr(root, `autofire tail failed sid=${sid}: ${e?.message || e}`);
+  } finally {
+    if (lockFd !== null) { try { closeSync(lockFd); } catch {} }
+    if (lockFd !== null && lockFile) { try { rmSync(lockFile, { force: true }); } catch {} }
+  }
+}

--- a/daemons/tests/capsule-content-gate.test.mjs
+++ b/daemons/tests/capsule-content-gate.test.mjs
@@ -1,0 +1,148 @@
+// capsule-content-gate.test.mjs — non-null ≠ resumable.
+//
+// Real-glue: drives the REAL patched stop-capsule-writer.mjs worker against a
+// temp-dir seat fixture and the REAL capsule-verb.validateCapsuleText. No mocks.
+//
+// Run from an APPLIED daemons tree (package files landed next to their
+// siblings): node daemons/tests/capsule-content-gate.test.mjs
+'use strict';
+
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import os from 'node:os';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DAEMON = process.env.SCW_DAEMON || path.resolve(__dirname, '..', 'stop-capsule-writer.mjs');
+// Windows: dynamic import of an absolute path needs a file:// URL.
+const asUrl = (p) => pathToFileURL(path.resolve(p)).href;
+const { validateCapsuleText } = await import(asUrl(process.env.CCG_VERB || path.resolve(__dirname, '..', 'capsule-verb.mjs')));
+const gate = await import(asUrl(process.env.CCG_GATE || path.resolve(__dirname, '..', 'capsule-content-gate.mjs')));
+
+let pass = 0;
+let fail = 0;
+function ok(cond, name) {
+  if (cond) { pass++; console.log(`  PASS  ${name}`); }
+  else { fail++; console.log(`  FAIL  ${name}`); }
+}
+
+// Representative injection/ceremony texts, matching the shapes actually seen from
+// a harness/supervisor refresh cycle and a stale resume-boot echo.
+const REFRESH_CYCLE_INJECTION = '[refresh-cycle] cycle=00000000-0000-4000-8000-000000000001 captured_through=00000000-0000-4000-8000-000000000002 read the matching RefreshRequest and run the capsule verb NOW with that cycle and challenge; you may not clear; the supervisor clears on verified receipt.';
+const SUPERVISOR_RESUME_INJECTION = "[supervisor-resume] This session was just /clear'd (refresh-cycle-cas-winner). Read your latest capsule and resume from its waiting_on / Pending-Gates / Claimed-Rows -- do not sit idle.";
+const CEREMONY_NEXT_ACTION = 'Re-read the active turn state below; latest assistant state: The capsule verb already ran and the receipt is on disk — the re-poke raced its completion.';
+
+// ── writer scenarios: run the REAL worker on a transcript delta ──────────────
+function runWriter({ sid, userText, existingCapsule = null }) {
+  const base = mkdtempSync(path.join(os.tmpdir(), 'ccg-'));
+  const root = path.join(base, 'test-seat');
+  const capsules = path.join(root, 'memory', 'capsules');
+  const runtime = path.join(root, 'memory', 'runtime', 'stop-writer');
+  mkdirSync(capsules, { recursive: true });
+  mkdirSync(runtime, { recursive: true });
+  writeFileSync(path.join(root, 'memory', 'BODY_STATE.json'), JSON.stringify({ state: {} }));
+
+  let capPath = null;
+  if (existingCapsule) {
+    capPath = path.join(capsules, 'existing.md');
+    writeFileSync(capPath, existingCapsule);
+    writeFileSync(path.join(runtime, `${sid}.json`),
+      JSON.stringify({ offset: 0, capsule_path: capPath, last_delta_sha: null }));
+  }
+
+  const transcript = path.join(base, 'transcript.jsonl');
+  const lines = [
+    JSON.stringify({ type: 'user', message: { content: userText } }),
+    JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'worked the claimed row; smoke green; delta ' + sid }] } }),
+  ];
+  writeFileSync(transcript, lines.join('\n') + '\n');
+
+  const payload = JSON.stringify({ __root: root, session_id: sid, transcript_path: transcript });
+  const out = execFileSync(process.execPath, [DAEMON, '--worker', payload], { encoding: 'utf8' });
+
+  // The capsule the writer landed on: existing one, or the auto file it created.
+  const state = JSON.parse(readFileSync(path.join(runtime, `${sid}.json`), 'utf8'));
+  const doc = readFileSync(state.capsule_path, 'utf8');
+  rmSync(base, { recursive: true, force: true });
+  return { out, doc };
+}
+
+const fm = (doc, key) => ((doc.match(new RegExp(`^${key}: (.*)$`, 'm')) || [])[1] || '');
+
+console.log(`── capsule content gate — daemon: ${DAEMON} ──`);
+
+// 1. INJECTION turn: the [refresh-cycle] injection must NOT become the objective,
+//    and the fresh capsule's next_valid_action must NOT be ceremony.
+{
+  const { out, doc } = runWriter({ sid: 'inj-11111111', userText: REFRESH_CYCLE_INJECTION });
+  ok(out.includes('SWE_OUTCOME:flushed'), 'inj: worker flushed');
+  ok(!fm(doc, 'objective').includes('[refresh-cycle]'),
+    'inj (a): [refresh-cycle] injection does NOT land as objective');
+  ok(!/re-?read the (active )?turn state/i.test(fm(doc, 'next_valid_action')),
+    'inj (b): next_valid_action is not the old ceremony template');
+  ok(doc.includes('[INJECT:harness]'),
+    'inj: injection stays recoverable as a tagged utterance');
+}
+
+// 2. SUPERVISOR-RESUME turn on a fresh capsule: same class, second real template.
+{
+  const { doc } = runWriter({ sid: 'inj-22222222', userText: SUPERVISOR_RESUME_INJECTION });
+  ok(!fm(doc, 'objective').includes('[supervisor-resume]'),
+    'inj (a): [supervisor-resume] injection does NOT land as objective');
+}
+
+// 3. HUMAN turn: a real utterance still becomes the objective (no regression).
+{
+  const { doc } = runWriter({ sid: 'hum-33333333', userText: 'ship the pulse view and fix the ghost overlap' });
+  ok(fm(doc, 'objective').includes('ship the pulse view'),
+    'human: real utterance still drives objective');
+}
+
+// 4. OWNERSHIP: a capsule WITHOUT the autosave tag keeps its contract fields even
+//    when the writer merges delta bullets into it.
+{
+  const curated = `---\nid: curated-x\nstatus: active\nobjective: "continuation: coverage net at gate"\nwaiting_on: gates\nresume_trigger: open\ndefinition_hash: abc123\nnext_valid_action: "On resume: re-ground and act on the verdict"\ntags: [capsule, refresh-cycle]\n---\n\n## Done (don't redo)\n<!-- swe:done -->\n\n## Historical-Errors → Resolutions\n<!-- swe:errors -->\n\n## Historical-Rejected-Approaches\n<!-- swe:rejected -->\n\n## Files-Read / Files-Modified\n<!-- swe:files -->\n\n## Operating-Facts\n<!-- swe:facts -->\n\n## Pending-Gates\n<!-- swe:gates -->\n\n## Claimed-Rows\n<!-- swe:rows -->\n`;
+  const { doc } = runWriter({ sid: 'own-44444444', userText: REFRESH_CYCLE_INJECTION, existingCapsule: curated });
+  ok(fm(doc, 'objective').includes('continuation'),
+    'ownership: non-autosave capsule keeps its objective');
+  ok(fm(doc, 'next_valid_action').includes('re-ground'),
+    'ownership: non-autosave capsule keeps its next_valid_action');
+  ok(doc.includes('worked the claimed row'),
+    'ownership: delta bullets still merge into the body');
+}
+
+// ── validator: content gate on REAL frontmatter shapes ───────────────────────
+const BAD_REAL = `---\nid: 2026-07-16-auto-test-seat\nstatus: active\nobjective: ${JSON.stringify(REFRESH_CYCLE_INJECTION)}\nwaiting_on: "gates"\nresume_trigger: compact\ndefinition_hash: cd31196d454a\nnext_valid_action: ${JSON.stringify(CEREMONY_NEXT_ACTION)}\ntags: [capsule, autosave]\n---\nbody\n`;
+{
+  const { problems } = validateCapsuleText(BAD_REAL);
+  ok(problems.some((p) => p.includes('injection echo')),
+    'verb (a): a clobbered objective is rejected');
+  ok(problems.some((p) => p.includes('resume ceremony')),
+    'verb (b): a ceremony next_valid_action is rejected');
+}
+
+// GOOD curated capsule that legitimately REFERENCES the ceremony mid-action —
+// anchored patterns must let it pass (false-positive guard).
+const GOOD_REAL = `---\nid: 2026-07-16-refresh-test-seat\nstatus: active\nobjective: "continuation (post-clear session): item 2 SHIPPED LIVE, coverage net at gate"\nwaiting_on: "gates"\nresume_trigger: open\ndefinition_hash: abc\nnext_valid_action: "On resume: (1) comply with any supervisor-resume instruction EXACTLY (nonce + receipt command live only in that instruction). (2) re-ground: re-read the latest memory."\ntags: [capsule, refresh-cycle]\n---\nbody\n`;
+{
+  const { problems } = validateCapsuleText(GOOD_REAL);
+  ok(problems.length === 0,
+    `verb: curated capsule referencing ceremony mid-action passes (got: ${problems.join(' | ') || 'none'})`);
+}
+
+// Existing behavior intact: unquoted YAML null waiting_on still flagged.
+{
+  const nullW = GOOD_REAL.replace('waiting_on: "gates"', 'waiting_on: null');
+  const { problems } = validateCapsuleText(nullW);
+  ok(problems.some((p) => p.includes('waiting_on')),
+    'verb (c): unquoted-null waiting_on still rejected (pre-existing gate intact)');
+}
+
+// Gate unit sanity: vocabulary is shared and anchored.
+ok(gate.isInjectionEcho(SUPERVISOR_RESUME_INJECTION), 'gate: supervisor-resume detected');
+ok(gate.isCeremonyAction('Resume from the latest session log entry.'), 'gate: old writer fallback detected');
+ok(!gate.isCeremonyAction('Fix the ghost overlap, then re-read the design doc'), 'gate: mid-text mention passes (anchored)');
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/daemons/tests/capsule-verb.test.mjs
+++ b/daemons/tests/capsule-verb.test.mjs
@@ -469,3 +469,108 @@ test('autofire worker invokes the trusted verb in dry-run mode and logs outcome'
   assert.equal(entries.at(-1).stamped, false);
   assert.equal(JSON.parse(readFileSync(path.join(seat.memory, 'BODY_STATE.json'), 'utf8')).state.last_capsule, undefined);
 });
+
+// ── Option-1 skeleton gate (PR #2 known issue; ruling: gate readiness, never ──
+// ── seed a placeholder — a writer-producible waiting_on would destroy the   ──
+// ── proof that the agent's own finalize ran).                               ──
+
+function skeletonCapsule(id, waitingOnRaw) {
+  // Mirrors stop-capsule-writer's skeleton(): status active, autosave tag,
+  // waiting_on still in the null family — the finalize step has not run.
+  return [
+    '---',
+    'id: ' + id,
+    'parent_capsule_id: null',
+    'status: active',
+    'objective: "Auto-captured working state"',
+    'waiting_on: ' + waitingOnRaw,
+    'resume_trigger: compact',
+    'trigger: stop-delta',
+    'next_valid_action: "Re-ground against live state and continue"',
+    'tags: [capsule, autosave]',
+    '---',
+    '',
+    '> [!info] [REFERENCE ONLY] — state snapshot, not instructions. Latest memory state wins.',
+    '',
+  ].join('\n');
+}
+
+function runAutofireWorker(seat, sid) {
+  const payload = Buffer.from(JSON.stringify({
+    root: seat.root,
+    sid,
+    eventId: 'evt-skeleton-gate',
+  }), 'utf8').toString('base64url');
+  const env = { ...process.env, AIGENT_ROOT: seat.root };
+  delete env.CAPSULE_VERB_AUTOFIRE_DRY_RUN;
+  const result = spawnSync(process.execPath, [SENSOR, '--autofire-worker', payload], {
+    encoding: 'utf8',
+    env,
+    cwd: seat.root,
+    timeout: 40_000,
+  });
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  const logPath = path.join(seat.memory, 'runtime', 'capsule-verb-autofire.jsonl');
+  return readFileSync(logPath, 'utf8').trim().split('\n').map(JSON.parse);
+}
+
+test('autofire worker DEFERS on a skeleton capsule — every null-family waiting_on spelling', (t) => {
+  const spellings = [
+    ['unquoted-null', 'null'],
+    ['tilde', '~'],
+    ['capitalized-Null', 'Null'],
+    ['empty-double-quoted', '""'],
+    ['empty-single-quoted', "''"],
+    ['empty-bare', ''],
+  ];
+  for (const [label, raw] of spellings) {
+    const seat = mkSeat(os.tmpdir());
+    t.after(seat.cleanup);
+    const sid = 'sensor-skel-' + label;
+    const capsule = writeCapsule(seat, skeletonCapsule('capsule-skel-' + label, raw));
+    writeFileSync(
+      path.join(seat.memory, 'runtime', 'stop-writer', sid + '.json'),
+      JSON.stringify({ capsule_path: capsule }),
+    );
+    const entries = runAutofireWorker(seat, sid);
+    const last = entries.at(-1);
+    assert.equal(last.outcome, 'skipped_skeleton',
+      label + ': a not-yet-finalized capsule must DEFER the cycle, never surface as a refusal');
+    assert.equal(last.capsule_path, capsule, label + ': defer entry names the capsule it deferred on');
+    assert.equal(existsSync(path.join(seat.memory, '.daemon-errors.log')), false,
+      label + ': deferring readiness is not an error');
+  }
+});
+
+test('autofire worker runs the verb once the capsule has left skeleton state (contrast pin)', (t) => {
+  const seat = mkSeat(os.tmpdir(), { git: true });
+  t.after(seat.cleanup);
+  const sid = 'sensor-skel-left';
+  const capsule = writeCapsule(seat, validCapsule('capsule-left-skeleton'));
+  writeFileSync(
+    path.join(seat.memory, 'runtime', 'stop-writer', sid + '.json'),
+    JSON.stringify({ capsule_path: capsule }),
+  );
+  const entries = runAutofireWorker(seat, sid);
+  assert.equal(entries.at(-1).outcome, 'completed',
+    'a finalized capsule must still flow to the verb — the gate only filters skeletons');
+});
+
+test('quoted "null" waiting_on is an intentional string — the gate lets the verb see it', (t) => {
+  // Consistency pin with validateCapsuleText: a QUOTED "null" is deliberate
+  // content, not the writer skeleton. The gate must not widen past the
+  // validator's own null family, or gate and verb would disagree about the
+  // same bytes.
+  const seat = mkSeat(os.tmpdir(), { git: true });
+  t.after(seat.cleanup);
+  const sid = 'sensor-skel-quoted-null';
+  const capsule = writeCapsule(seat, skeletonCapsule('capsule-quoted-null', '"null"'));
+  writeFileSync(
+    path.join(seat.memory, 'runtime', 'stop-writer', sid + '.json'),
+    JSON.stringify({ capsule_path: capsule }),
+  );
+  const entries = runAutofireWorker(seat, sid);
+  assert.notEqual(entries.at(-1).outcome, 'skipped_skeleton',
+    'quoted "null" left skeleton state — the verb owns judging it, not the gate');
+});

--- a/daemons/tests/capsule-verb.test.mjs
+++ b/daemons/tests/capsule-verb.test.mjs
@@ -1,0 +1,471 @@
+'use strict';
+
+import test, { after } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  canonicalJson,
+  collectEvidence,
+  reconcileDigest,
+} from '../reconcile-collector.mjs';
+import {
+  appendReceipt,
+  readReceipts,
+  receiptDigest,
+} from '../effect-receipts.mjs';
+import {
+  CapsuleVerbRefusal,
+  runCapsuleVerb,
+} from '../capsule-verb.mjs';
+import {
+  createCycleRecord,
+  cycleRecordPath,
+  readCycleRecord,
+} from '../refresh-cycle.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const CCP = path.resolve(__dirname, '..', 'curated-close-pointer.mjs');
+const SENSOR = path.resolve(__dirname, '..', 'ctx-refresh-sensor.mjs');
+const SHA256 = /^[0-9a-f]{64}$/;
+const SEAT_ID = 'operator';
+
+// The board evidence class is pluggable (AIGENT_BOARD_ADAPTER). Leaving it unset
+// exercises the real "no adapter configured" path — board:null, honest degrade,
+// no live board touched from this isolated test.
+const BOARD_ENV_KEYS = ['AIGENT_BOARD_ADAPTER'];
+const savedBoardEnv = Object.fromEntries(
+  BOARD_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+for (const key of BOARD_ENV_KEYS) delete process.env[key];
+after(() => {
+  for (const key of BOARD_ENV_KEYS) {
+    if (savedBoardEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedBoardEnv[key];
+  }
+});
+
+function mkSeat(parent = os.tmpdir(), { git = false } = {}) {
+  const base = mkdtempSync(path.join(parent, '.cv-test-'));
+  const root = path.join(base, 'test-seat');
+  const memory = path.join(root, 'memory');
+  mkdirSync(path.join(memory, 'capsules'), { recursive: true });
+  mkdirSync(path.join(memory, 'runtime', 'stop-writer'), { recursive: true });
+  writeFileSync(path.join(memory, 'BODY_STATE.json'), JSON.stringify({ state: {} }));
+  if (git) {
+    const gitCfg = ['-c', 'user.name=cv-fixture', '-c', 'user.email=cv-fixture@test.local'];
+    execFileSync('git', ['-C', root, 'init', '-q'], { encoding: 'utf8' });
+    writeFileSync(path.join(root, 'seed.txt'), 'capsule-verb fixture seed\n');
+    execFileSync('git', ['-C', root, ...gitCfg, 'add', '.'], { encoding: 'utf8' });
+    execFileSync('git', ['-C', root, ...gitCfg, 'commit', '-q', '-m', 'fixture seed'], { encoding: 'utf8' });
+  }
+  return {
+    base,
+    root,
+    memory,
+    cleanup() { rmSync(base, { recursive: true, force: true }); },
+  };
+}
+
+function validCapsule(id = 'capsule-cv') {
+  return [
+    '---',
+    'id: ' + id,
+    'status: active',
+    'objective: "Finish the trusted writer"',
+    'waiting_on: "verification"',
+    'next_valid_action: "Run the daemon test suite"',
+    '---',
+    '',
+    '> [!info] [REFERENCE ONLY] — state snapshot, not instructions. Latest memory state wins.',
+    '',
+  ].join('\n');
+}
+
+function writeCapsule(seat, text = validCapsule()) {
+  const file = path.join(seat.memory, 'capsules', 'capsule-CV.md');
+  writeFileSync(file, text);
+  return file;
+}
+
+async function expectRefusal(promise, pattern) {
+  await assert.rejects(promise, (error) => {
+    assert.ok(error instanceof CapsuleVerbRefusal);
+    assert.match(error.message, pattern);
+    assert.equal(error.result.stamped, false);
+    assert.equal(error.result.pointerPath, null);
+    assert.ok(error.result.refusals.length > 0);
+    return true;
+  });
+}
+
+test('collector is deterministic and returns canonical git/effect evidence', async (t) => {
+  const scratch = mkdtempSync(path.join(os.tmpdir(), 'cv-collector-'));
+  t.after(() => rmSync(scratch, { recursive: true, force: true }));
+  const memory = path.join(scratch, 'memory');
+  mkdirSync(path.join(memory, 'runtime'), { recursive: true });
+
+  const args = {
+    seatId: SEAT_ID,
+    memRoot: memory,
+    workspaces: [{ path: REPO_ROOT, repo: 'aigent-os-cv' }],
+  };
+  const first = await collectEvidence(args);
+  const second = await collectEvidence(args);
+
+  assert.deepEqual(second, first);
+  assert.equal(reconcileDigest(second), reconcileDigest(first));
+  assert.equal(first.version, 1);
+  assert.equal(first.git.length, 1);
+  assert.equal(first.git[0].repo, 'aigent-os-cv');
+  assert.match(first.git[0].index_tree, SHA256);
+  assert.match(first.git[0].working_tree_digest, SHA256);
+  assert.equal(typeof first.git[0].dirty, 'boolean');
+  assert.deepEqual(first.external_effects, []);
+});
+
+test('canonical reconcile digest is independent of object key insertion order', () => {
+  const left = {
+    version: 1,
+    board: null,
+    git: [{
+      repo: 'r', branch: 'main', head: 'abc', index_tree: '1'.repeat(64),
+      working_tree_digest: '2'.repeat(64), dirty: false,
+    }],
+    external_effects: [],
+  };
+  const right = {
+    external_effects: [],
+    git: [{
+      dirty: false, working_tree_digest: '2'.repeat(64),
+      index_tree: '1'.repeat(64), head: 'abc', branch: 'main', repo: 'r',
+    }],
+    board: null,
+    version: 1,
+  };
+  assert.equal(canonicalJson(left), canonicalJson(right));
+  assert.equal(reconcileDigest(left), reconcileDigest(right));
+});
+
+test('no board adapter configured degrades honestly to board:null', async (t) => {
+  const scratch = mkdtempSync(path.join(os.tmpdir(), 'cv-board-null-'));
+  t.after(() => rmSync(scratch, { recursive: true, force: true }));
+  const memory = path.join(scratch, 'memory');
+  mkdirSync(path.join(memory, 'runtime'), { recursive: true });
+  const evidence = await collectEvidence({
+    seatId: SEAT_ID,
+    memRoot: memory,
+    workspaces: [{ path: REPO_ROOT, repo: 'aigent-os-cv' }],
+  });
+  assert.equal(evidence.board, null);
+  assert.ok(!canonicalJson(evidence).includes('fabricated'));
+});
+
+test('effect ledger append/read round-trip and digest stability', (t) => {
+  const memory = mkdtempSync(path.join(os.tmpdir(), 'cv-receipts-'));
+  t.after(() => rmSync(memory, { recursive: true, force: true }));
+  const scope = { memRoot: memory, seatId: SEAT_ID };
+  const requested = {
+    idempotency_key: 'mail:42',
+    system: 'email',
+    state: 'requested',
+    ts: '2026-07-12T12:00:00.000Z',
+  };
+  const completed = {
+    system: 'email',
+    external_id: 'provider-42',
+    ts: '2026-07-12T12:00:01.000Z',
+    state: 'completed',
+    idempotency_key: 'mail:42',
+  };
+  assert.deepEqual(readReceipts(scope), []);
+  appendReceipt(requested, scope);
+  appendReceipt(completed, scope);
+  const receipts = readReceipts(scope);
+  assert.equal(receipts.length, 2);
+  assert.equal(receipts[0].external_id, null);
+  assert.equal(receipts[1].external_id, 'provider-42');
+  assert.match(receiptDigest(requested), SHA256);
+  assert.equal(receiptDigest(completed), receiptDigest({
+    idempotency_key: 'mail:42',
+    state: 'completed',
+    external_id: 'provider-42',
+    system: 'email',
+    ts: '2026-07-12T12:00:01.000Z',
+  }));
+});
+
+test('effect ledger fails closed on a malformed line', (t) => {
+  const memory = mkdtempSync(path.join(os.tmpdir(), 'cv-receipts-bad-'));
+  t.after(() => rmSync(memory, { recursive: true, force: true }));
+  const scope = { memRoot: memory, seatId: SEAT_ID };
+  appendReceipt({
+    idempotency_key: 'deploy:1',
+    system: 'deploy',
+    state: 'accepted',
+    ts: '2026-07-12T12:00:00.000Z',
+  }, scope);
+  const ledger = path.join(memory, 'runtime', `effect-receipts-${SEAT_ID}.jsonl`);
+  appendFileSync(ledger, '{not-json\n');
+  assert.throws(() => readReceipts(scope), /malformed JSON at line 2/);
+});
+
+test('trusted writer refuses invalid capsules and evidence gaps without stamping', async (t) => {
+  await t.test('missing capsule id', async (st) => {
+    const seat = mkSeat(os.tmpdir());
+    st.after(seat.cleanup);
+    const capsule = writeCapsule(seat, validCapsule().replace('id: capsule-cv\n', ''));
+    await expectRefusal(runCapsuleVerb({
+      seatId: SEAT_ID, memRoot: seat.memory, capsulePath: capsule,
+    }), /frontmatter id must be non-empty/);
+    assert.equal(JSON.parse(readFileSync(path.join(seat.memory, 'BODY_STATE.json'), 'utf8')).state.last_capsule, undefined);
+  });
+
+  await t.test('empty waiting_on', async (st) => {
+    const seat = mkSeat(os.tmpdir());
+    st.after(seat.cleanup);
+    const capsule = writeCapsule(
+      seat,
+      validCapsule().replace('waiting_on: "verification"', 'waiting_on: ""'),
+    );
+    await expectRefusal(runCapsuleVerb({
+      seatId: SEAT_ID, memRoot: seat.memory, capsulePath: capsule,
+    }), /frontmatter waiting_on must be non-empty/);
+  });
+
+  await t.test('git evidence gap', async (st) => {
+    const seat = mkSeat(os.tmpdir());
+    st.after(seat.cleanup);
+    const capsule = writeCapsule(seat);
+    await expectRefusal(runCapsuleVerb({
+      seatId: SEAT_ID, memRoot: seat.memory, capsulePath: capsule,
+    }), /evidence collection failed/);
+  });
+});
+
+test('full trusted stamp round-trips proofs and later no-flag stamp clears them', async (t) => {
+  const seat = mkSeat(os.tmpdir(), { git: true });
+  t.after(seat.cleanup);
+  const capsule = writeCapsule(seat, validCapsule('capsule-round-trip'));
+  const result = await runCapsuleVerb({
+    seatId: SEAT_ID,
+    memRoot: seat.memory,
+    capsulePath: capsule,
+    capturedThroughEventId: 'evt-73',
+  });
+
+  assert.equal(result.stamped, true);
+  assert.deepEqual(result.refusals, []);
+  assert.match(result.digests.capsule_sha256, SHA256);
+  assert.match(result.digests.reconcile_digest, SHA256);
+  const pointer = JSON.parse(readFileSync(result.pointerPath, 'utf8')).state.last_capsule;
+  assert.equal(pointer.id, 'capsule-round-trip');
+  assert.deepEqual(pointer.reconciled.board_rows, []);
+  assert.ok(typeof pointer.reconciled.git_head === 'string' && pointer.reconciled.git_head.length > 0);
+  assert.equal(pointer.capsule_sha256, result.digests.capsule_sha256);
+  assert.equal(pointer.reconcile_digest, result.digests.reconcile_digest);
+  assert.equal(pointer.captured_through_event_id, 'evt-73');
+  assert.equal(pointer.captured_through_offset, null, 'non-cycle stamp: lone event id keeps legacy semantics, offset stays null');
+  assert.equal(pointer.cycle_token, null);
+
+  execFileSync(process.execPath, [CCP, capsule], {
+    cwd: seat.root,
+    env: { ...process.env, AIGENT_ROOT: seat.root },
+    encoding: 'utf8',
+  });
+  const restamped = JSON.parse(readFileSync(result.pointerPath, 'utf8')).state.last_capsule;
+  assert.equal(restamped.reconciled, null);
+  assert.equal(restamped.cycle_token, null);
+  assert.equal(restamped.cycle_id, null);
+  assert.equal(restamped.context_epoch, null);
+  assert.equal(restamped.captured_through_event_id, null);
+  assert.equal(restamped.captured_through_offset, null);
+  assert.equal(restamped.capsule_sha256, null);
+  assert.equal(restamped.reconcile_digest, null);
+});
+
+test('cycle stores only challenge digest and walks requested→capsuling→prepared', async (t) => {
+  const seat = mkSeat(os.tmpdir(), { git: true });
+  t.after(seat.cleanup);
+  const capsule = writeCapsule(seat, validCapsule('capsule-cycle'));
+  const sid = 'session-cycle-cv';
+  const challenge = 'raw-challenge-must-never-land';
+  const record = createCycleRecord({
+    cycle_id: 'cycle-cv',
+    lineage_id: 'lineage-cv',
+    runtime_session: sid,
+    context_epoch: 7,
+  });
+  const result = await runCapsuleVerb({
+    seatId: SEAT_ID,
+    memRoot: seat.memory,
+    capsulePath: capsule,
+    capturedThroughEventId: 'evt-99',
+    capturedThroughOffset: 4425,
+    cycle: { record, challenge },
+  });
+
+  assert.deepEqual(result.cycleStates, ['requested', 'capsuling', 'prepared']);
+  const stored = readCycleRecord(seat.root, sid);
+  const expectedDigest = 'sha256:' + createHash('sha256').update(challenge).digest('hex');
+  assert.equal(stored.state, 'prepared');
+  assert.equal(stored.challenge_digest, expectedDigest);
+  assert.equal(stored.captured_through_event_id, 'evt-99');
+  assert.equal(stored.captured_through_offset, 4425, 'full cursor round-trips into the prepared record');
+  assert.equal(stored.capsule_id, 'capsule-cycle');
+  assert.equal(stored.capsule_sha256, result.digests.capsule_sha256);
+  assert.equal(stored.reconcile_digest, result.digests.reconcile_digest);
+  const rawRecord = readFileSync(cycleRecordPath(seat.root, sid), 'utf8');
+  assert.equal(rawRecord.includes(challenge), false);
+  const pointer = JSON.parse(readFileSync(result.pointerPath, 'utf8')).state.last_capsule;
+  assert.equal(pointer.cycle_token, null);
+  assert.equal(pointer.cycle_id, 'cycle-cv');
+  assert.equal(pointer.context_epoch, 7);
+  assert.equal(pointer.captured_through_offset, 4425, 'full cursor round-trips into the stamped pointer — an offset-less stamp could never verify');
+});
+
+test('cycle receipt with an event id but no offset refuses loudly (offset-less receipts can never verify)', async (t) => {
+  const seat = mkSeat(os.tmpdir(), { git: true });
+  t.after(seat.cleanup);
+  const capsule = writeCapsule(seat, validCapsule('capsule-halfcursor'));
+  const record = createCycleRecord({
+    cycle_id: 'cycle-halfcursor',
+    lineage_id: 'lineage-halfcursor',
+    runtime_session: 'session-halfcursor',
+    context_epoch: 0,
+  });
+  await expectRefusal(
+    runCapsuleVerb({
+      seatId: SEAT_ID,
+      memRoot: seat.memory,
+      capsulePath: capsule,
+      capturedThroughEventId: 'evt-half',
+      cycle: { record, challenge: 'half-cursor-challenge' },
+    }),
+    /capturedThroughOffset is required for a cycle receipt/,
+  );
+});
+
+test('malformed persisted cycle fails closed before pointer stamp', async (t) => {
+  const seat = mkSeat(os.tmpdir(), { git: true });
+  t.after(seat.cleanup);
+  const capsule = writeCapsule(seat, validCapsule('capsule-bad-cycle'));
+  const sid = 'session-bad-cycle-cv';
+  const record = createCycleRecord({
+    cycle_id: 'cycle-bad-cv',
+    lineage_id: 'lineage-bad-cv',
+    runtime_session: sid,
+    context_epoch: 1,
+  });
+  writeFileSync(cycleRecordPath(seat.root, sid), '{malformed-json');
+  await expectRefusal(runCapsuleVerb({
+    seatId: SEAT_ID,
+    memRoot: seat.memory,
+    capsulePath: capsule,
+    cycle: { record, challenge: 'transient-only' },
+  }), /cycle record read failed/);
+});
+
+function runSensor(root, home, sid, flagValue) {
+  const ctxDir = path.join(home, '.claude', 'ctx-refresh');
+  mkdirSync(ctxDir, { recursive: true });
+  writeFileSync(path.join(ctxDir, sid + '.json'), JSON.stringify({ used_percentage: 60 }));
+  const env = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    AIGENT_ROOT: root,
+  };
+  delete env.CAPSULE_VERB_AUTOFIRE_DRY_RUN;
+  if (flagValue === undefined) delete env.CAPSULE_VERB_AUTOFIRE;
+  else env.CAPSULE_VERB_AUTOFIRE = flagValue;
+  const result = spawnSync(process.execPath, [SENSOR], {
+    input: JSON.stringify({ session_id: sid, cwd: root, tool_name: 'Read' }),
+    encoding: 'utf8',
+    env,
+    cwd: root,
+    timeout: 10_000,
+  });
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  return {
+    result,
+    state: readFileSync(path.join(ctxDir, sid + '.state'), 'utf8'),
+  };
+}
+
+test('autofire is observationally inert when flag is absent', (t) => {
+  const seat = mkSeat(os.tmpdir());
+  t.after(seat.cleanup);
+  const homeA = mkdtempSync(path.join(os.tmpdir(), 'cv-sensor-home-a-'));
+  const homeB = mkdtempSync(path.join(os.tmpdir(), 'cv-sensor-home-b-'));
+  t.after(() => rmSync(homeA, { recursive: true, force: true }));
+  t.after(() => rmSync(homeB, { recursive: true, force: true }));
+
+  const absent = runSensor(seat.root, homeA, 'sensor-inert', undefined);
+  const explicitOff = runSensor(seat.root, homeB, 'sensor-inert', '0');
+  assert.equal(absent.result.stdout, explicitOff.result.stdout);
+  assert.equal(absent.result.stderr, explicitOff.result.stderr);
+  assert.equal(absent.result.stderr, '');
+  assert.equal(absent.state, explicitOff.state);
+  const output = JSON.parse(absent.result.stdout);
+  assert.equal(output.hookSpecificOutput.hookEventName, 'PreToolUse');
+  assert.match(output.hookSpecificOutput.additionalContext, /CONTEXT-REFRESH/);
+  assert.deepEqual(JSON.parse(absent.state), {
+    fired: true,
+    fires: 1,
+    last_pct: 60,
+    last_emit_pct: 60,
+    pct_read_failed: false,
+  });
+  assert.equal(existsSync(path.join(seat.memory, '.daemon-errors.log')), false);
+  assert.equal(existsSync(path.join(seat.memory, 'runtime', 'capsule-verb-autofire.jsonl')), false);
+  assert.equal(JSON.parse(readFileSync(path.join(seat.memory, 'BODY_STATE.json'), 'utf8')).state.last_capsule, undefined);
+});
+
+test('autofire worker invokes the trusted verb in dry-run mode and logs outcome', (t) => {
+  const seat = mkSeat(os.tmpdir(), { git: true });
+  t.after(seat.cleanup);
+  const sid = 'sensor-worker-cv';
+  const capsule = writeCapsule(seat, validCapsule('capsule-sensor-worker'));
+  writeFileSync(
+    path.join(seat.memory, 'runtime', 'stop-writer', sid + '.json'),
+    JSON.stringify({ capsule_path: capsule }),
+  );
+  const payload = Buffer.from(JSON.stringify({
+    root: seat.root,
+    sid,
+    eventId: 'evt-sensor',
+  }), 'utf8').toString('base64url');
+  const env = { ...process.env, AIGENT_ROOT: seat.root };
+  delete env.CAPSULE_VERB_AUTOFIRE_DRY_RUN;
+  const result = spawnSync(process.execPath, [SENSOR, '--autofire-worker', payload], {
+    encoding: 'utf8',
+    env,
+    cwd: seat.root,
+    timeout: 40_000,
+  });
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, '');
+  const logPath = path.join(seat.memory, 'runtime', 'capsule-verb-autofire.jsonl');
+  const entries = readFileSync(logPath, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.equal(entries.at(-1).outcome, 'completed');
+  assert.equal(entries.at(-1).dry_run, true);
+  assert.equal(entries.at(-1).stamped, false);
+  assert.equal(JSON.parse(readFileSync(path.join(seat.memory, 'BODY_STATE.json'), 'utf8')).state.last_capsule, undefined);
+});

--- a/daemons/tests/fixtures/refresh-cursor-golden.json
+++ b/daemons/tests/fixtures/refresh-cursor-golden.json
@@ -1,0 +1,202 @@
+{
+  "_README": "Golden fixture for the refresh-cursor capture-cursor primitive. Bytes = lines.map(l=>l+String.fromCharCode(10)).join(\"\") + (trailing||\"\"). expected = {event_id, offset} or null.",
+  "vectors": [
+    {
+      "name": "empty",
+      "doc": "zero bytes -> null",
+      "lines": [],
+      "trailing": "",
+      "expected": null
+    },
+    {
+      "name": "single_complete",
+      "doc": "one newline-terminated line",
+      "lines": [
+        "{\"uuid\":\"u1\",\"type\":\"user\"}"
+      ],
+      "trailing": "",
+      "expected": {
+        "event_id": "u1",
+        "offset": 28
+      }
+    },
+    {
+      "name": "multi_line",
+      "doc": "three complete lines -> cursor at the 3rd",
+      "lines": [
+        "{\"uuid\":\"u1\",\"type\":\"user\"}",
+        "{\"uuid\":\"u2\",\"type\":\"assistant\"}",
+        "{\"uuid\":\"u3\",\"type\":\"user\"}"
+      ],
+      "trailing": "",
+      "expected": {
+        "event_id": "u3",
+        "offset": 89
+      }
+    },
+    {
+      "name": "partial_trailing_line",
+      "doc": "complete lines + a torn trailing write (no newline) -> cursor at last COMPLETE line, torn bytes ignored",
+      "lines": [
+        "{\"uuid\":\"u1\",\"type\":\"user\"}",
+        "{\"uuid\":\"u2\",\"type\":\"assistant\"}",
+        "{\"uuid\":\"u3\",\"type\":\"user\"}"
+      ],
+      "trailing": "{\"uuid\":\"u4\",\"type\":\"assis",
+      "expected": {
+        "event_id": "u3",
+        "offset": 89
+      }
+    },
+    {
+      "name": "growth_before",
+      "doc": "two complete lines (baseline for growth-by-one)",
+      "lines": [
+        "{\"uuid\":\"u1\",\"type\":\"user\"}",
+        "{\"uuid\":\"u2\",\"type\":\"assistant\"}"
+      ],
+      "trailing": "",
+      "expected": {
+        "event_id": "u2",
+        "offset": 61
+      }
+    },
+    {
+      "name": "growth_after",
+      "doc": "growth_before + one appended line -> cursor advances",
+      "lines": [
+        "{\"uuid\":\"u1\",\"type\":\"user\"}",
+        "{\"uuid\":\"u2\",\"type\":\"assistant\"}",
+        "{\"uuid\":\"u3\",\"type\":\"user\"}"
+      ],
+      "trailing": "",
+      "expected": {
+        "event_id": "u3",
+        "offset": 89
+      }
+    },
+    {
+      "name": "multibyte",
+      "doc": "a 4-byte astral char (rocket) in a value -> offset counts BYTES not chars",
+      "lines": [
+        "{\"uuid\":\"u1\",\"t\":\"go 🚀\"}"
+      ],
+      "trailing": "",
+      "expected": {
+        "event_id": "u1",
+        "offset": 28
+      }
+    },
+    {
+      "name": "corrupt_last_line_fallback",
+      "doc": "last newline-terminated line is invalid JSON -> fall back to previous complete line boundary",
+      "lines": [
+        "{\"uuid\":\"u1\",\"type\":\"user\"}",
+        "{\"uuid\":\"u2\",\"type\":\"assistant\"}",
+        "{\"uuid\":\"u3\""
+      ],
+      "trailing": "",
+      "expected": {
+        "event_id": "u2",
+        "offset": 61
+      }
+    },
+    {
+      "name": "message_id_fallback",
+      "doc": "no top-level uuid -> event_id = message.id",
+      "lines": [
+        "{\"type\":\"assistant\",\"message\":{\"id\":\"msg_abc123\",\"role\":\"assistant\"}}"
+      ],
+      "trailing": "",
+      "expected": {
+        "event_id": "msg_abc123",
+        "offset": 70
+      }
+    },
+    {
+      "name": "no_complete_line",
+      "doc": "only a torn partial, no newline yet -> null (nothing captured through)",
+      "lines": [],
+      "trailing": "{\"uuid\":\"u1\",\"type\":\"us",
+      "expected": null
+    },
+    {
+      "name": "trailing_metadata_single",
+      "doc": "identity record then one uuid-less metadata line -> cursor anchors to the identity line (cursor-neutral rule)",
+      "lines": [
+        "{\"uuid\":\"u1\",\"type\":\"user\"}",
+        "{\"type\":\"permission-mode\",\"mode\":\"acceptEdits\"}"
+      ],
+      "trailing": "",
+      "expected": {
+        "event_id": "u1",
+        "offset": 28
+      }
+    },
+    {
+      "name": "trailing_metadata_multi",
+      "doc": "two identity records then permission-mode + bridge-session tail -> cursor anchors to last identity line; metadata churn moves nothing",
+      "lines": [
+        "{\"uuid\":\"u1\",\"type\":\"user\"}",
+        "{\"uuid\":\"u2\",\"type\":\"assistant\"}",
+        "{\"type\":\"permission-mode\",\"mode\":\"acceptEdits\"}",
+        "{\"type\":\"bridge-session\",\"state\":\"attached\"}"
+      ],
+      "trailing": "",
+      "expected": {
+        "event_id": "u2",
+        "offset": 61
+      }
+    },
+    {
+      "name": "metadata_then_torn",
+      "doc": "identity record, metadata line, then a torn trailing segment -> identity boundary (both fallback rules compose)",
+      "lines": [
+        "{\"uuid\":\"u1\",\"type\":\"user\"}",
+        "{\"type\":\"permission-mode\",\"mode\":\"acceptEdits\"}"
+      ],
+      "trailing": "{\"type\":\"permis",
+      "expected": {
+        "event_id": "u1",
+        "offset": 28
+      }
+    },
+    {
+      "name": "metadata_only",
+      "doc": "only uuid-less metadata lines -> null (not-ready), never a null event_id cursor",
+      "lines": [
+        "{\"type\":\"permission-mode\",\"mode\":\"acceptEdits\"}",
+        "{\"type\":\"bridge-session\",\"state\":\"attached\"}"
+      ],
+      "trailing": "",
+      "expected": null
+    },
+    {
+      "name": "corrupt_between_identity_and_metadata",
+      "doc": "identity record, corrupt line, metadata line -> torn-line and cursor-neutral fallbacks compose to the identity boundary",
+      "lines": [
+        "{\"uuid\":\"u1\",\"type\":\"user\"}",
+        "{\"uuid\":\"u3\"",
+        "{\"type\":\"permission-mode\",\"mode\":\"acceptEdits\"}"
+      ],
+      "trailing": "",
+      "expected": {
+        "event_id": "u1",
+        "offset": 28
+      }
+    },
+    {
+      "name": "message_id_fallback_with_metadata",
+      "doc": "message.id identity (no uuid) then metadata tail -> message id anchors the cursor",
+      "lines": [
+        "{\"type\":\"assistant\",\"message\":{\"id\":\"msg_abc123\",\"role\":\"assistant\"}}",
+        "{\"type\":\"bridge-session\",\"state\":\"attached\"}"
+      ],
+      "trailing": "",
+      "expected": {
+        "event_id": "msg_abc123",
+        "offset": 70
+      }
+    }
+  ]
+}

--- a/daemons/tests/lifecycle-flip.test.mjs
+++ b/daemons/tests/lifecycle-flip.test.mjs
@@ -1,0 +1,311 @@
+// lifecycle-flip.test.mjs — resume-flip regression suite for sessionstart-reinject.mjs.
+//
+// aigent-OS is single-operator, so there is ONE SessionStart hook (unlike the
+// private origin of this port, which split warm-start reinject across two
+// per-agent scripts — see sessionstart-reinject.mjs's header). This suite proves,
+// against that single merged hook:
+//   - the flip: status active→resumed, stamps written, dedupe applied
+//   - CONFIRMED-1: the pre-seeded null-placeholder pair is DEDUPED, never duplicated
+//   - CONFIRMED-3/v3: CRLF capsules keep CRLF line endings — delimiters included
+//   - CONFIRMED-5: already-resumed is STEADY-STATE (not drift, not an error)
+//   - malformed frontmatter logs, never a silent no-op
+//   - compact is NOT a resume — capsule untouched
+//   - startup, resume, and clear ALL flip (folding what used to be two separate
+//     per-source scripts into this one hook's source-agnostic anchor step)
+//
+// FIXTURE SHAPE: field list/order and the null-placeholder pair mirror a real
+// autosave capsule's frontmatter shape (see stop-capsule-writer.mjs's skeleton()).
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REINJECT = path.join(path.resolve(__dirname, '..'), 'sessionstart-reinject.mjs');
+
+let pass = 0;
+let fail = 0;
+function ok(cond, name, detail = '') {
+  if (cond) { pass++; console.log(`  PASS  ${name}`); }
+  else { fail++; console.log(`  FAIL  ${name}${detail ? `: ${detail}` : ''}`); }
+}
+
+const BODY_QUOTE = 'The incident line said "status: active" verbatim — never touch me.';
+
+// `placeholder` controls whether the pre-seeded null pair is present (the real,
+// current shape); `resumedStamp` lets a caller pre-seed an ALREADY-flipped
+// capsule (steady-state fixtures) instead of the null placeholder.
+function realFrontmatter({ status = 'active', eol = '\n', placeholder = true, resumedStamp = null, closed = true } = {}) {
+  const lines = [
+    '---',
+    'id: test-capsule',
+    'parent_capsule_id: null',
+    `status: ${status}`,
+  ];
+  if (resumedStamp) {
+    lines.push(`resumed_at: ${resumedStamp.at}`, `resumed_by_session: ${resumedStamp.by}`);
+  } else if (placeholder) {
+    lines.push('resumed_at: null', 'resumed_by_session: null');
+  }
+  lines.push(
+    'waiting_on: "review gate"',
+    'resume_trigger: open',
+    'expires: 2026-12-31T00:00:00Z',
+    'trigger: refresh-cycle',
+    'definition_hash: PENDING_HASH',
+    'objective: "prove the flip"',
+    'next_valid_action: "resume the ladder"',
+    'success_criteria: []',
+    'tags: [capsule, test]',
+    'created_at: 2026-07-17T00:00:00.000Z',
+    'resolved_at: null',
+  );
+  if (closed) lines.push('---');
+  lines.push('', BODY_QUOTE, '');
+  return lines.join(eol);
+}
+
+function fixture(label, opts = {}) {
+  const base = path.join(os.tmpdir(), `lifecycle-flip-${label}-${process.pid}`);
+  rmSync(base, { recursive: true, force: true });
+  const root = path.join(base, 'test-seat');
+  const capDir = path.join(root, 'memory', 'capsules');
+  mkdirSync(path.join(root, 'memory', 'runtime'), { recursive: true });
+  mkdirSync(capDir, { recursive: true });
+  const capPath = path.join(capDir, 'test-capsule.md');
+  writeFileSync(capPath, realFrontmatter(opts));
+  writeFileSync(path.join(root, 'memory', 'BODY_STATE.json'), JSON.stringify({
+    state: {
+      last_capsule: {
+        id: 'test-capsule',
+        path: 'memory/capsules/test-capsule.md',
+        status: 'active',
+        objective: 'prove the flip',
+        trigger: 'curated-close',
+        session_id: 'prev-sid',
+        finalized_at: new Date().toISOString(),
+      },
+    },
+  }));
+  return { base, root, capPath };
+}
+
+// Pointer references a capsule file that is never written (dangling — the file
+// was deleted externally, or never existed).
+function danglingFixture(label) {
+  const base = path.join(os.tmpdir(), `lifecycle-flip-${label}-${process.pid}`);
+  rmSync(base, { recursive: true, force: true });
+  const root = path.join(base, 'test-seat');
+  mkdirSync(path.join(root, 'memory'), { recursive: true });
+  writeFileSync(path.join(root, 'memory', 'BODY_STATE.json'), JSON.stringify({
+    state: {
+      last_capsule: {
+        id: 'ghost-capsule',
+        path: 'memory/capsules/ghost-capsule.md', // never written
+        status: 'active',
+        objective: 'prove the dangling branch',
+        trigger: 'curated-close',
+        session_id: 'prev-sid',
+        finalized_at: new Date().toISOString(),
+      },
+    },
+  }));
+  return { base, root };
+}
+
+function errLogPath(root) {
+  return path.join(root, 'memory', '.daemon-errors.log');
+}
+
+function readErrLog(root) {
+  try { return readFileSync(errLogPath(root), 'utf8'); } catch { return ''; }
+}
+
+function runReinject(root, source, sid) {
+  return spawnSync(process.execPath, [REINJECT], {
+    input: JSON.stringify({ source, session_id: sid, cwd: root }),
+    encoding: 'utf8',
+    windowsHide: true,
+    env: { ...process.env, AIGENT_ROOT: root },
+  });
+}
+
+// Every resumed_at/resumed_by_session line in a frontmatter block, in order.
+function stampLines(doc) {
+  const block = doc.split(/^---\s*$/m)[1] || '';
+  return block.split(/\r?\n/).filter((l) => /^resumed_at:|^resumed_by_session:/.test(l));
+}
+
+console.log('-- lifecycle-flip suite --');
+
+// 1. source=clear anchors AND flips: status resumed, stamps present, body byte-safe,
+// and the pre-seeded null placeholder is REPLACED, not duplicated.
+{
+  const { base, root, capPath } = fixture('clear');
+  const r = runReinject(root, 'clear', 'newsid-1111');
+  const doc = readFileSync(capPath, 'utf8');
+  ok(r.status === 0, 'clear run exits 0', r.stderr || '');
+  ok(/ACTIVE CAPSULE/.test(r.stdout), 'pointer table still prints on clear');
+  ok(/resume-flip.*finalize-lock released/.test(r.stdout), 'flip announced in output');
+  ok(/^status: resumed$/m.test(doc), 'frontmatter status flipped to resumed');
+  const stamps = stampLines(doc);
+  ok(stamps.length === 2, `exactly one resumed_at + one resumed_by_session line survives (dedupe), got ${stamps.length}: ${JSON.stringify(stamps)}`);
+  ok(/^resumed_at: (?!null)/.test(stamps[0] || ''), 'resumed_at carries the REAL stamp, not the null placeholder', JSON.stringify(stamps));
+  ok(/^resumed_by_session: newsid-1/.test(stamps[1] || ''), 'resumed_by_session carries the real session prefix', JSON.stringify(stamps));
+  ok(doc.includes(BODY_QUOTE), 'body line quoting "status: active" untouched');
+  rmSync(base, { recursive: true, force: true });
+}
+
+// 2. source=compact is NOT a resume: capsule untouched.
+{
+  const { base, root, capPath } = fixture('compact');
+  const before = readFileSync(capPath, 'utf8');
+  runReinject(root, 'compact', 'newsid-2222');
+  ok(readFileSync(capPath, 'utf8') === before, 'compact leaves the capsule byte-identical');
+  rmSync(base, { recursive: true, force: true });
+}
+
+// 3. Non-active capsule (already resolved) is never touched by startup.
+{
+  const { base, root, capPath } = fixture('resolved', { status: 'resolved', placeholder: false });
+  const before = readFileSync(capPath, 'utf8');
+  const r = runReinject(root, 'startup', 'newsid-3333');
+  ok(readFileSync(capPath, 'utf8') === before, 'resolved capsule untouched');
+  ok(!/resume-flip/.test(r.stdout), 'no flip announcement for non-active capsule');
+  rmSync(base, { recursive: true, force: true });
+}
+
+// 4. Idempotence: a second clear on an already-resumed capsule still anchors, no double-stamp.
+{
+  const { base, root, capPath } = fixture('twice');
+  runReinject(root, 'clear', 'newsid-4444');
+  const afterFirst = readFileSync(capPath, 'utf8');
+  const r2 = runReinject(root, 'clear', 'newsid-5555');
+  ok(/ACTIVE CAPSULE/.test(r2.stdout), 'second clear still anchors from the pointer');
+  ok(readFileSync(capPath, 'utf8') === afterFirst, 'second clear does not re-stamp (steady-state)');
+  ok(!/resume-flip.*finalize-lock released/.test(r2.stdout), 'second clear does not re-announce the flip (steady-state, silent)');
+  rmSync(base, { recursive: true, force: true });
+}
+
+// 5. Malformed frontmatter (no closing '---') leaves a trail in .daemon-errors.log.
+{
+  const { base, root, capPath } = fixture('malformed', { closed: false });
+  const before = readFileSync(capPath, 'utf8');
+  const r = runReinject(root, 'clear', 'newsid-6666');
+  ok(readFileSync(capPath, 'utf8') === before, 'malformed capsule is never written to');
+  ok(!/resume-flip.*finalize-lock released/.test(r.stdout), 'no flip announcement for malformed frontmatter');
+  const log = readErrLog(root);
+  ok(/resume-flip/.test(log) && /no closing delimiter/.test(log), 'the drift is logged to .daemon-errors.log', log);
+  rmSync(base, { recursive: true, force: true });
+}
+
+// 6. source=startup flips too (folds what used to be a separate cold-start script
+// into this one hook's source-agnostic anchor step).
+{
+  const { base, root, capPath } = fixture('startup');
+  const r = runReinject(root, 'startup', 'newsid-7777');
+  const doc = readFileSync(capPath, 'utf8');
+  ok(r.status === 0, 'startup run exits 0', r.stderr || '');
+  ok(/ACTIVE CAPSULE/.test(r.stdout), 'pointer table still prints on startup');
+  ok(/resume-flip.*finalize-lock released/.test(r.stdout), 'flip announced on startup');
+  ok(/^status: resumed$/m.test(doc), 'frontmatter status flipped to resumed (startup)');
+  const stamps = stampLines(doc);
+  ok(stamps.length === 2, `exactly one resumed_at + one resumed_by_session line survives (startup dedupe), got ${stamps.length}`, JSON.stringify(stamps));
+  ok(/^resumed_by_session: newsid-7/.test(stamps[1] || ''), 'resume stamps written', JSON.stringify(stamps));
+  ok(doc.includes(BODY_QUOTE), 'body line quoting "status: active" untouched');
+  rmSync(base, { recursive: true, force: true });
+}
+
+// 7. source=resume flips identically.
+{
+  const { base, root, capPath } = fixture('resume');
+  const r = runReinject(root, 'resume', 'newsid-8888');
+  const doc = readFileSync(capPath, 'utf8');
+  ok(r.status === 0, 'resume run exits 0', r.stderr || '');
+  ok(/^status: resumed$/m.test(doc), 'frontmatter status flipped to resumed (source=resume)');
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ── the null-placeholder pair is DEDUPED, never duplicated ──────────────────
+{
+  const { base, root, capPath } = fixture('dedupe-explicit');
+  const before = readFileSync(capPath, 'utf8');
+  ok(/^resumed_at: null$/m.test(before), 'fixture sanity: the null placeholder pair is present before the flip');
+  runReinject(root, 'clear', 'newsid-dedupe1');
+  const after = readFileSync(capPath, 'utf8');
+  const nullCount = (after.match(/^resumed_at: null$/gm) || []).length;
+  ok(nullCount === 0, `the null placeholder is GONE after the flip (a last-key-wins reader must never see it again), got ${nullCount} remaining`, after);
+  const stamps = stampLines(after);
+  ok(stamps.length === 2, `exactly 2 stamp lines total (not 4 — no duplication), got ${stamps.length}`, JSON.stringify(stamps));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ── CRLF capsules keep CRLF line endings, no mixed endings ──────────────────
+{
+  const { base, root, capPath } = fixture('crlf', { eol: '\r\n' });
+  const before = readFileSync(capPath, 'utf8');
+  ok(before.includes('\r\n'), 'fixture sanity: the capsule is genuinely CRLF before the flip');
+  const beforeBlock = before.split(/^---\s*$/m)[1] || '';
+  const baselineLoneLf = (beforeBlock.match(/(?<!\r)\n/g) || []).length;
+  runReinject(root, 'clear', 'newsid-crlf1');
+  const after = readFileSync(capPath, 'utf8');
+  const block = after.split(/^---\s*$/m)[1] || '';
+  const afterLoneLf = (block.match(/(?<!\r)\n/g) || []).length;
+  ok(afterLoneLf === baselineLoneLf, `the flip introduces no NEW bare-LF beyond the pre-existing split-boundary baseline (before=${baselineLoneLf}, after=${afterLoneLf})`, JSON.stringify(block));
+  ok(/^status: resumed\r$/m.test(after), 'status line itself is CRLF-terminated');
+  const stamps = stampLines(after);
+  ok(stamps.length === 2, 'dedupe still holds on a CRLF capsule', JSON.stringify(stamps));
+  ok(after.includes(BODY_QUOTE), 'body line quoting "status: active" untouched (CRLF fixture)');
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ── the '---' DELIMITER lines themselves stay CRLF-terminated (whole-file, not
+// just the body) — the strict, byte-for-byte version of the CRLF assertion above.
+{
+  const { base, root, capPath } = fixture('crlf-delimiters', { eol: '\r\n' });
+  runReinject(root, 'clear', 'newsid-crlfdelim1');
+  const after = readFileSync(capPath, 'utf8');
+  const lines = after.split('\n');
+  const badLines = lines
+    .map((l, i) => ({ i, l }))
+    .slice(0, lines[lines.length - 1] === '' ? -1 : undefined)
+    .filter(({ l }) => !l.endsWith('\r'));
+  ok(badLines.length === 0,
+    `every line in the CRLF output ends with \\r\\n, delimiter lines included -- found ${badLines.length} bare-LF line(s)`,
+    JSON.stringify({ badLines, after }));
+  ok(/^---\r$/m.test(after), 'the OPENING delimiter line is CRLF-terminated');
+  ok((after.match(/^---\r$/gm) || []).length === 2, 'both delimiter lines (open + close) are CRLF-terminated');
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ── the dangling-pointer branch ──────────────────────────────────────────────
+{
+  const { base, root } = danglingFixture('dangling');
+  const r = runReinject(root, 'clear', 'newsid-dangle1');
+  ok(!/ACTIVE CAPSULE/.test(r.stdout), 'no pointer table for a dangling capsule');
+  ok(/no longer exists/.test(r.stdout), 'the dangling warning prints');
+  const log = readErrLog(root);
+  ok(/DANGLING capsule pointer/.test(log), 'dangling is logged', log);
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ── already-resumed is STEADY-STATE, not drift, not an error ────────────────
+{
+  const { base, root, capPath } = fixture('steady-state', {
+    status: 'resumed',
+    placeholder: false,
+    resumedStamp: { at: '2026-07-16T12:00:00.000Z', by: 'priorsid' },
+  });
+  const before = readFileSync(capPath, 'utf8');
+  const r = runReinject(root, 'clear', 'newsid-steady1');
+  ok(readFileSync(capPath, 'utf8') === before, 'an already-resumed capsule is byte-identical after another clear (steady-state, untouched)');
+  ok(!/resume-flip.*finalize-lock released/.test(r.stdout), 'no flip announcement for an already-resumed capsule');
+  const log = readErrLog(root);
+  ok(!/resume-flip/.test(log), 'steady-state is NOT logged as drift — silently fine', log);
+  rmSync(base, { recursive: true, force: true });
+}
+
+console.log(`\n${pass} passed, ${fail} failed.`);
+process.exit(fail === 0 ? 0 : 1);

--- a/daemons/tests/refresh-cursor.test.mjs
+++ b/daemons/tests/refresh-cursor.test.mjs
@@ -1,0 +1,176 @@
+// daemons/tests/refresh-cursor.test.mjs — the capture-cursor primitive.
+// Run: node --test daemons/tests/refresh-cursor.test.mjs
+//
+// Golden-fixture transcripts -> expected cursor; cursorEqual/cursorAdvanced truth
+// table; and a CONCURRENT-WRITE RACE test (read at EVERY mid-write byte position
+// must never over- or under-count).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readCursor, cursorEqual, cursorAdvanced } from '../refresh-cursor.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── shared fixture + helpers ─────────────────────────────────────────────────
+const FIXTURE = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'fixtures', 'refresh-cursor-golden.json'), 'utf8'),
+);
+const vec = (name) => {
+  const v = FIXTURE.vectors.find((x) => x.name === name);
+  if (!v) throw new Error(`fixture vector not found: ${name}`);
+  return v;
+};
+// On-disk bytes for a vector: complete lines each + '\n', then the torn trailing.
+function bytesOf(v) {
+  return Buffer.from(v.lines.map((l) => l + '\n').join('') + (v.trailing || ''), 'utf8');
+}
+// Inject a buffer as the transcript; stat reports its byte length.
+function depsFor(buf) {
+  return { readFile: () => buf, stat: () => ({ size: buf.length }) };
+}
+function cursorOf(v) {
+  const buf = bytesOf(v);
+  return readCursor('X:/fake/<slug>/<sid>.jsonl', depsFor(buf));
+}
+
+// ── golden-fixture transcripts -> expected cursor ────────────────────────────
+describe('readCursor — golden fixture vectors', () => {
+  for (const v of FIXTURE.vectors) {
+    it(`${v.name}: ${v.doc}`, () => {
+      assert.deepEqual(cursorOf(v), v.expected);
+    });
+  }
+
+  it('empty transcript -> null', () => {
+    assert.equal(cursorOf(vec('empty')), null);
+  });
+
+  it('partial-trailing-line -> cursor at last COMPLETE line, torn bytes ignored', () => {
+    const partial = cursorOf(vec('partial_trailing_line'));
+    const multi = cursorOf(vec('multi_line'));
+    assert.deepEqual(partial, multi);
+    assert.equal(partial.event_id, 'u3');
+  });
+
+  it('multi-line -> cursor at the final complete line', () => {
+    assert.deepEqual(cursorOf(vec('multi_line')), { event_id: 'u3', offset: 89 });
+  });
+
+  it('offset counts BYTES not chars (astral multibyte char)', () => {
+    assert.equal(cursorOf(vec('multibyte')).offset, 28);
+  });
+
+  it('corrupt last complete line -> falls back to previous boundary', () => {
+    assert.deepEqual(cursorOf(vec('corrupt_last_line_fallback')), { event_id: 'u2', offset: 61 });
+  });
+
+  it('no top-level uuid -> event_id from message.id', () => {
+    assert.equal(cursorOf(vec('message_id_fallback')).event_id, 'msg_abc123');
+  });
+
+  it('only a torn partial (no newline yet) -> null', () => {
+    assert.equal(cursorOf(vec('no_complete_line')), null);
+  });
+});
+
+// ── growth-by-one ────────────────────────────────────────────────────────────
+describe('readCursor — growth by one line advances the cursor', () => {
+  it('before -> after: strictly advanced, not equal, new event_id', () => {
+    const before = cursorOf(vec('growth_before'));
+    const after = cursorOf(vec('growth_after'));
+    assert.equal(cursorAdvanced(before, after), true);
+    assert.equal(cursorEqual(before, after), false);
+    assert.ok(after.offset > before.offset, 'offset must strictly increase');
+    assert.notEqual(after.event_id, before.event_id);
+  });
+});
+
+// ── cursorEqual / cursorAdvanced truth tables ────────────────────────────────
+describe('cursorEqual truth table', () => {
+  const A = { event_id: 'a', offset: 5 };
+  const cases = [
+    ['same event_id+offset', A, { event_id: 'a', offset: 5 }, true],
+    ['offset differs', A, { event_id: 'a', offset: 6 }, false],
+    ['event_id differs', A, { event_id: 'b', offset: 5 }, false],
+    ['null,null', null, null, true],
+    ['null,cursor', null, A, false],
+    ['cursor,null', A, null, false],
+  ];
+  for (const [name, a, b, expected] of cases) {
+    it(name, () => assert.equal(cursorEqual(a, b), expected));
+  }
+});
+
+describe('cursorAdvanced truth table', () => {
+  const cases = [
+    ['cur beyond prev', { event_id: 'a', offset: 5 }, { event_id: 'b', offset: 6 }, true],
+    ['cur behind prev', { event_id: 'b', offset: 6 }, { event_id: 'a', offset: 5 }, false],
+    ['equal offsets', { event_id: 'a', offset: 5 }, { event_id: 'a', offset: 5 }, false],
+    ['prev null, cur set', null, { event_id: 'a', offset: 1 }, true],
+    ['prev set, cur null', { event_id: 'a', offset: 5 }, null, false],
+    ['both null', null, null, false],
+  ];
+  for (const [name, prev, cur, expected] of cases) {
+    it(name, () => assert.equal(cursorAdvanced(prev, cur), expected));
+  }
+});
+
+// ── CRLF robustness (local; the shared fixture is LF-only like real transcripts)
+describe('readCursor — CRLF transcripts', () => {
+  it('strips trailing CR before parse; offset counts the \\r\\n bytes', () => {
+    const buf = Buffer.from('{"uuid":"c1"}\r\n{"uuid":"c2"}\r\n', 'utf8');
+    const cur = readCursor('x', depsFor(buf));
+    assert.equal(cur.event_id, 'c2');
+    assert.equal(cur.offset, buf.length);
+  });
+  it('torn CRLF (\\r without \\n) -> last complete line, no over-count', () => {
+    const buf = Buffer.from('{"uuid":"c1"}\r\n{"uuid":"c2"}\r\n{"uuid":"c3"}\r', 'utf8');
+    const cur = readCursor('x', depsFor(buf));
+    assert.equal(cur.event_id, 'c2');
+    assert.equal(cur.offset, Buffer.byteLength('{"uuid":"c1"}\r\n{"uuid":"c2"}\r\n', 'utf8'));
+  });
+});
+
+// ── CONCURRENT-WRITE RACE ────────────────────────────────────────────────────
+describe('readCursor — concurrent-write race (never over/under-counts)', () => {
+  const LINES = [
+    '{"uuid":"r1","type":"user"}',
+    '{"uuid":"r2","type":"assistant","t":"go 🚀"}',
+    '{"uuid":"r3","type":"user"}',
+  ];
+  const boundaries = [];
+  let acc = 0;
+  for (const l of LINES) { acc += Buffer.byteLength(l + '\n', 'utf8'); boundaries.push(acc); }
+  const torn = '{"uuid":"r4","type":"assis';
+  const full = Buffer.from(LINES.map((l) => l + '\n').join('') + torn, 'utf8');
+
+  it('read at every byte position lands exactly on the last complete boundary', () => {
+    let lastOffset = 0;
+    for (let p = 0; p <= full.length; p++) {
+      const slice = full.subarray(0, p);
+      const cur = readCursor('x', depsFor(slice));
+      let expected = null;
+      for (const b of boundaries) { if (b <= p) expected = b; }
+      if (expected === null) {
+        assert.equal(cur, null, `p=${p}: no complete line yet -> null`);
+      } else {
+        assert.equal(cur.offset, expected, `p=${p}: must sit on boundary ${expected}`);
+        assert.ok(cur.offset <= p, `p=${p}: never over-counts past available bytes`);
+        assert.ok(cur.offset >= lastOffset, `p=${p}: never regresses (no under-count)`);
+        lastOffset = cur.offset;
+      }
+    }
+  });
+
+  it('the torn 4th write never advances the cursor past line 3', () => {
+    const b3 = boundaries[2];
+    for (let p = b3; p <= full.length; p++) {
+      const cur = readCursor('x', depsFor(full.subarray(0, p)));
+      assert.equal(cur.offset, b3, `p=${p}: torn tail must not advance the cursor`);
+      assert.equal(cur.event_id, 'r3');
+    }
+  });
+});

--- a/daemons/tests/refresh-request.test.mjs
+++ b/daemons/tests/refresh-request.test.mjs
@@ -1,0 +1,359 @@
+'use strict';
+
+// refresh-request.test.mjs — seat request-intake (challenge crossing).
+// Run: node --test daemons/tests/refresh-request.test.mjs
+//
+// Proves: RefreshRequest round-trips; a present, unexpired request drives the
+// autofire worker to stamp a 'prepared' seat cycle whose challenge_digest is
+// 'sha256:'+sha256(challenge) (the seat authors NO nonce); absent / expired /
+// malformed requests fail CLOSED (refuse, no stamp); and the dryRun default stamps
+// nothing live.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  createRequest, writeRequest, readRequest, requestPath,
+} from '../refresh-request.mjs';
+import { readCycleRecord, cycleRecordPath } from '../refresh-cycle.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SENSOR = path.resolve(__dirname, '..', 'ctx-refresh-sensor.mjs');
+const SHA256 = /^sha256:[0-9a-f]{64}$/;
+const SEAT_ID = 'operator';
+
+function mkSeat(parent = os.tmpdir(), { git = false } = {}) {
+  const base = mkdtempSync(path.join(parent, '.rr-seat-'));
+  const root = path.join(base, 'test-seat');
+  const memory = path.join(root, 'memory');
+  mkdirSync(path.join(memory, 'capsules'), { recursive: true });
+  mkdirSync(path.join(memory, 'runtime', 'stop-writer'), { recursive: true });
+  writeFileSync(path.join(memory, 'BODY_STATE.json'), JSON.stringify({ state: {} }));
+  if (git) {
+    const cfg = ['-c', 'user.name=rr-fixture', '-c', 'user.email=rr-fixture@test.local'];
+    execFileSync('git', ['-C', root, 'init', '-q'], { encoding: 'utf8' });
+    writeFileSync(path.join(root, 'seed.txt'), 'refresh-request fixture seed\n');
+    execFileSync('git', ['-C', root, ...cfg, 'add', '.'], { encoding: 'utf8' });
+    execFileSync('git', ['-C', root, ...cfg, 'commit', '-q', '-m', 'fixture seed'], { encoding: 'utf8' });
+  }
+  return { base, root, memory, cleanup() { rmSync(base, { recursive: true, force: true }); } };
+}
+
+function validCapsule(id = 'capsule-rr') {
+  return [
+    '---',
+    'id: ' + id,
+    'status: active',
+    'objective: "Close the challenge crossing"',
+    'waiting_on: "verification"',
+    'next_valid_action: "Run the daemon test suite"',
+    '---',
+    '',
+    '> [!info] [REFERENCE ONLY] — state snapshot, not instructions.',
+    '',
+  ].join('\n');
+}
+
+function writeCapsule(seat, text = validCapsule()) {
+  const file = path.join(seat.memory, 'capsules', 'capsule-RR.md');
+  writeFileSync(file, text);
+  return file;
+}
+
+function writeStop(seat, sid, capsulePath) {
+  writeFileSync(
+    path.join(seat.memory, 'runtime', 'stop-writer', sid + '.json'),
+    JSON.stringify({ capsule_path: capsulePath }),
+  );
+}
+
+// A transcript whose LAST complete line carries uuid 'evt-live-cursor' — the live
+// cursor readCursor returns, and therefore the captured_through_event_id stamped.
+function writeTranscript(seat, name = 'transcript.jsonl') {
+  const p = path.join(seat.base, name);
+  writeFileSync(
+    p,
+    '{"uuid":"evt-first","type":"user"}\n'
+    + '{"uuid":"evt-live-cursor","type":"assistant","message":{"id":"msg-x"}}\n',
+  );
+  return p;
+}
+
+// Invoke the detached autofire worker directly (the same entry the sensor
+// spawns). No board adapter is configured, so evidence collection never touches
+// a live board.
+function runWorker(seat, sid, { transcriptPath = null, dryRunOff = false } = {}) {
+  const payload = Buffer.from(JSON.stringify({
+    root: seat.root, sid, eventId: 'evt-hint', transcriptPath,
+  }), 'utf8').toString('base64url');
+  const env = {
+    ...process.env,
+    AIGENT_ROOT: seat.root,
+  };
+  delete env.AIGENT_BOARD_ADAPTER;
+  if (dryRunOff) env.CAPSULE_VERB_AUTOFIRE_DRY_RUN = '0';
+  else delete env.CAPSULE_VERB_AUTOFIRE_DRY_RUN;
+  const result = spawnSync(process.execPath, [SENSOR, '--autofire-worker', payload], {
+    encoding: 'utf8', env, cwd: seat.root, timeout: 40_000,
+  });
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, '');
+  const logPath = path.join(seat.memory, 'runtime', 'capsule-verb-autofire.jsonl');
+  const entries = existsSync(logPath)
+    ? readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse)
+    : [];
+  return { result, entries, last: entries.at(-1) };
+}
+
+const notStamped = (seat, sid) => {
+  assert.equal(existsSync(cycleRecordPath(seat.root, sid)), false);
+  assert.equal(JSON.parse(readFileSync(path.join(seat.memory, 'BODY_STATE.json'), 'utf8')).state.last_capsule, undefined);
+};
+
+// ── unit: request file round-trip + fail-closed reader ──────────────────────────
+test('RefreshRequest round-trips through write/read unchanged', (t) => {
+  const memory = mkdtempSync(path.join(os.tmpdir(), 'rr-rt-'));
+  t.after(() => rmSync(memory, { recursive: true, force: true }));
+  const sid = 'rt-session';
+  const req = createRequest({
+    cycle_id: 'cyc-rt',
+    challenge: 'round-trip-nonce',
+    captured_through_hint: { event_id: 'evt-9', offset: 128 },
+    issued_at: '2026-07-12T12:00:00.000Z',
+    expires_at: '2026-07-12T12:30:00.000Z',
+  });
+  const file = writeRequest(memory, sid, req);
+  assert.equal(existsSync(file), true);
+  assert.deepEqual(readRequest(memory, sid), req);
+  assert.equal(req.version, 1);
+});
+
+test('readRequest fails closed: absent -> null; torn JSON -> null', (t) => {
+  const memory = mkdtempSync(path.join(os.tmpdir(), 'rr-fc-'));
+  t.after(() => rmSync(memory, { recursive: true, force: true }));
+  assert.equal(readRequest(memory, 'never-written'), null);
+  const sid = 'torn';
+  mkdirSync(path.join(memory, 'runtime'), { recursive: true });
+  writeFileSync(requestPath(memory, sid), '{"version":1,"cycle_id":');
+  assert.equal(readRequest(memory, sid), null);
+});
+
+test('writeRequest refuses to persist a malformed request (loud, no file)', (t) => {
+  const memory = mkdtempSync(path.join(os.tmpdir(), 'rr-badwrite-'));
+  t.after(() => rmSync(memory, { recursive: true, force: true }));
+  assert.throws(() => writeRequest(memory, 'x', {
+    version: 2, // not 1
+    cycle_id: 'c', challenge: 'k',
+    captured_through_hint: { event_id: null, offset: 0 },
+    issued_at: '2026-07-12T12:00:00.000Z', expires_at: '2026-07-12T12:30:00.000Z',
+  }), /refusing to write malformed request/);
+  assert.equal(existsSync(requestPath(memory, 'x')), false);
+});
+
+// ── integration: a present request drives a 'prepared' cycle (dryRun OFF) ────────
+test('present request -> autofire stamps a prepared seat cycle; challenge_digest = sha256:challenge', (t) => {
+  const seat = mkSeat(os.tmpdir(), { git: true });
+  t.after(seat.cleanup);
+  const sid = 'rr-present';
+  const capsule = writeCapsule(seat, validCapsule('capsule-rr-present'));
+  writeStop(seat, sid, capsule);
+  const transcriptPath = writeTranscript(seat);
+  const challenge = 'Zm9vYmFyLW5vbmNlLTMyYnl0ZS1iYXNlNjR1cmwtWFla';
+  writeRequest(seat.memory, sid, createRequest({
+    cycle_id: 'cycle-rr-present',
+    challenge,
+    captured_through_hint: { event_id: 'evt-live-cursor', offset: 34 },
+    issued_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+  }));
+
+  const { last } = runWorker(seat, sid, { transcriptPath, dryRunOff: true });
+  assert.equal(last.outcome, 'completed');
+  assert.equal(last.mode, 'cycle');
+  assert.equal(last.dry_run, false);
+  assert.equal(last.stamped, true);
+  assert.deepEqual(last.cycle_states, ['requested', 'capsuling', 'prepared']);
+
+  const stored = readCycleRecord(seat.root, sid);
+  assert.equal(stored.state, 'prepared');
+  const expectedDigest = 'sha256:' + createHash('sha256').update(challenge).digest('hex');
+  assert.match(stored.challenge_digest, SHA256);
+  assert.equal(stored.challenge_digest, expectedDigest);
+  // Live cursor from the raw transcript, not the request hint, is authoritative.
+  assert.equal(stored.captured_through_event_id, 'evt-live-cursor');
+  assert.equal(stored.cycle_id, 'cycle-rr-present');
+  // The raw nonce NEVER lands in the persisted cycle record.
+  assert.equal(readFileSync(cycleRecordPath(seat.root, sid), 'utf8').includes(challenge), false);
+  // Pointer stamped.
+  assert.notEqual(JSON.parse(readFileSync(path.join(seat.memory, 'BODY_STATE.json'), 'utf8')).state.last_capsule, undefined);
+});
+
+// ── integration: dryRun default stamps nothing live ─────────────────────────────
+test('dryRun default (flag unset) stamps nothing live', (t) => {
+  const seat = mkSeat(os.tmpdir(), { git: true });
+  t.after(seat.cleanup);
+  const sid = 'rr-dry';
+  const capsule = writeCapsule(seat, validCapsule('capsule-rr-dry'));
+  writeStop(seat, sid, capsule);
+  const transcriptPath = writeTranscript(seat);
+  writeRequest(seat.memory, sid, createRequest({
+    cycle_id: 'cycle-rr-dry',
+    challenge: 'dry-run-challenge-nonce',
+    captured_through_hint: { event_id: 'evt-live-cursor', offset: 34 },
+    expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+  }));
+
+  const { last } = runWorker(seat, sid, { transcriptPath }); // dryRun default ON
+  assert.equal(last.outcome, 'completed');
+  assert.equal(last.mode, 'cycle');
+  assert.equal(last.dry_run, true);
+  assert.equal(last.stamped, false);
+  assert.deepEqual(last.cycle_states, []);
+  notStamped(seat, sid);
+});
+
+// ── integration: absent / expired / malformed requests fail CLOSED ──────────────
+test('absent request (transcript present) -> autofire refuses, no stamp', (t) => {
+  const seat = mkSeat(os.tmpdir());
+  t.after(seat.cleanup);
+  const sid = 'rr-absent';
+  writeStop(seat, sid, writeCapsule(seat, validCapsule('capsule-rr-absent')));
+  const transcriptPath = writeTranscript(seat);
+  // No request written. dryRunOff so a non-refusal WOULD stamp — makes "no stamp" load-bearing.
+  const { last } = runWorker(seat, sid, { transcriptPath, dryRunOff: true });
+  assert.equal(last.outcome, 'refused');
+  assert.match(last.error, /request absent/i);
+  notStamped(seat, sid);
+});
+
+test('expired request -> autofire refuses, no stamp', (t) => {
+  const seat = mkSeat(os.tmpdir());
+  t.after(seat.cleanup);
+  const sid = 'rr-expired';
+  writeStop(seat, sid, writeCapsule(seat, validCapsule('capsule-rr-expired')));
+  const transcriptPath = writeTranscript(seat);
+  writeRequest(seat.memory, sid, createRequest({
+    cycle_id: 'cycle-rr-expired',
+    challenge: 'expired-nonce',
+    captured_through_hint: { event_id: 'evt-live-cursor', offset: 34 },
+    issued_at: '2000-01-01T00:00:00.000Z',
+    expires_at: '2000-01-01T00:10:00.000Z',
+  }));
+  const { last } = runWorker(seat, sid, { transcriptPath, dryRunOff: true });
+  assert.equal(last.outcome, 'refused');
+  assert.match(last.error, /expired/i);
+  notStamped(seat, sid);
+});
+
+test('malformed request file -> autofire refuses, no stamp', (t) => {
+  const seat = mkSeat(os.tmpdir());
+  t.after(seat.cleanup);
+  const sid = 'rr-malformed';
+  writeStop(seat, sid, writeCapsule(seat, validCapsule('capsule-rr-malformed')));
+  const transcriptPath = writeTranscript(seat);
+  writeFileSync(requestPath(seat.memory, sid), '{ this is not valid json ');
+  const { last } = runWorker(seat, sid, { transcriptPath, dryRunOff: true });
+  assert.equal(last.outcome, 'refused');
+  notStamped(seat, sid);
+});
+
+// ── integration: chained abort -> re-mint over ONE seat record ──────────────────
+// A controller quiescence-abort + re-arm leaves the persisted seat record on the
+// DEAD cycle (state=prepared); before the supersede rule the verb's begin-in-
+// requested guard then refused every NEW cycle forever (permanent seat strand).
+// The controller's re-minted request (different cycle_id, strictly newer
+// issued_at, unexpired) IS the supersede signal: the worker yields the stale
+// record to it and the new cycle proceeds from requested.
+test('chained abort -> re-mint: a strictly-newer request supersedes the stale prepared seat record', (t) => {
+  const seat = mkSeat(os.tmpdir(), { git: true });
+  t.after(seat.cleanup);
+  const sid = 'rr-chained';
+  writeStop(seat, sid, writeCapsule(seat, validCapsule('capsule-rr-chained')));
+  const transcriptPath = writeTranscript(seat);
+
+  const challengeA = 'Y2hhaW5lZC1jeWNsZS1hLW5vbmNlLTMyYnl0ZS1YWFhY';
+  writeRequest(seat.memory, sid, createRequest({
+    cycle_id: 'cycle-rr-chain-a',
+    challenge: challengeA,
+    captured_through_hint: { event_id: 'evt-live-cursor', offset: 34 },
+    issued_at: new Date(Date.now() - 60_000).toISOString(),
+    expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+  }));
+  const first = runWorker(seat, sid, { transcriptPath, dryRunOff: true });
+  assert.equal(first.last.outcome, 'completed');
+  const staleRecord = readCycleRecord(seat.root, sid);
+  assert.equal(staleRecord.state, 'prepared');
+  assert.equal(staleRecord.cycle_id, 'cycle-rr-chain-a');
+
+  // Controller aborts cycle A and re-mints B: the request-file overwrite is the
+  // controller's real behavior (one request file per sid = its current intent).
+  const challengeB = 'Y2hhaW5lZC1jeWNsZS1iLW5vbmNlLTMyYnl0ZS1ZWVlZ';
+  writeRequest(seat.memory, sid, createRequest({
+    cycle_id: 'cycle-rr-chain-b',
+    challenge: challengeB,
+    captured_through_hint: { event_id: 'evt-live-cursor', offset: 34 },
+    issued_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+  }));
+  const second = runWorker(seat, sid, { transcriptPath, dryRunOff: true });
+
+  const supersede = second.entries.find((e) => e.outcome === 'superseded_stale_seat_record');
+  assert.ok(supersede, 'supersede log entry present');
+  assert.equal(supersede.superseded_cycle, 'cycle-rr-chain-a');
+  assert.equal(supersede.superseded_state, 'prepared');
+  assert.equal(supersede.by_cycle, 'cycle-rr-chain-b');
+  assert.equal(second.last.outcome, 'completed');
+  assert.equal(second.last.stamped, true);
+  assert.deepEqual(second.last.cycle_states, ['requested', 'capsuling', 'prepared']);
+
+  const stored = readCycleRecord(seat.root, sid);
+  assert.equal(stored.cycle_id, 'cycle-rr-chain-b');
+  assert.equal(stored.state, 'prepared');
+  const expectedDigestB = 'sha256:' + createHash('sha256').update(challengeB).digest('hex');
+  assert.equal(stored.challenge_digest, expectedDigestB);
+});
+
+test('fail-closed: a different-cycle request NOT strictly newer than the record does not supersede', (t) => {
+  const seat = mkSeat(os.tmpdir(), { git: true });
+  t.after(seat.cleanup);
+  const sid = 'rr-not-newer';
+  writeStop(seat, sid, writeCapsule(seat, validCapsule('capsule-rr-not-newer')));
+  const transcriptPath = writeTranscript(seat);
+
+  writeRequest(seat.memory, sid, createRequest({
+    cycle_id: 'cycle-rr-nn-a',
+    challenge: 'bm90LW5ld2VyLWN5Y2xlLWEtbm9uY2UtMzJieXRlLVo',
+    captured_through_hint: { event_id: 'evt-live-cursor', offset: 34 },
+    issued_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+  }));
+  const first = runWorker(seat, sid, { transcriptPath, dryRunOff: true });
+  assert.equal(first.last.outcome, 'completed');
+
+  // Different cycle_id, unexpired, but issued BEFORE the record: a replay/clock
+  // corner, not the controller's newer intent: refuse loudly, delete nothing.
+  writeRequest(seat.memory, sid, createRequest({
+    cycle_id: 'cycle-rr-nn-replay',
+    challenge: 'bm90LW5ld2VyLXJlcGxheS1ub25jZS0zMmJ5dGUtUVE',
+    captured_through_hint: { event_id: 'evt-live-cursor', offset: 34 },
+    issued_at: new Date(Date.now() - 3_600_000).toISOString(),
+    expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+  }));
+  const second = runWorker(seat, sid, { transcriptPath, dryRunOff: true });
+  assert.equal(second.last.outcome, 'refused');
+  assert.match(second.last.error, /not superseded/i);
+  assert.match(second.last.error, /not strictly newer/i);
+
+  const stored = readCycleRecord(seat.root, sid);
+  assert.equal(stored.cycle_id, 'cycle-rr-nn-a');
+  assert.equal(stored.state, 'prepared');
+});

--- a/daemons/tests/resume-verb.test.mjs
+++ b/daemons/tests/resume-verb.test.mjs
@@ -1,0 +1,152 @@
+// resume-verb.test.mjs — the resume verb container.
+//
+// Proves the DETERMINISTIC half of the resume verb: pointer resolution
+// (BODY_STATE.json's state.last_capsule — aigent-OS is single-operator, so there
+// is exactly one pointer shape), capsule-frontmatter loading, degraded-path
+// behavior (missing/dangling/corrupt pointer must degrade to the
+// re-derive-from-memory instruction, never throw, never break session start), and
+// that the emitted prompt carries every load-bearing line of the authored
+// procedure (docs/two-verb-lifecycle.md): the three fences, the re-ground step,
+// the ACT-not-pointer-presence postcondition, the definition_hash recompute
+// recipe (sha256(objective+next_valid_action) first-12-hex), and the ACK step.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { runResumeVerb } from '../resume-verb.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.join(__dirname, '..', 'resume-verb.mjs');
+
+const CAPSULE_MD = `---
+id: 2026-07-15-test-capsule
+objective: "Test objective for the resume verb"
+status: active
+waiting_on: "review gate on the open branch"
+next_valid_action: "Fold pre-gate review findings, then hand off"
+definition_hash: abc123def456
+---
+
+# Test capsule body
+`;
+
+function mkFixture() {
+  const base = mkdtempSync(path.join(tmpdir(), 'rv-'));
+  const root = path.join(base, 'test-seat');
+  const mem = path.join(root, 'memory');
+  mkdirSync(path.join(mem, 'runtime'), { recursive: true });
+  mkdirSync(path.join(mem, 'capsules'), { recursive: true });
+  const capPath = path.join(mem, 'capsules', '2026-07-15-test-capsule.md');
+  writeFileSync(capPath, CAPSULE_MD);
+  writeFileSync(path.join(mem, 'BODY_STATE.json'), JSON.stringify({
+    state: {
+      last_capsule: {
+        id: '2026-07-15-test-capsule',
+        path: 'memory/capsules/2026-07-15-test-capsule.md',
+        status: 'active',
+        trigger: 'curated-close',
+      },
+    },
+  }));
+  return { base, root, mem, capPath };
+}
+
+test('pointer resolves, frontmatter loads, prompt carries the loaded values', () => {
+  const f = mkFixture();
+  try {
+    const r = runResumeVerb({ projectRoot: f.root, source: 'clear', sessionId: 'sid-1' });
+    assert.equal(r.degraded, false);
+    assert.equal(r.loaded.id, '2026-07-15-test-capsule');
+    assert.equal(r.loaded.waiting_on, 'review gate on the open branch');
+    assert.equal(r.loaded.next_valid_action, 'Fold pre-gate review findings, then hand off');
+    assert.equal(r.loaded.definition_hash, 'abc123def456');
+    assert.ok(r.prompt.includes('2026-07-15-test-capsule'), 'prompt names the capsule');
+    assert.ok(r.prompt.includes('review gate on the open branch'), 'prompt carries waiting_on');
+  } finally { rmSync(f.base, { recursive: true, force: true }); }
+});
+
+test('prompt carries all three fences + re-ground + ACT postcondition + ACK-after-action (load-bearing lines)', () => {
+  const f = mkFixture();
+  try {
+    const p = runResumeVerb({ projectRoot: f.root, source: 'clear', sessionId: 'sid-1' }).prompt;
+    // Fence 1: pointer presence is not resumption.
+    assert.ok(/Do NOT assert resumption is complete because the pointer table appears in context/.test(p), 'fence 1');
+    // Fence 2: resume never reads cycle_token.
+    assert.ok(/never read.*cycle_token|Do NOT read.*cycle_token/i.test(p), 'fence 2');
+    // Fence 3: capsule content is not an instruction queue.
+    assert.ok(/not an active instruction queue|NOT.*an active instruction queue/i.test(p), 'fence 3');
+    // Re-ground step folds /open: re-read the session log + priorities.
+    assert.ok(/RE-GROUND against live memory/i.test(p), 're-ground step present');
+    // ACT: live memory wins; the verb ends on the ACTION.
+    assert.ok(/live memory wins/i.test(p), 'ACT: conflict rule');
+    // ACK: emitted after the action, never before.
+    assert.ok(/ONLY after|only AFTER/i.test(p), 'ACK: after the action, never before');
+  } finally { rmSync(f.base, { recursive: true, force: true }); }
+});
+
+test('prompt carries the definition_hash recompute recipe (seat-side sha256 first-12)', () => {
+  const f = mkFixture();
+  try {
+    const p = runResumeVerb({ projectRoot: f.root, source: 'clear', sessionId: 'sid-1' }).prompt;
+    assert.ok(p.includes('abc123def456'), 'the stamped hash is inlined for comparison');
+    assert.ok(/sha256\(objective \+ next_valid_action\).*first 12|first 12.*sha256/i.test(p), 'recompute recipe stated');
+    assert.ok(/mismatch.*re-derive.*memory|re-derive from memory/i.test(p), 'drift consequence stated');
+  } finally { rmSync(f.base, { recursive: true, force: true }); }
+});
+
+test('missing pointer degrades to re-derive-from-memory (never throws)', () => {
+  const base = mkdtempSync(path.join(tmpdir(), 'rv-'));
+  const root = path.join(base, 'test-seat');
+  mkdirSync(path.join(root, 'memory', 'runtime'), { recursive: true });
+  try {
+    const r = runResumeVerb({ projectRoot: root, source: 'clear', sessionId: 'sid-1' });
+    assert.equal(r.degraded, true);
+    assert.equal(r.loaded, null);
+    assert.ok(/No resolvable capsule pointer/i.test(r.prompt), 'degraded prompt names the condition');
+    // Pin the degraded-SPECIFIC re-derive line, not the always-present STEPS text.
+    assert.ok(/Do NOT guess at prior state/.test(r.prompt), 'degraded prompt forbids guessing and re-derives');
+  } finally { rmSync(base, { recursive: true, force: true }); }
+});
+
+test('dangling capsule path degrades (pointer names a file that is gone)', () => {
+  const f = mkFixture();
+  try {
+    rmSync(f.capPath);
+    const r = runResumeVerb({ projectRoot: f.root, source: 'clear', sessionId: 'sid-1' });
+    assert.equal(r.degraded, true);
+    assert.ok(/No resolvable capsule pointer|no longer exists|dangling/i.test(r.prompt));
+  } finally { rmSync(f.base, { recursive: true, force: true }); }
+});
+
+test('corrupt pointer JSON degrades AND logs to .daemon-errors.log (never breaks session start)', () => {
+  const f = mkFixture();
+  try {
+    writeFileSync(path.join(f.mem, 'BODY_STATE.json'), '{not json');
+    const r = runResumeVerb({ projectRoot: f.root, source: 'clear', sessionId: 'sid-1' });
+    assert.equal(r.degraded, true);
+    const errLog = path.join(f.mem, '.daemon-errors.log');
+    assert.ok(existsSync(errLog) && readFileSync(errLog, 'utf8').includes('resume-verb'), 'failure logged, not swallowed');
+  } finally { rmSync(f.base, { recursive: true, force: true }); }
+});
+
+test('CLI: source=clear prints the prompt; source=startup and source=resume print nothing; always exit 0', () => {
+  const f = mkFixture();
+  try {
+    const run = (source) => spawnSync(process.execPath, [CLI], {
+      input: JSON.stringify({ source, session_id: 'sid-cli', cwd: f.root }),
+      env: { ...process.env, AIGENT_ROOT: f.root },
+      encoding: 'utf8',
+    });
+    const clear = run('clear');
+    assert.equal(clear.status, 0);
+    assert.ok(clear.stdout.includes('RESUME VERB'), 'clear boot gets the procedure');
+    for (const source of ['startup', 'resume', 'compact']) {
+      const r = run(source);
+      assert.equal(r.status, 0, `${source} exits 0`);
+      assert.equal(r.stdout.trim(), '', `${source} injects nothing (reinject owns warm-start; the verb is post-clear only)`);
+    }
+  } finally { rmSync(f.base, { recursive: true, force: true }); }
+});

--- a/daemons/tests/stop-capsule-writer.classify.test.mjs
+++ b/daemons/tests/stop-capsule-writer.classify.test.mjs
@@ -1,0 +1,126 @@
+// stop-capsule-writer.classify.test.mjs — speaker-tag classifier regression guard.
+//
+// Extracted from a broader private regression suite that also covered a journal
+// WAL, a session-end flush, and a PreCompact block-matrix — none of which are
+// part of this two-verb-lifecycle port (they belonged to a separate zero-leak
+// subsystem). This file keeps ONLY the piece that IS in scope: the
+// stop-capsule-writer.mjs speaker-tag classifier (classify()) — OPERATOR / RELAY /
+// PEER / INJECT tagging, including the anchor regression where a human message
+// merely quoting teammate_id="x" must stay tagged OPERATOR, not PEER.
+//
+// Black-box by design — spawns the REAL daemon against a self-contained OS-temp
+// seat, so it tests shipped behavior and cannot drift from it.
+// Run: node daemons/tests/stop-capsule-writer.classify.test.mjs (exit 0 = PASS)
+
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const DAEMONS = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const TMP = path.join(os.tmpdir(), `classify-test-${process.pid}`);
+const SANDBOX = path.join(TMP, 'test-seat');
+const MEM = path.join(SANDBOX, 'memory');
+
+let failed = 0;
+const check = (name, ok, detail = '') => { console.log(`${ok ? 'ok' : 'FAIL'}: ${name}${detail ? ` — ${detail}` : ''}`); if (!ok) failed++; };
+const run = (file, args, opts = {}) => spawnSync(process.execPath, [path.join(DAEMONS, file), ...args], {
+  encoding: 'utf8', timeout: 8000, windowsHide: true,
+  ...opts,
+  env: { ...process.env, LIFECYCLE_KILL_STOP_WRITER: '', AIGENT_ROOT: SANDBOX, ...(opts.env || {}) },
+});
+
+rmSync(TMP, { recursive: true, force: true });
+mkdirSync(path.join(MEM, 'capsules'), { recursive: true });
+mkdirSync(path.join(MEM, 'runtime', 'stop-writer'), { recursive: true });
+writeFileSync(path.join(MEM, 'BODY_STATE.json'), JSON.stringify({ state: {} }));
+
+// ── syntax ────────────────────────────────────────────────────────────────────
+for (const f of ['lifecycle-common.mjs', 'stop-capsule-writer.mjs', 'capsule-content-gate.mjs']) {
+  const r = spawnSync(process.execPath, ['--check', path.join(DAEMONS, f)], { encoding: 'utf8' });
+  check(`syntax ${f}`, r.status === 0, r.stderr?.trim().split('\n')[0] ?? '');
+}
+
+// ── speaker-tag: [OPERATOR] + [RELAY:agent] bullets, dedup ──────────────────
+const readPointer = () => JSON.parse(readFileSync(path.join(MEM, 'BODY_STATE.json'), 'utf8')).state.last_capsule;
+
+const transcript = path.join(SANDBOX, 'zl2.jsonl');
+writeFileSync(transcript, [
+  JSON.stringify({ type: 'user', message: { content: 'Do the thing tomorrow at nine' } }),
+  JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: '[room from agent-a] relay: stand back up' }] } }),
+  JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Standing up now.' }] } }),
+].join('\n') + '\n');
+{
+  const r = run('stop-capsule-writer.mjs', ['--worker', JSON.stringify({ __root: SANDBOX, session_id: 'zl2', transcript_path: transcript })]);
+  check('speaker-tag: worker flushed', (r.stdout || '').includes('SWE_OUTCOME:flushed'), JSON.stringify(r.stdout));
+  const ptr = readPointer();
+  const cap = readFileSync(path.join(SANDBOX, ptr.path), 'utf8');
+  check('speaker-tag: [OPERATOR] bullet in Done', /- \d{2}:\d{2} \[OPERATOR\] Do the thing tomorrow at nine/.test(cap));
+  check('speaker-tag: [RELAY:agent-a] bullet, prefix normalized on bullet lines', /- \d{2}:\d{2} \[RELAY:agent-a\] relay: stand back up/.test(cap) && !/^- .*\[room from/m.test(cap));
+  const r2 = run('stop-capsule-writer.mjs', ['--worker', JSON.stringify({ __root: SANDBOX, session_id: 'zl2', transcript_path: transcript })]);
+  check('speaker-tag: rerun dedups (no-delta)', (r2.stdout || '').includes('SWE_OUTCOME:noop:no-delta'));
+  const capAfter = readFileSync(path.join(SANDBOX, ptr.path), 'utf8');
+  check('speaker-tag: no duplicate bullets after rerun', (capAfter.match(/\[OPERATOR\] Do the thing/g) || []).length === 1);
+}
+
+// ── real relay/peer/injection formats must not mis-tag as [OPERATOR] ────────
+{
+  const tF1 = path.join(SANDBOX, 'zlf1.jsonl');
+  writeFileSync(tF1, [
+    JSON.stringify({ type: 'user', message: { content: 'Genuine operator directive: ship it' } }),
+    JSON.stringify({ type: 'user', message: { content: '[room from agent-a @ Thu 7/2 23:14 PT] STAND BACK UP — build now' } }),
+    JSON.stringify({ type: 'user', message: { content: '[inbox: 2 unread · latest agent-a: "USAGE DOCTRINE" · pull: room_drain]' } }),
+    JSON.stringify({ type: 'user', message: { content: 'Another Claude session sent a message:\n<teammate-message teammate_id="zl-reviewer" color="yellow">\nfindings\n</teammate-message>' } }),
+    JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'ack' }] } }),
+  ].join('\n') + '\n');
+  run('stop-capsule-writer.mjs', ['--worker', JSON.stringify({ __root: SANDBOX, session_id: 'zlf1', transcript_path: tF1 })]);
+  const cap = readFileSync(path.join(SANDBOX, readPointer().path), 'utf8');
+  check('genuine human utterance tagged [OPERATOR]', /\[OPERATOR\] Genuine operator directive: ship it/.test(cap));
+  check('"[room from agent-a @ ts]" relay tagged [RELAY:agent-a] NOT [OPERATOR]', /\[RELAY:agent-a\] STAND BACK UP/.test(cap) && !/\[OPERATOR\][^\n]*STAND BACK UP/.test(cap));
+  check('"[inbox: ...]" marker tagged [RELAY:inbox] NOT [OPERATOR]', /\[RELAY:inbox\]/.test(cap) && !/\[OPERATOR\][^\n]*inbox/.test(cap));
+  check('teammate-message peer tagged [PEER:zl-reviewer] NOT [OPERATOR]', /\[PEER:zl-reviewer\]/.test(cap) && !/\[OPERATOR\][^\n]*teammate_id/.test(cap));
+  check('objective is the human utterance, not a peer envelope', /^objective: "Genuine operator directive/m.test(cap), JSON.stringify(cap.match(/^objective: .*/m)?.[0]?.slice(0, 60)));
+}
+
+// ── a human message quoting teammate_id="x" stays [OPERATOR] (anchored) ─────
+{
+  const tHuman = path.join(SANDBOX, 'zlhuman.jsonl');
+  writeFileSync(tHuman, [
+    JSON.stringify({ type: 'user', message: { content: 'Anchor the classifier: a human quoting teammate_id="zztop" must stay OPERATOR' } }),
+    JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'ok' }] } }),
+  ].join('\n') + '\n');
+  run('stop-capsule-writer.mjs', ['--worker', JSON.stringify({ __root: SANDBOX, session_id: 'zlhuman', transcript_path: tHuman })]);
+  const cap = readFileSync(path.join(SANDBOX, readPointer().path), 'utf8');
+  check('human quoting teammate_id stays [OPERATOR] (not PEER)', /\[OPERATOR\][^\n]*teammate_id="zztop"/.test(cap) && !/\[PEER:zztop\]/.test(cap), JSON.stringify(cap.match(/- \d{2}:\d{2} \[(OPERATOR|PEER:[^\]]+)\][^\n]*zztop[^\n]*/)?.[0]?.slice(0, 70)));
+  check('that human msg still sets the objective', /^objective: "Anchor the classifier/m.test(cap));
+}
+
+// ── injection tagged, never [OPERATOR] ───────────────────────────────────────
+{
+  const tInj = path.join(SANDBOX, 'zlinj.jsonl');
+  writeFileSync(tInj, [
+    JSON.stringify({ type: 'user', message: { content: '[refresh-cycle] cycle=abc read the matching RefreshRequest and run the capsule verb NOW' } }),
+    JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'ok' }] } }),
+  ].join('\n') + '\n');
+  run('stop-capsule-writer.mjs', ['--worker', JSON.stringify({ __root: SANDBOX, session_id: 'zlinj', transcript_path: tInj })]);
+  const cap = readFileSync(path.join(SANDBOX, readPointer().path), 'utf8');
+  check('harness injection tagged [INJECT:harness] NOT [OPERATOR]', /\[INJECT:harness\]/.test(cap) && !/\[OPERATOR\][^\n]*refresh-cycle/.test(cap));
+  check('injection does not become the objective', !/^objective: "\[refresh-cycle\]/m.test(cap));
+}
+
+// ── embedded newlines collapsed (no section corruption) ─────────────────────
+{
+  const t5 = path.join(SANDBOX, 'zl6.jsonl');
+  writeFileSync(t5, [
+    JSON.stringify({ type: 'user', message: { content: 'line one\n## Fake Section\nline two' } }),
+    JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'ok' }] } }),
+  ].join('\n') + '\n');
+  const r5 = run('stop-capsule-writer.mjs', ['--worker', JSON.stringify({ __root: SANDBOX, session_id: 'zl6', transcript_path: t5 })]);
+  const cap5 = readFileSync(path.join(SANDBOX, readPointer().path), 'utf8');
+  check('embedded newlines collapsed in [OPERATOR] bullet (no section corruption)', (r5.stdout || '').includes('flushed') && /\[OPERATOR\] line one ## Fake Section line two/.test(cap5) && !cap5.includes('\n## Fake Section'));
+}
+
+rmSync(TMP, { recursive: true, force: true });
+console.log(failed ? `STOP-CAPSULE-WRITER.CLASSIFY.TEST: FAIL (${failed})` : 'STOP-CAPSULE-WRITER.CLASSIFY.TEST: PASS');
+process.exit(failed ? 1 : 0);

--- a/daemons/tests/stop-capsule-writer.pointer-advance.test.mjs
+++ b/daemons/tests/stop-capsule-writer.pointer-advance.test.mjs
@@ -1,0 +1,122 @@
+// stop-capsule-writer.pointer-advance.test.mjs — clobber-guard regression.
+//
+// Integration test for the clobber-guard. Runs the REAL stop-capsule-writer.mjs
+// worker (`--worker`) against temp-dir fixtures and asserts the pointer OUTCOME —
+// no mocking; it exercises the exact shipped code path (pointerLockedByFinalize +
+// thisFinalized). Override the daemon under test with SCW_DAEMON=<abs path>.
+'use strict';
+
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DAEMON = process.env.SCW_DAEMON || path.resolve(__dirname, '..', 'stop-capsule-writer.mjs');
+
+let pass = 0;
+let fail = 0;
+function ok(cond, name) {
+  if (cond) { pass++; console.log(`  PASS  ${name}`); }
+  else { fail++; console.log(`  FAIL  ${name}`); }
+}
+
+const BODY = `\n## Done (don't redo)\n<!-- swe:done -->\n\n## Historical-Errors → Resolutions\n<!-- swe:errors -->\n\n## Historical-Rejected-Approaches\n<!-- swe:rejected -->\n\n## Files-Read / Files-Modified\n<!-- swe:files -->\n\n## Operating-Facts\n<!-- swe:facts -->\n\n## Pending-Gates\n<!-- swe:gates -->\n\n## Claimed-Rows\n<!-- swe:rows -->\n`;
+
+// A deliberate (hand/close/context-capsule) capsule: has waiting_on, NO autosave tag.
+const cap = (name, waitingOn) =>
+  `---\nid: ${name}\nstatus: active\nobjective: "x"\nwaiting_on: ${waitingOn}\nresume_trigger: clear\ndefinition_hash: aaa\nnext_valid_action: "x"\n---\n${BODY}`;
+
+// A DISPOSABLE auto-writer capsule (skeleton()): carries the `autosave` tag and NO
+// waiting_on line — exactly what the guard must recognize as clobberable.
+const autoCap = (name, kind) =>
+  `---\ncapsule_id: ${name}\nobjective: "x"\nstatus: active\ntrigger: ${kind}\ntags: [capsule, autosave, ${kind}]\ncreated_at: 2026-07-07T00:00:00Z\n---\n${BODY}`;
+
+// One scenario = a fresh temp seat root. The pointer always lives at
+// memory/BODY_STATE.json's state.last_capsule (single-operator convention).
+function runScenario({ sid, capsuleBWaitingOn, capsuleAWaitingOn = '"prior finalize — real"', capsuleAAuto = null, skeletonB = false }) {
+  const base = mkdtempSync(path.join(os.tmpdir(), 'scw-'));
+  const root = path.join(base, 'test-seat');
+  const capsules = path.join(root, 'memory', 'capsules');
+  const runtime = path.join(root, 'memory', 'runtime', 'stop-writer');
+  mkdirSync(capsules, { recursive: true });
+  mkdirSync(runtime, { recursive: true });
+
+  // capsule-A: the capsule the pointer currently aims at. Either a deliberate
+  // capsule (cap: has waiting_on, no autosave tag) or a disposable auto-writer
+  // capsule (autoCap: autosave tag, no waiting_on) when capsuleAAuto is a kind.
+  writeFileSync(
+    path.join(capsules, 'capsule-A.md'),
+    capsuleAAuto ? autoCap('capsule-A', capsuleAAuto) : cap('capsule-A', capsuleAWaitingOn),
+  );
+  // capsule-B: THIS session's capsule. Pre-written (ADVANCE/HELD), or left ABSENT
+  // so the daemon writes its own real auto-skeleton (trigger:stop-delta) when
+  // skeletonB — the true clobber source.
+  const capsuleB = path.join(capsules, 'capsule-B.md');
+  if (!skeletonB) writeFileSync(capsuleB, cap('capsule-B', capsuleBWaitingOn));
+
+  const bodyStatePath = path.join(root, 'memory', 'BODY_STATE.json');
+  writeFileSync(bodyStatePath, JSON.stringify({
+    state: { last_capsule: { id: 'capsule-A', path: 'memory/capsules/capsule-A.md', status: 'active' } },
+  }));
+  writeFileSync(path.join(runtime, `${sid}.json`), JSON.stringify({ offset: 0, capsule_path: capsuleB, last_delta_sha: null }));
+
+  const transcript = path.join(base, 'transcript.jsonl');
+  writeFileSync(transcript, JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'integration delta ' + sid }] } }) + '\n');
+
+  const payload = JSON.stringify({ __root: root, session_id: sid, transcript_path: transcript });
+  const out = execFileSync(process.execPath, [DAEMON, '--worker', payload], { encoding: 'utf8' });
+
+  const pointerAfter = JSON.parse(readFileSync(bodyStatePath, 'utf8')).state.last_capsule;
+  rmSync(base, { recursive: true, force: true });
+  return { pointerAfter, out };
+}
+
+console.log(`── stop-capsule-writer pointer-advance — daemon: ${DAEMON} ──`);
+
+// ADVANCE: this session's capsule is itself finalized → pointer moves to it.
+{
+  const { pointerAfter, out } = runScenario({ sid: 'adv-11111111', capsuleBWaitingOn: '"my own finalize — real"' });
+  ok(out.includes('SWE_OUTCOME:flushed'), 'ADVANCE: worker flushed (reached the pointer logic)');
+  ok(pointerAfter.path === 'memory/capsules/capsule-B.md',
+    'ADVANCE: a finalized new capsule advances the pointer off the prior finalized one (finalize-advance, not clobber)');
+}
+
+// HELD: this session's capsule is a skeleton (waiting_on:null) → pointer stays on A.
+{
+  const { pointerAfter, out } = runScenario({ sid: 'held-22222222', capsuleBWaitingOn: 'null' });
+  ok(out.includes('SWE_OUTCOME:flushed'), 'HELD: worker flushed (reached the pointer logic)');
+  ok(pointerAfter.path === 'memory/capsules/capsule-A.md',
+    'HELD: an unfinalized skeleton capsule does NOT clobber the finalized pointer (clobber-guard holds)');
+}
+
+// DELIB-NULL (null-gap): pointer aims at a DELIBERATE ready capsule-A with
+// waiting_on:null (a /context-capsule resume capsule — nothing blocks its
+// resume, NO autosave tag); THIS session writes a real auto-skeleton
+// (trigger:stop-delta). The deliberate pointer MUST be HELD.
+{
+  const { pointerAfter, out } = runScenario({ sid: 'delib-33333333', capsuleAWaitingOn: 'null', skeletonB: true });
+  ok(out.includes('SWE_OUTCOME:flushed'), 'DELIB-NULL: worker flushed (reached the pointer logic)');
+  ok(pointerAfter.path === 'memory/capsules/capsule-A.md',
+    'DELIB-NULL: a deliberate ready capsule (waiting_on:null, no autosave tag) is NOT clobbered (null-gap closed)');
+}
+
+// PRECOMPACT-ADVANCE (the reviewer's catch): pointer aims at a DISPOSABLE
+// safety-net capsule-A (tags:[capsule,autosave,precompact], NO waiting_on); THIS
+// session writes only its own auto-skeleton (skeletonB — NOT finalized, so
+// thisFinalized can't mask the guard). The disposable safety-net MUST NOT freeze
+// the pointer — it advances to capsule-B. A trigger==='stop-delta' allowlist
+// FAILS this (protects the wrong writer and reintroduces the stuck-pointer bug);
+// the `autosave`-tag discriminator PASSES it. (capsule-B finalized would advance
+// under ALL predicates via thisFinalized and would NOT exercise the guard — must
+// be a skeleton.)
+{
+  const { pointerAfter, out } = runScenario({ sid: 'precmp-44444444', capsuleAAuto: 'precompact', capsuleBWaitingOn: 'null' });
+  ok(out.includes('SWE_OUTCOME:flushed'), 'PRECOMPACT-ADVANCE: worker flushed (reached the pointer logic)');
+  ok(pointerAfter.path === 'memory/capsules/capsule-B.md',
+    'PRECOMPACT-ADVANCE: a disposable autosave safety-net (waiting_on:null) does NOT freeze the pointer — this session\'s capsule advances past it (no stuck-pointer regression)');
+}
+
+console.log(`\n${pass} passed, ${fail} failed.`);
+process.exit(fail === 0 ? 0 : 1);

--- a/docs/capsule-v2-doctrine.md
+++ b/docs/capsule-v2-doctrine.md
@@ -7,6 +7,9 @@ created: 2026-05-08
 
 # Capsule v2 Doctrine
 
+> [!info] Superseded by the two-verb lifecycle
+> `/open` and `/close` are deprecated — see [[../docs/two-verb-lifecycle.md|Two-Verb Lifecycle]]. `/resume` absorbs `/open`, `/context-capsule` absorbs `/close`. The v2 schema below (waiting_on, resume_trigger, next_valid_action, success_criteria) is unchanged and still the capsule's field contract; the two-verb doc adds the trusted-writer gate (`daemons/capsule-verb.mjs`), `definition_hash`, and the pointer schema on top of it.
+
 > [!abstract] Key insight
 > Capsules are resumable execution state, not summaries. (12-Factor Agents: unify execution state and business state.)
 

--- a/docs/two-verb-lifecycle.md
+++ b/docs/two-verb-lifecycle.md
@@ -1,0 +1,117 @@
+---
+title: Two-Verb Lifecycle
+tags: [doctrine, capsule, lifecycle, resume, session-management]
+aliases: [two-verb, capsule verb, resume verb]
+created: 2026-07-17
+---
+
+# Two-Verb Lifecycle
+
+> [!abstract] Core idea
+> Session continuity collapses to exactly two verbs — `/context-capsule` (write state, then stop) and `/resume` (load state, re-ground, act). `/open` and `/close` are retired: resume absorbs open, the capsule verb absorbs close. Both verbs also fire automatically at the right SessionStart/Stop hook points, so the operator rarely needs to invoke them by name.
+
+This doc is the design reference for `skills/context-capsule/SKILL.md`, `skills/resume/SKILL.md`, and the daemons that implement them. Edit those files in lockstep with this one — this doc is the authored source; the skill files and daemon prompts are its runtime artifacts.
+
+## Why two verbs, not four
+
+The prior generation had four session-lifecycle skills: `/open` (load context), `/close` (commit memory), `/context-capsule` (checkpoint state), `/pause` (mid-session checkpoint). In practice `/open` and `/close` were always paired with a capsule write/read anyway — the capsule *was* the state that made open/close meaningful. Collapsing to two verbs removes the duplication:
+
+- **`/context-capsule`** is the only way state gets written. It absorbs `/close` — there is no separate close ceremony, and no separate `/pause` either (a mid-session checkpoint is just an early capsule).
+- **`/resume`** is the only way state gets loaded and acted on. It absorbs `/open` — there is no separate open ceremony.
+
+Both verbs also run automatically, at the two points in a session's lifecycle where they matter most: `/resume`'s procedure fires on `SessionStart(clear)` via `daemons/resume-verb.mjs`, and a rolling, best-effort version of `/context-capsule`'s write runs on every `Stop` event via `daemons/stop-capsule-writer.mjs`. The explicit skill invocations exist for the cases automation doesn't cover: a deliberate mid-session checkpoint, a named-capsule resume, or a handoff.
+
+## The capsule schema
+
+Every capsule is a markdown file with YAML frontmatter. Four fields are REQUIRED and validated by the trusted writer (`daemons/capsule-verb.mjs`'s `validateCapsuleText()`):
+
+| Field | Meaning |
+|---|---|
+| `id` | Stable identifier, non-empty |
+| `objective` | What this thread of work is about, non-empty |
+| `waiting_on` | The resume contract — what a fresh session needs to act, non-empty, never bare YAML `null` |
+| `next_valid_action` | The concrete next step, non-empty |
+
+Plus `parent_capsule_id`, `status` (`active → resumed → resolved`, also `paused`/`abandoned`), `trigger`, `expires`, `tags`, `created_at`, `resolved_at`, and `definition_hash` — the first 12 hex characters of `sha256(objective + next_valid_action)`, a cheap drift detector: `/resume` recomputes it against the live frontmatter and refuses to trust a capsule whose hash no longer matches its own content.
+
+The body carries seven `[REFERENCE ONLY]` sections behind HTML anchor comments (`<!-- swe:done -->` etc.) that `stop-capsule-writer.mjs` merges bullets into: `Done (don't redo)`, `Historical-Errors → Resolutions`, `Historical-Rejected-Approaches`, `Files-Read / Files-Modified`, `Operating-Facts`, `Pending-Gates`, `Claimed-Rows`. "Historical-" prefixes and latest-wins framing are deliberate — body content is a *reference snapshot*, never an active instruction queue. Treating it as one is exactly the trap `/resume`'s fences exist to prevent.
+
+## The content gate
+
+`daemons/capsule-content-gate.mjs` is a zero-dependency vocabulary shared by both enforcement points (`capsule-verb.mjs`'s validator and `stop-capsule-writer.mjs`'s classifier). It rejects two failure classes that non-empty checks alone miss:
+
+- **Injection echo** — an `objective` that is actually a harness/supervisor instruction verbatim (`[supervisor-resume]`, `[refresh-cycle]`, `[auto-pull]`, an inbox marker, a loop-tick banner...). Non-null, but not the operator's real objective.
+- **Ceremony action** — a `next_valid_action` that opens with resume-boot ceremony text ("re-read the active turn state...") instead of real content. Non-null, but tells a fresh session nothing it can act on.
+
+Both patterns are START-ANCHORED: a capsule that legitimately *references* the ceremony mid-action ("On resume: comply with the supervisor-resume instruction, then...") passes — only text that *is* the injection/ceremony fails.
+
+## The trusted writer
+
+`daemons/capsule-verb.mjs`'s `runCapsuleVerb()` is the one path that stamps a capsule pointer. The model authors capsule prose; this module is the authority that deterministic reconciliation ran:
+
+1. Validates the capsule text (content gate + required fields).
+2. Collects evidence — `daemons/reconcile-collector.mjs` gathers read-only git state (index tree + working tree digests, branch, HEAD) always, and pluggable board evidence (see below) if an adapter is configured.
+3. Computes `reconcile_digest` — a canonical SHA-256 over the evidence object, so two runs against unchanged state produce an identical digest.
+4. Shells out to `daemons/curated-close-pointer.mjs`, which alone writes the pointer at `vault/memory/BODY_STATE.json`'s `state.last_capsule`.
+5. Reads the pointer back and verifies every stamped field matches what was computed — a mismatch refuses loudly rather than trusting the write blindly.
+
+A refusal (`CapsuleVerbRefusal`) never stamps anything and always names the specific problem, so a caller (human or automated) knows exactly what to fix.
+
+## Pluggable evidence: the board adapter
+
+aigent-OS ships no task-board integration by default — `evidence.board` degrades honestly to `null`, a valid, documented state. To wire a real task-board (Linear, a Postgres-backed board, anything), point `AIGENT_BOARD_ADAPTER` at a module exporting:
+
+```js
+export async function collectBoardEvidence({ seatId, boardRowIds }) {
+  // boardRowIds is null for "everything this identity created or claimed",
+  // else an explicit array of row ids. Return { query, rows } or null.
+}
+```
+
+`reconcile-collector.mjs` computes the canonical digest itself — adapters never compute or trust their own digest, which keeps the evidence class reproducible regardless of the adapter's own bugs.
+
+## Pluggable coordination: multi-agent guard
+
+If a fork wires multiple agents/sessions that need to pause for a conducted, multi-party lifecycle event (a coordinated clear across several concurrent sessions, for example), point `AIGENT_COORDINATION_STATE` at a JSON file carrying a `phase` field. While `phase` is non-terminal (anything other than `done`/`cancelled`/`closed`/`complete`/`aborted`), both `sessionstart-reinject.mjs` and `ctx-refresh-sensor.mjs` defer to the external conductor instead of running their own lifecycle logic. Unset by default — a single-operator install never touches this seam.
+
+## The supervisor cycle (context-pressure self-refresh)
+
+`daemons/ctx-refresh-sensor.mjs` is a `PreToolUse` hook implementing a single-session self-refresh reflex: at 60% context usage it nudges a capsule-then-clear/compact; at 75% it escalates to mandatory `/clear`; it re-arms below 50%, and re-nudges every +5 points while armed to avoid going silent between 60% and 90%.
+
+This reflex depends on an **optional** integration: something must write `~/.claude/ctx-refresh/<session-id>.json` with a `used_percentage` field (a statusline script is the natural place). Nothing in this port writes that file — if it's absent, the sensor is silently inert (checked first, before any other logic runs). Wiring a percentage-tracking statusline is a documented but unbundled integration point.
+
+Behind an opt-in flag (`CAPSULE_VERB_AUTOFIRE=1`), the sensor can also drive the trusted writer automatically: it waits for the transcript to fall genuinely still (two identical capture-cursor reads separated by an age floor, guarding against reading mid-flush), then calls `runCapsuleVerb()` in dry-run mode by default. A real, request-gated cycle (`daemons/refresh-request.mjs` + `daemons/refresh-cycle.mjs`) exists for a controller that wants to mint a nonce-bound refresh challenge and verify the receipt — none of that fires unless something writes a `RefreshRequest` file, which, like the board adapter, ships as a seam rather than a default behavior.
+
+## Operator sovereignty (never violate)
+
+- **The capsule is best-effort autosave, never a gate.** An operator `/clear` passes through whether or not a capsule landed. Nothing in this system should ever tell the operator to wait on capsule machinery.
+- **A session rotation satisfies any pending refresh cycle** — never re-arm or service a stale cycle against a fresh session.
+- **`/context-capsule` goes quiet after writing.** If an automated refresh cycle is active, the seal fires on transcript stillness; every extra tool call after the write resets that clock.
+
+## Known issue (documented, not fixed here)
+
+`stop-capsule-writer.mjs`'s `skeleton()` template seeds a fresh autosave capsule with `waiting_on: null`. The content gate correctly treats a bare YAML `null` as empty (not a resumable receipt), which means a fresh autosave capsule can never pass `validateCapsuleText()` as-is — an automated refresh cycle that tries to stamp a freshly-created autosave capsule mid-session will be refused until the operator (or a later turn's delta merge) fills in a real `waiting_on`. This is a real architectural gap carried over from the source system, not a design choice, and it ships as-is in this port. The fix — most likely deferring the trusted-writer stamp until a capsule has left skeleton state, or seeding a non-null placeholder that the content gate treats distinctly from a deliberate empty value — is planned as a follow-up commit on this branch, not bundled into the port itself.
+
+## File map
+
+| File | Role |
+|---|---|
+| `daemons/lifecycle-common.mjs` | Shared identity/vault resolution, the `flipCapsuleToResumed` CRLF-safe frontmatter flip |
+| `daemons/capsule-content-gate.mjs` | Injection-echo / ceremony-action vocabulary |
+| `daemons/capsule-verb.mjs` | Trusted-writer orchestration for the capsule verb |
+| `daemons/curated-close-pointer.mjs` | The one write path for the pointer stamp |
+| `daemons/resume-verb.mjs` | Resume verb container — SessionStart(clear) hook |
+| `daemons/sessionstart-reinject.mjs` | Warm-start pointer-table reinject — SessionStart(all sources) hook |
+| `daemons/stop-capsule-writer.mjs` | Every-turn rolling capsule delta writer — Stop hook |
+| `daemons/reconcile-collector.mjs` | Deterministic evidence collection (git always, board pluggable) |
+| `daemons/effect-receipts.mjs` | Append-only external-effect receipt ledger (business-OS seam) |
+| `daemons/refresh-cycle.mjs` | The transactional cycle-record data shape |
+| `daemons/refresh-request.mjs` | The controller→session challenge-crossing request |
+| `daemons/refresh-cursor.mjs` | The capture-cursor primitive (byte-exact transcript position) |
+| `daemons/ctx-refresh-sensor.mjs` | Context-pressure self-refresh reflex — PreToolUse hook |
+| `skills/context-capsule/SKILL.md` | The capsule verb, explicit invocation |
+| `skills/resume/SKILL.md` | The resume verb, explicit invocation |
+
+## A note on the merged SessionStart hook
+
+The source system this was ported from ran two separate SessionStart scripts because it coordinated several concurrent agent identities, each with its own hook-matcher wiring quirks. aigent-OS is single-operator, so `sessionstart-reinject.mjs` handles every source (`startup`, `resume`, `clear`, `compact`) in one file — there's no per-agent matcher split to preserve. If a fork later adds genuine multi-identity support, re-splitting by source is a reasonable place to start, but nothing in the current architecture requires it.

--- a/skills/close/SKILL.md
+++ b/skills/close/SKILL.md
@@ -2,9 +2,12 @@
 name: close
 description: Commit the session to durable vault memory and prepare a clean resume point
 trigger: /close
+status: DEPRECATED by the two-verb lifecycle — see skills/context-capsule/SKILL.md. /context-capsule absorbs /close; there is no separate close ceremony. Kept for manual invocation during the transition; not deleted.
 ---
 
 # Session Close
+
+> **Deprecated.** This skill is superseded by [[skills/context-capsule/SKILL.md|/context-capsule]] (docs/two-verb-lifecycle.md). New installs should reach for `/context-capsule`; this file stays for anyone still invoking `/close` by habit during the transition.
 
 Run the aigent-OS end-of-session memory commit inline. The close must be idempotent: rerunning it after a partial failure must not duplicate ledger entries, capsules, or session summaries.
 

--- a/skills/context-capsule/SKILL.md
+++ b/skills/context-capsule/SKILL.md
@@ -1,88 +1,54 @@
-# /context-capsule — Capsule v2: Resumable Execution State
-
-Structured state preservation when context pressure rises OR a task completes. Output is a resume-ready capsule with full execution state, not a vibes summary.
-
-**v2 upgrade:** Capsules are now resumable execution state (12-Factor Agents pattern). Every capsule includes `waiting_on`, `resume_trigger`, `next_valid_action`, and `success_criteria`.
-
-## Trigger
-
-`/context-capsule` or automatic when Caddy detects context pressure / task completion.
-
-## Capsule v2 Schema
-
-Write capsule to `$AIGENT_VAULT/memory/capsules/{id}.md` with this frontmatter:
-
-```yaml
 ---
-id: {YYYY-MM-DD}-{context}-{sequence}
-parent_capsule_id: {previous capsule id or null}
-status: active          # active | paused | resumed | resolved | abandoned
-waiting_on: null        # will | agent | tool | external | null
-resume_trigger: open    # open | file_change | manual | webhook
-objective: "{one-line objective}"
-next_valid_action: "{what to do next when resumed}"
-success_criteria:
-  - "{criterion 1}"
-  - "{criterion 2}"
-open_questions:
-  - "{unresolved question}"
-files_touched:
-  - "{path/to/file}"
-skills_used:
-  - "{skill-name}"
-agents_used:
-  - "{agent-name}"
-last_verified_state: "{what was confirmed working}"
-created_at: {ISO 8601}
-resolved_at: null
-tags: [capsule, {context tags}]
+name: context-capsule
+description: The capsule verb, invoked explicitly — reconcile from the live memory, write a resume-ready capsule, stamp nothing yourself, stop. Mid-session checkpoint or completion capsule; the threshold-triggered path runs the SAME contract automatically via the injected RefreshRequest.
+trigger: /context-capsule
+status: Two-verb lifecycle — supersedes the v1 capsule skill and absorbs /close (there is no separate close ceremony).
+related:
+  - "docs/two-verb-lifecycle.md (design doc — the gate, the supervisor cycle, sovereignty rules)"
+  - "daemons/capsule-verb.mjs (trusted writer — REQUIRED_CAPSULE_FIELDS, refusal rules)"
+  - "daemons/capsule-content-gate.mjs (content gate; shared with the stop-writer)"
+  - "skills/resume/SKILL.md (the mirror verb)"
 ---
-```
 
-## Body Content
+# /context-capsule — the capsule verb
 
-After frontmatter, write:
+**The entire job: reconcile → write the capsule → STOP.** The capsule absorbs `/close`: there is no separate close ceremony. Digests, pointer stamping, and `cycle_token` belong to the trusted writer (`daemons/capsule-verb.mjs` + `daemons/curated-close-pointer.mjs`) — the operator authors content and never stamps machinery fields.
 
-```markdown
-# Capsule — {objective}
+## When this skill fires vs the automatic verb
 
-## What shipped
-{bullet list of completed work}
+The threshold-triggered refresh does NOT need this skill — if a fork wires a controller, it injects a RefreshRequest carrying cycle + challenge, and the autofire worker consumes your capsule when the transcript falls still. Invoke `/context-capsule` for the explicit cases: a mid-session checkpoint before risky work, a completion capsule when a thread ships, or a handoff.
 
-## Mental model
-{key decisions, constraints, architecture choices made}
+## Operator sovereignty (never violate)
 
-## Open threads
-{unresolved items, pending decisions, blocked work}
+- The capsule is **best-effort autosave, never a gate**. An operator `/clear` passes through whether or not a capsule landed; never tell the operator to wait on capsule machinery.
+- A session rotation satisfies the cycle — never re-arm or service a refresh cycle against a fresh session.
+- If a RefreshRequest is active: author the capsule, then **go quiet** — the seal fires on transcript stillness. Every extra tool call resets the clock.
 
-## Resume prompt
-{paste-ready prompt that picks up exactly where we left off — include specific file paths, line numbers, what to verify first}
-```
+## Fences (never cross)
 
-## BODY_STATE Update
+- **Do NOT read the refresh machinery** — sensor, worker, supervisor, CAS/marker code. Sealing is automatic and none of the operator's business; the urge to "understand how it's invoked" IS the bug.
+- **Do NOT stamp digests, pointer, or cycle_token** — trusted-writer territory. A self-stamped digest is refused anyway.
+- **Do NOT write a narration capsule.** Reconcile-from-memory is the value: a capsule that restates the transcript instead of the live memory/git state is the trap this verb exists to prevent.
 
-After writing the capsule, update `memory/BODY_STATE.json` field `state.last_capsule`:
+## Steps (tight + terminal)
 
-```json
-{
-  "id": "{capsule id}",
-  "path": "memory/capsules/{capsule id}.md",
-  "objective": "{objective}",
-  "status": "{status}",
-  "created_at": "{ISO 8601}",
-  "resolved_at": null,
-  "parent_capsule_id": "{parent or null}"
-}
-```
+1. **RECONCILE from live memory** — re-read the session log, active priorities, and this session's git commits. Record what happened, not what was said. Budget: **2–4 reads, no more**.
+2. **WRITE** `vault/memory/capsules/<YYYY-MM-DD>-<slug>.md`:
+   - Frontmatter — all four REQUIRED fields non-empty, no inline `#` comments on them, `waiting_on` quoted (never bare `null`): `id`, `objective`, `waiting_on`, `next_valid_action`; plus `parent_capsule_id`, `status: active`, `trigger`, `expires`, `tags`, `created_at`, and `definition_hash` = first 12 hex of sha256(objective + next_valid_action).
+   - Body — `[REFERENCE ONLY]` banner, then: `Done (don't redo)` · `Historical-Errors → Resolutions` · `Historical-Rejected-Approaches` · `Files-Read / Files-Modified` · `Operating-Facts` · `Pending-Gates` · `Claimed-Rows`. Historical- prefixes and latest-wins stay (anti-zombie).
+   - `waiting_on` is the resume contract: write it so a fresh session can act from it alone — concrete items, owners, gates.
+3. **STOP.** One line acknowledging the capsule path, then silence. No verification reads, no pointer checks — the writer refuses loudly if content fails its gate, and a refusal names the exact field to fix.
 
-## Backward Compatibility
+## Lifecycle
 
-Existing capsules without v2 fields (waiting_on, resume_trigger, etc.) still work. /open reads whatever fields exist. New capsules MUST include all v2 fields.
+`active → resumed → resolved`. The resume verb flips `active → resumed` when it acts from the capsule; a capsule superseded by a newer one, or `resumed` >30 days, resolves. `/open`/`/close` are retired — resume absorbs open, this verb absorbs close.
 
-## Related
+## When NOT to capsule
 
-- [[concepts/Capsule v2 Doctrine]] — why capsules evolved
-- [[concepts/Somatic Layer]] — the broader body-state system
-- [[concepts/Session Protocol]] — how /open offers capsule resume
-- `/pause` — create a paused capsule mid-session
-- `/resume` — resume from last capsule
+- Mid-thought (finish the thought).
+- Trivial sessions a fresh session could reconstruct from memory alone.
+- Inside a dispatched sub-agent (the dispatch brief IS the capsule).
+
+## Known issue (documented, not fixed here)
+
+Fresh autosave capsules seed `waiting_on: null` (the stop-capsule-writer's `skeleton()` template). The content gate then refuses to treat them as a resumable receipt for the trusted-writer path, which can abort an automated refresh cycle mid-flight if a fork wires one. This is a real gap in the ported architecture, not a design choice — see docs/two-verb-lifecycle.md's "Known issue" section. The fix is planned as a follow-up commit on this same branch, not bundled into this port.

--- a/skills/open/SKILL.md
+++ b/skills/open/SKILL.md
@@ -2,9 +2,12 @@
 name: open
 description: Boot the session, load context from the vault, and surface what matters
 trigger: /open
+status: DEPRECATED by the two-verb lifecycle — see skills/resume/SKILL.md. /resume absorbs /open; the post-clear boot runs it automatically via daemons/resume-verb.mjs. Kept for manual invocation during the transition; not deleted.
 ---
 
 # Session Open
+
+> **Deprecated.** This skill is superseded by [[skills/resume/SKILL.md|/resume]] (docs/two-verb-lifecycle.md). New installs should reach for `/resume`; this file stays for anyone still invoking `/open` by habit during the transition.
 
 Run this at the start of every normal working session.
 

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -1,49 +1,33 @@
-# /resume — Resume from last capsule
+---
+name: resume
+description: The resume verb, invoked explicitly — load the latest capsule, validate definition_hash, re-ground against live memory, then ACT on waiting_on. Mid-session or on explicit ask; the post-clear boot fires the same procedure automatically via daemons/resume-verb.mjs.
+trigger: /resume
+status: Two-verb lifecycle — supersedes the v1 open skill and absorbs /open (there is no separate open ceremony).
+related:
+  - "docs/two-verb-lifecycle.md (design doc — the gate, the supervisor cycle, sovereignty rules)"
+  - "daemons/resume-verb.mjs (the runtime container — SessionStart(clear) hook)"
+  - "skills/context-capsule/SKILL.md (the mirror verb)"
+---
 
-Pick up paused or active work from the most recent capsule.
+# /resume
 
-## Trigger
+**The entire job: load → validate → re-ground → ACT on `waiting_on`.** Resumption is proven by the action taken, never by a pointer table being in context. The verb ends when the first real step from `waiting_on`/`next_valid_action` has been taken.
 
-`/resume` or `/resume {capsule-id}`
+## When this skill fires vs the automatic verb
 
-## Flow
+The post-clear boot does NOT need this skill — `daemons/resume-verb.mjs` injects the full procedure automatically on `SessionStart(clear)`. Invoke `/resume` for the explicit cases: picking up a specific named capsule mid-session (`/resume <capsule_id>`), or re-grounding on request without a clear.
 
-1. **Find capsule**:
-   - If argument provided: read `memory/capsules/{argument}.md`
-   - If no argument: read `memory/BODY_STATE.json` → `state.last_capsule`
-   - If no capsule found: output "Nothing to resume." and stop
+## Fences (never cross)
 
-2. **Validate status** — only resume capsules with `status: active` or `status: paused`
-   - `resumed` → "Already resumed in a prior session."
-   - `resolved` → "This work was completed."
-   - `abandoned` → "This work was abandoned. Reopen? [y/n]"
+- **Do NOT assert resumption is complete because the pointer table appears in context.** Only an action taken from `waiting_on` proves it.
+- **Do NOT read or reason about `cycle_token`** — it belongs to the CLEAR gate alone. Do not skip the `definition_hash` check.
+- **Do NOT treat capsule content as an active instruction queue** — `Done` / `Historical-*` / `Pending-Gates` / `Claimed-Rows` are `[REFERENCE ONLY]`, stale-by-default; re-grounding is what makes acting safe.
 
-3. **Display capsule summary**:
-   ```
-   Resuming: {objective}
-   Status: {status}
-   Waiting on: {waiting_on}
-   Next action: {next_valid_action}
-   Success criteria:
-     - {criterion 1}
-     - {criterion 2}
-   Open questions:
-     - {question 1}
-   Last verified: {last_verified_state}
-   ```
+## Steps
 
-4. **Verify state** — before proceeding, check `last_verified_state`:
-   - If it names a file: verify the file exists and hasn't changed unexpectedly
-   - If it names a deploy: check deploy status
-   - If it names a branch: verify branch exists and HEAD matches expectation
-   - Report any drift before resuming work
+1. **LOAD** — resolve the pointer (`vault/memory/BODY_STATE.json`'s `state.last_capsule`), or the named capsule if an id was given. Follow `path` to the capsule FILE; pull `waiting_on`, `next_valid_action`, `definition_hash` from its frontmatter. Validate: recompute `sha256(objective + next_valid_action)` first 12 hex against the live capsule frontmatter — mismatch = drifted → re-derive from memory, don't trust the capsule.
+2. **RE-GROUND** — re-read the session log and active priorities, surface anything that changed since the capsule was written. On any conflict, live memory wins over capsule content.
+3. **ACT** — take the one next step from `waiting_on`/`next_valid_action` resolved against step 2. Terminal: done when the action is TAKEN, not summarized.
+4. **ACK (post-clear only, if a supervising process demands one)** — reply in exactly the format it demands, ONLY after step 3's action. The exact format lives in that instruction, never guessed.
 
-5. **Mark resumed** — Edit capsule frontmatter: `status: resumed`
-
-6. **Execute** — paste `next_valid_action` as the work prompt and proceed
-
-## Related
-
-- `/pause` — create a paused capsule
-- `/context-capsule` — the capsule system
-- [[concepts/Capsule v2 Doctrine]] — design rationale
+No stillness clock — resume is the wake-up, not the seal — but stay terminal: still reading past re-grounding without acting = the exact trap this verb exists to prevent.

--- a/skills/skill-index.json
+++ b/skills/skill-index.json
@@ -9,7 +9,7 @@
     {
       "id": "sk_open",
       "name": "open",
-      "description": "Session open protocol \u2014 load vault context, check comms, orient the session",
+      "description": "DEPRECATED by the two-verb lifecycle \u2014 /resume now absorbs open (the post-clear boot runs it automatically; the router should route open-shaped intent to resume). Kept for manual invocation during the transition.",
       "triggers": [
         "open",
         "start session",
@@ -24,12 +24,12 @@
       "lifecycle": "open",
       "path": "~/.claude/skills/open",
       "pantheon_agent": null,
-      "active": true
+      "active": false
     },
     {
       "id": "sk_close",
       "name": "close",
-      "description": "Session close \u2014 commit memory, write session log, capsule state",
+      "description": "DEPRECATED by the two-verb lifecycle \u2014 /context-capsule now absorbs close (there is no separate close ceremony; the capsule verb reconciles, writes, and stops). Kept for manual invocation during the transition.",
       "triggers": [
         "close",
         "end session",
@@ -44,7 +44,7 @@
       "lifecycle": "close",
       "path": "~/.claude/skills/close",
       "pantheon_agent": null,
-      "active": true
+      "active": false
     },
     {
       "id": "sk_comms",
@@ -243,20 +243,49 @@
     {
       "id": "sk_context_capsule",
       "name": "context-capsule",
-      "description": "Structured state preservation when context pressure rises or task completes",
+      "description": "The capsule verb — reconcile from the live memory, write a resume-ready capsule, stop. Absorbs /close: there is no separate close ceremony. Threshold-triggered refreshes run the same contract automatically.",
       "triggers": [
         "capsule",
         "save state",
         "preserve context",
-        "checkpoint"
+        "checkpoint",
+        "close",
+        "wrap up",
+        "task done",
+        "milestone shipped"
       ],
       "intent_patterns": [
         "context window is getting full",
-        "user wants to save progress for resume"
+        "user wants to save progress for resume",
+        "user wants to end the session",
+        "a task or thread just shipped"
       ],
       "model_preference": "opus",
       "lifecycle": "on_demand",
       "path": "~/.claude/skills/context-capsule",
+      "pantheon_agent": null,
+      "active": true
+    },
+    {
+      "id": "sk_resume",
+      "name": "resume",
+      "description": "The resume verb — load the latest capsule, validate definition_hash, re-ground against live memory, then ACT on waiting_on. Absorbs /open: there is no separate open ceremony. The post-clear boot runs the same contract automatically via daemons/resume-verb.mjs.",
+      "triggers": [
+        "resume",
+        "open",
+        "start session",
+        "good morning",
+        "let's go",
+        "pick up where we left off"
+      ],
+      "intent_patterns": [
+        "user starts a new session",
+        "user wants to pick up where we left off",
+        "a session just cleared and needs to re-ground"
+      ],
+      "model_preference": "opus",
+      "lifecycle": "open",
+      "path": "~/.claude/skills/resume",
       "pantheon_agent": null,
       "active": true
     },


### PR DESCRIPTION
## What this is

The two-verb session lifecycle, ported from our production fleet where it has run all week: a session's working state is continuously captured into a **capsule** (verb 1), and a fresh session **resumes** from it (verb 2) — load → validate → re-ground against live state → act. No open/close ceremony; the lifecycle is the two verbs plus a supervisor refresh cycle that seals a capsule when the transcript falls still.

## What's in the box

- **12 lifecycle daemons** (`daemons/`): the stop-delta capsule writer, the trusted-writer capsule verb + content gate (refuses hollow checkpoints — required fields non-empty, `definition_hash` = first 12 hex of sha256(objective+next_valid_action)), the resume verb (hash re-validation, CRLF-preserving status flip, fresh-seat discrimination), and the refresh-cycle family (sensor, request, cursor, curated-close pointer).
- **76 tests** (`daemons/tests/`), including golden fixtures for the refresh cursor and classify/pointer-advance/flip suites.
- **Skills**: `context-capsule` and `resume` rewritten to the two-verb contract; `open`/`close` deprecated with pointers.
- **Docs**: `docs/two-verb-lifecycle.md` — design, sovereignty rules (the capsule is best-effort autosave, never a gate; an operator `/clear` always passes through), and the supervisor cycle.
- **Pluggable seams**: board/mesh evidence hooks are adapter-driven (`AIGENT_BOARD_ADAPTER`) — aigent-OS ships no task board; the seam is documented.

## Evidence

- Full ported suite: **76/76 pass** (verified independently of the port author).
- Two-pass sanitization scrub over the full diff: zero private identifiers, paths, or history data.

## Known issue — shipped deliberately, fix lands on this branch before merge

`stop-capsule-writer.mjs`'s skeleton seeds a fresh autosave capsule with `waiting_on: null`, which the content gate (correctly) refuses — so a refresh cycle against a brand-new capsule is refused until real state lands. This is a real gap carried from the source system, documented in `docs/two-verb-lifecycle.md`. **Please review with this in mind; the fix is being built on our side and will be pushed to this branch before any merge.** That's also why this PR should stay open rather than merge-on-approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)