### PR TITLE
feat(lifecycle): bundle the statusline ctx writer (closes the sensor's read seam)

### DIFF
--- a/.claude/settings.json.template
+++ b/.claude/settings.json.template
@@ -3,6 +3,10 @@
     "AIGENT_ROOT": "__AIGENT_ROOT__",
     "AIGENT_VAULT": "__AIGENT_ROOT__"
   },
+  "statusLine": {
+    "type": "command",
+    "command": "bash \"__AIGENT_ROOT__/daemons/statusline-ctx.sh\""
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For changes to the kernel itself (the 15 numbered system documents and extended 
   - `daemons/sessionstart-reinject.mjs` — warm-start pointer-table reinject, a new `SessionStart` hook covering every source (startup/resume/clear/compact) in one merged file.
   - `daemons/stop-capsule-writer.mjs` — every-turn rolling capsule delta writer, a new `Stop` hook. Includes a speaker-tag classifier (`OPERATOR`/`RELAY:x`/`PEER:x`/`INJECT:harness`) so injected instructions and cross-session relay text never masquerade as the operator's own objective.
   - `daemons/ctx-refresh-sensor.mjs` — optional context-pressure self-refresh reflex, a new `PreToolUse` hook. Silently inert unless a statusline integration writes `~/.claude/ctx-refresh/<sid>.json`.
+  - `daemons/statusline-ctx.sh` — the statusline integration that writes it: a `statusLine` wrapper (wired in `settings.json.template`) persisting `{"used_percentage": N, "ts": "..."}` per session (atomic tmp+rename, 7-day stale-file pruning), then delegating the visible line to `~/.claude/statusline-command.sh` when present (override: `AIGENT_STATUSLINE_DELEGATE`) or a minimal model + ctx-% fallback. No-op without `jq`. Test: `daemons/tests/statusline-ctx.test.mjs`.
   - `.claude/settings.json.template` — wires the four new hooks above.
   - `skills/context-capsule/SKILL.md`, `skills/resume/SKILL.md` — rewritten to the two-verb contract.
   - `skill-index.json` — added `sk_resume`; `sk_open`/`sk_close` marked `active: false` (deprecated, not removed).

--- a/daemons/statusline-ctx.sh
+++ b/daemons/statusline-ctx.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# statusline-ctx.sh — statusline wrapper: context-percentage writer.
+#
+# The writer half of the ctx-refresh contract. On every statusline refresh it
+# persists the session's ground-truth context usage for
+# daemons/ctx-refresh-sensor.mjs (the readPct contract:
+#   ~/.claude/ctx-refresh/<session_id>.json  {"used_percentage": N, "ts": "..."}),
+# then delegates the visible status line unchanged.
+#
+# Wired via .claude/settings.json:
+#   "statusLine": { "type": "command", "command": "bash \"__AIGENT_ROOT__/daemons/statusline-ctx.sh\"" }
+#
+# Passive telemetry only — writes a number to a JSON file; injects nothing,
+# changes no session behavior. Degrades to a no-op without jq, and the sensor
+# is silently inert without the file, so nothing here can error the lifecycle.
+#
+# Display delegation: if ~/.claude/statusline-command.sh exists (the
+# conventional home of an operator's own statusline script), the visible line
+# is delegated to it unchanged — override the path with
+# AIGENT_STATUSLINE_DELEGATE. Otherwise a minimal built-in line is shown
+# (model name + ctx %).
+
+INPUT=$(cat)
+
+SENSOR_DIR="$HOME/.claude/ctx-refresh"
+
+if command -v jq >/dev/null 2>&1; then
+  SID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+  PCT=$(printf '%s' "$INPUT" | jq -r '.context_window.used_percentage // empty' 2>/dev/null)
+
+  # Refuse to build a path from a session id that isn't a plain token, and
+  # refuse to splice a non-numeric value into the JSON literal below.
+  [[ "$SID" =~ ^[A-Za-z0-9_-]+$ ]] || SID=""
+  [[ "$PCT" =~ ^[0-9]+(\.[0-9]+)?$ ]] || PCT=""
+
+  if [ -n "$SID" ] && [ -n "$PCT" ]; then
+    mkdir -p "$SENSOR_DIR" 2>/dev/null
+    TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    # Atomic write: tmp + mv so the sensor never reads a torn file.
+    printf '{"used_percentage": %s, "ts": "%s"}\n' "$PCT" "$TS" > "$SENSOR_DIR/$SID.json.tmp" 2>/dev/null \
+      && mv -f "$SENSOR_DIR/$SID.json.tmp" "$SENSOR_DIR/$SID.json" 2>/dev/null
+    # Housekeeping: drop sensor files idle >7 days (session ids rotate on
+    # /clear; old files are dead). Only *.json — the sensor's own *.state
+    # files are its business, not ours.
+    find "$SENSOR_DIR" -name '*.json' -mtime +7 -delete 2>/dev/null
+  fi
+fi
+
+# Display: delegate to an existing statusline script unchanged, if one is wired.
+DELEGATE="${AIGENT_STATUSLINE_DELEGATE:-$HOME/.claude/statusline-command.sh}"
+if [ -f "$DELEGATE" ]; then
+  printf '%s' "$INPUT" | bash "$DELEGATE"
+elif command -v jq >/dev/null 2>&1; then
+  # Minimal built-in fallback: model name + context usage. `|| true` so an
+  # unparseable payload shows an empty line rather than a failing statusline.
+  printf '%s' "$INPUT" | jq -r '
+    [(.model.display_name // "Claude"),
+     (if .context_window.used_percentage != null
+      then "ctx \(.context_window.used_percentage | floor)%" else empty end)]
+    | join(" | ")' 2>/dev/null || true
+fi

--- a/daemons/tests/statusline-ctx.test.mjs
+++ b/daemons/tests/statusline-ctx.test.mjs
@@ -1,0 +1,122 @@
+// statusline-ctx.test.mjs — the statusline context-percentage writer.
+//
+// Proves the WRITER half of the ctx-refresh contract that
+// ctx-refresh-sensor.mjs reads: a statusline payload on stdin produces
+// ~/.claude/ctx-refresh/<session_id>.json with a numeric used_percentage
+// (atomic — no .tmp stray left behind), a malformed or hostile payload
+// produces nothing (never a path escape, never torn JSON), display
+// delegation passes the payload through unchanged, stale sensor files are
+// pruned after 7 idle days, and the sensor's own *.state files are never
+// touched by the pruning pass.
+//
+// Every case runs against a throwaway HOME so no real operator state is read
+// or written. Skipped entirely when jq is unavailable (the script itself
+// degrades to a display-only no-op in that case, by design).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, existsSync, utimesSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(__dirname, '..', 'statusline-ctx.sh');
+
+const hasJq = spawnSync('bash', ['-c', 'command -v jq'], { encoding: 'utf8' }).status === 0;
+
+function freshHome() {
+  return mkdtempSync(path.join(tmpdir(), 'statusline-ctx-test-'));
+}
+
+function run(payload, home, extraEnv = {}) {
+  return spawnSync('bash', [SCRIPT], {
+    input: payload,
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home, ...extraEnv },
+  });
+}
+
+const PAYLOAD = JSON.stringify({
+  session_id: 'sess-abc123',
+  model: { display_name: 'TestModel' },
+  context_window: { used_percentage: 42.5 },
+});
+
+test('writes the sensor file atomically with a numeric used_percentage', { skip: !hasJq && 'jq unavailable' }, () => {
+  const home = freshHome();
+  try {
+    const res = run(PAYLOAD, home);
+    assert.equal(res.status, 0);
+    const dir = path.join(home, '.claude', 'ctx-refresh');
+    const file = path.join(dir, 'sess-abc123.json');
+    assert.ok(existsSync(file), 'sensor file must exist');
+    const parsed = JSON.parse(readFileSync(file, 'utf8'));
+    assert.equal(typeof parsed.used_percentage, 'number'); // the sensor's readPct requirement
+    assert.equal(parsed.used_percentage, 42.5);
+    assert.match(parsed.ts, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    assert.ok(!readdirSync(dir).some((f) => f.endsWith('.tmp')), 'no .tmp stray after the rename');
+    // Built-in fallback display (no delegate wired in this HOME).
+    assert.match(res.stdout, /TestModel/);
+    assert.match(res.stdout, /ctx 42%/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('malformed payload and hostile session_id write nothing', { skip: !hasJq && 'jq unavailable' }, () => {
+  const home = freshHome();
+  try {
+    for (const bad of [
+      '{}',
+      'not json at all',
+      JSON.stringify({ session_id: '../evil', context_window: { used_percentage: 50 } }),
+      JSON.stringify({ session_id: 'sess-ok', context_window: { used_percentage: '50; rm -rf' } }),
+    ]) {
+      const res = run(bad, home);
+      assert.equal(res.status, 0, 'always exits 0');
+    }
+    const dir = path.join(home, '.claude', 'ctx-refresh');
+    if (existsSync(dir)) assert.deepEqual(readdirSync(dir), []);
+    assert.ok(!existsSync(path.join(home, '.claude', 'evil.json')), 'no path escape');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('delegates the visible line to an existing statusline script unchanged', { skip: !hasJq && 'jq unavailable' }, () => {
+  const home = freshHome();
+  try {
+    mkdirSync(path.join(home, '.claude'), { recursive: true });
+    writeFileSync(
+      path.join(home, '.claude', 'statusline-command.sh'),
+      '#!/bin/bash\nINPUT=$(cat)\necho "DELEGATE saw $(printf \'%s\' "$INPUT" | jq -r .model.display_name)"\n',
+    );
+    const res = run(PAYLOAD, home);
+    assert.equal(res.status, 0);
+    assert.equal(res.stdout.trim(), 'DELEGATE saw TestModel');
+    // The sensor write still happened alongside delegation.
+    assert.ok(existsSync(path.join(home, '.claude', 'ctx-refresh', 'sess-abc123.json')));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('prunes >7-day-idle *.json but never the sensor\'s *.state files', { skip: !hasJq && 'jq unavailable' }, () => {
+  const home = freshHome();
+  try {
+    const dir = path.join(home, '.claude', 'ctx-refresh');
+    mkdirSync(dir, { recursive: true });
+    const old = new Date(Date.now() - 8 * 24 * 3600 * 1000);
+    for (const f of ['stale-session.json', 'stale-session.state']) {
+      writeFileSync(path.join(dir, f), '{}');
+      utimesSync(path.join(dir, f), old, old);
+    }
+    assert.equal(run(PAYLOAD, home).status, 0);
+    assert.ok(!existsSync(path.join(dir, 'stale-session.json')), 'stale sensor file pruned');
+    assert.ok(existsSync(path.join(dir, 'stale-session.state')), '.state files are the sensor\'s business');
+    assert.ok(existsSync(path.join(dir, 'sess-abc123.json')), 'fresh write landed');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/docs/two-verb-lifecycle.md
+++ b/docs/two-verb-lifecycle.md
@@ -78,7 +78,7 @@ If a fork wires multiple agents/sessions that need to pause for a conducted, mul
 
 `daemons/ctx-refresh-sensor.mjs` is a `PreToolUse` hook implementing a single-session self-refresh reflex: at 60% context usage it nudges a capsule-then-clear/compact; at 75% it escalates to mandatory `/clear`; it re-arms below 50%, and re-nudges every +5 points while armed to avoid going silent between 60% and 90%.
 
-This reflex depends on an **optional** integration: something must write `~/.claude/ctx-refresh/<session-id>.json` with a `used_percentage` field (a statusline script is the natural place). Nothing in this port writes that file — if it's absent, the sensor is silently inert (checked first, before any other logic runs). Wiring a percentage-tracking statusline is a documented but unbundled integration point.
+This reflex depends on one integration: something must write `~/.claude/ctx-refresh/<session-id>.json` with a numeric `used_percentage` field. `daemons/statusline-ctx.sh` is that writer — a statusline wrapper wired through the template's `statusLine` entry. On every statusline refresh it persists `{"used_percentage": N, "ts": "..."}` for the current session (atomic tmp+rename, so the sensor never reads a torn file) and prunes sensor files idle more than 7 days (session ids rotate on `/clear`; old files are dead), then delegates the visible status line unchanged to `~/.claude/statusline-command.sh` when that exists (the conventional home of an operator's own statusline script — override the path with `AIGENT_STATUSLINE_DELEGATE`), falling back to a minimal model-name + ctx-% line. The write degrades to a no-op without `jq`, and if the file is absent the sensor is silently inert (checked first, before any other logic runs) — so a missing or unwired statusline can never error the lifecycle. To opt out of the bundled writer, drop the `statusLine` entry from `settings.json`; the sensor then waits for whatever integration the operator wires instead.
 
 Behind an opt-in flag (`CAPSULE_VERB_AUTOFIRE=1`), the sensor can also drive the trusted writer automatically: it waits for the transcript to fall genuinely still (two identical capture-cursor reads separated by an age floor, guarding against reading mid-flush), then calls `runCapsuleVerb()` in dry-run mode by default. A real, request-gated cycle (`daemons/refresh-request.mjs` + `daemons/refresh-cycle.mjs`) exists for a controller that wants to mint a nonce-bound refresh challenge and verify the receipt — none of that fires unless something writes a `RefreshRequest` file, which, like the board adapter, ships as a seam rather than a default behavior.
 
@@ -109,6 +109,7 @@ Behind an opt-in flag (`CAPSULE_VERB_AUTOFIRE=1`), the sensor can also drive the
 | `daemons/refresh-request.mjs` | The controller→session challenge-crossing request |
 | `daemons/refresh-cursor.mjs` | The capture-cursor primitive (byte-exact transcript position) |
 | `daemons/ctx-refresh-sensor.mjs` | Context-pressure self-refresh reflex — PreToolUse hook |
+| `daemons/statusline-ctx.sh` | Context-percentage writer — statusLine wrapper feeding the sensor |
 | `skills/context-capsule/SKILL.md` | The capsule verb, explicit invocation |
 | `skills/resume/SKILL.md` | The resume verb, explicit invocation |
 


### PR DESCRIPTION
The statusline writer you accepted on #2 ("yes, please PR it genericized") — the missing input half of `ctx-refresh-sensor.mjs`'s contract.

**Base note:** stacked on `feat/two-verb-lifecycle` since the consumer and doc only exist there; retargets to master trivially if #2 merges first.

## What it does

`daemons/statusline-ctx.sh` runs as the statusline command: on every refresh it writes `~/.claude/ctx-refresh/<session_id>.json` (`{"used_percentage": N, "ts": "..."}`, atomic tmp+mv, 7-day cleanup of `*.json` only — the sensor's `*.state` files are untouched), then delegates the *visible* line unchanged to an existing `~/.claude/statusline-command.sh` if one exists (`AIGENT_STATUSLINE_DELEGATE` overrides), else shows a minimal model + ctx% fallback. Passive telemetry only — injects nothing; degrades to a no-op without jq; the sensor stays silently inert without the file, exactly as documented.

Hardening beyond our production original (matching this repo's posture): session_id must be a plain path token before it's used in a filename, and the percentage must be numeric before it's spliced into the JSON literal — a hostile/malformed statusline payload writes nothing.

## One deliberate stance change — flag if you'd rather not

The `.claude/settings.json.template` stanza makes the writer **active by default on fresh installs**, superseding the doc's "documented but unbundled" stance (the doc paragraph is updated accordingly). Read on your "shipping the sensor dead-on-arrival was the port's weakest seam" comment. Behavior-preserving for operators with an existing statusline script (delegation). If you'd rather keep it opt-in, dropping the 4-line template stanza is the whole revert.

## Tests

`daemons/tests/statusline-ctx.test.mjs` (house style): 4/4 — atomic numeric write · hostile/malformed payloads write nothing · delegation passthrough · stale-prune spares `.state`. `bash -n` clean (your CI's shell gate); substituted template stanza parses as JSON. Honest limit: shellcheck isn't installed on this machine, so it wasn't run here.
