### PR TITLE
fix(lifecycle): two-verb refresh livelock — cross-session curated-close discriminator + resume-flip defer

### DIFF
--- a/daemons/ctx-refresh-sensor.mjs
+++ b/daemons/ctx-refresh-sensor.mjs
@@ -38,6 +38,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { crossSessionCuratedAllowed, curatedWindowMs } from './lifecycle-common.mjs';
 
 const FIRE_AT = 60;       // raise to 75-80 ONLY after reinject is proven on one
                           // live compaction — this is an early-warning threshold.
@@ -83,7 +84,6 @@ function readCuratedPointer(root, memory, sid) {
       ?.state?.last_capsule ?? null;
     const finalizedAtMs = Date.parse(pointer?.finalized_at);
     if (pointer?.trigger !== 'curated-close'
-      || pointer.session_id !== sid
       || !Number.isFinite(finalizedAtMs)
       || typeof pointer.path !== 'string'
       || pointer.path.trim() === '') return null;
@@ -91,6 +91,19 @@ function readCuratedPointer(root, memory, sid) {
       ? pointer.path
       : path.resolve(root, pointer.path);
     if (!fs.existsSync(capsulePath)) return null;
+    if (pointer.session_id !== sid) {
+      // A curated close whose stamping session rotated away WITHOUT a clear is
+      // still THE close to seal — raw equality sent the autofire to the rolling
+      // skeleton instead, which defers forever. The cross-session path is
+      // window-bounded (curatedWindowMs — a curated close is a fresh close
+      // awaiting seal, not an ancient anchor) and fails closed on clear-born
+      // sessions, stale/absent boot evidence, consumed (status:resumed) capsules,
+      // and falsy pointer sids (the stamper's no-sid branch — never cross-session
+      // eligible). The same-session fast path above is untouched.
+      if (!pointer.session_id) return null;
+      if ((Date.now() - finalizedAtMs) >= curatedWindowMs()) return null;
+      if (!crossSessionCuratedAllowed(memory, sid, capsulePath)) return null;
+    }
     return { capsulePath, finalizedAtMs };
   } catch {
     return null;

--- a/daemons/lifecycle-common.mjs
+++ b/daemons/lifecycle-common.mjs
@@ -7,7 +7,7 @@
 // single 'operator' identity via AIGENT_SEAT_ID (or the default). Keep this file
 // dependency-free and side-effect-free — everything downstream imports from here.
 
-import { readFileSync, writeFileSync, existsSync, appendFileSync, writeSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, appendFileSync, writeSync, mkdirSync, renameSync, rmSync } from 'node:fs';
 import path from 'node:path';
 
 // seatId resolution: env override first (multi-instance forks), else the fixed
@@ -101,6 +101,11 @@ export function logErr(root, tag, msg) {
 // a delimiter line's line ending.
 const FRONTMATTER_RE = /^(---[ \t]*\r?\n)([\s\S]*?)(^---[ \t]*(?:\r?\n|$))/m;
 
+// The consumed-status signal (status: resumed). ONE owner — the flip writes it,
+// the flip's steady-state check reads it, and crossSessionCuratedAllowed gates on
+// it; drifting copies of this regex would silently split those three.
+const CONSUMED_STATUS_RE = /^status:[ \t]*['"]?resumed['"]?[ \t]*$/m;
+
 export function flipCapsuleToResumed(capsulePath, sessionId, { readFile = readFileSync, writeFile = writeFileSync } = {}) {
   let doc;
   try {
@@ -123,7 +128,7 @@ export function flipCapsuleToResumed(capsulePath, sessionId, { readFile = readFi
   // trailing terminator of its own, orphaning that \n with no \r partner. A
   // trailing value can only legitimately carry spaces/tabs, never a line
   // terminator, so [ \t]* can never consume across the CRLF boundary.
-  if (/^status:[ \t]*['"]?resumed['"]?[ \t]*$/m.test(block)) {
+  if (CONSUMED_STATUS_RE.test(block)) {
     return { outcome: 'steady_state', detail: 'capsule frontmatter already reads status: resumed' };
   }
   if (!/^status:[ \t]*['"]?active['"]?[ \t]*$/m.test(block)) {
@@ -150,4 +155,96 @@ export function flipCapsuleToResumed(capsulePath, sessionId, { readFile = readFi
     return { outcome: 'error', detail: `write failed: ${e?.message || e}` };
   }
   return { outcome: 'flipped', detail: 'status flipped active -> resumed, stamps written, any duplicate placeholder removed' };
+}
+
+// stampBootEvidence — board c1f777e9 (the two-verb refresh livelock).
+//
+// The ONE ground-truth record of how the CURRENT session booted:
+// <memRoot>/runtime/boot-evidence.json = { sid, source, ts }. Called from
+// sessionstart-reinject.mjs, which in aigent-OS already fires on EVERY source
+// (startup | resume | clear | compact — see docs/two-verb-lifecycle.md, "A note
+// on the merged SessionStart hook"), so existing installs get the stamp on a
+// plain git pull with no settings migration. crossSessionCuratedAllowed below
+// reads it as the Case-A discriminator. Non-seat children (headless workers,
+// judges spawned in the seat cwd) self-identify via SEAT_BOOT_EVIDENCE_SKIP=1 so
+// they never overwrite the seat's own record. Fail-open: stamping must never
+// break a session start — callers already run inside a try that exits 0.
+export function stampBootEvidence(memoryRoot, sid, source) {
+  if (process.env.SEAT_BOOT_EVIDENCE_SKIP === '1') return;
+  const runtime = path.join(String(memoryRoot), 'runtime');
+  const file = path.join(runtime, 'boot-evidence.json');
+  const doc = JSON.stringify({ sid: String(sid || ''), source: String(source || 'startup'), nonce: process.env.SEAT_BOOT_NONCE || null, ts: Date.now() }, null, 1);
+  mkdirSync(runtime, { recursive: true });
+  // Per-pid tmp + atomic rename so a racing sibling SessionStart never interleaves.
+  const tmp = `${file}.${process.pid}.tmp`;
+  writeFileSync(tmp, doc);
+  try { renameSync(tmp, file); } catch {
+    try { rmSync(file, { force: true }); renameSync(tmp, file); } catch {
+      writeFileSync(file, doc);
+      try { rmSync(tmp, { force: true }); } catch { /* orphan tmp is harmless */ }
+    }
+  }
+}
+
+// crossSessionCuratedAllowed — board c1f777e9 (the two-verb refresh livelock).
+//
+// Whether a curated-close pointer stamped by a DIFFERENT session than the live one
+// is still authoritative. Raw session_id equality livelocked a seat overnight: the
+// session rotated WITHOUT a clear, the valid finalized close became invisible to
+// both the stop-writer's clobber protection (curatedPointerWins) and the autofire's
+// curated preference (readCuratedPointer), the rolling skeleton won the pointer
+// every turn, and the sealer deferred forever (skipped_skeleton on every poll).
+//
+// The equality gate's REAL job was Case-A: exclude a stale PRIOR-session close
+// after a /clear. boot-evidence.json (stamped above on EVERY SessionStart)
+// discriminates exactly that: a live session whose own boot record reads
+// source=clear was born from a clear — the rotation crossed a clear, exclude the
+// close. Any other fresh record (startup / resume / compact) proves
+// rotation-without-clear — the close stays authoritative.
+//
+// FAIL CLOSED everywhere: stale evidence (sid mismatch — the stamp failed for this
+// boot), absent/unreadable evidence, or an unreadable capsule all return false,
+// which IS the pre-fix cross-session behavior. A status:resumed capsule is
+// CONSUMED (a post-clear resume already used it) and is never re-armed — this also
+// covers clears older than the single-record boot evidence can see: the resume
+// verb's own flip (flipCapsuleToResumed above) leaves the durable trace.
+//
+// Callers keep their own freshness window (SCW_CURATED_WIN_MS) — this function
+// judges only the clear/consumed axes.
+export function crossSessionCuratedAllowed(memoryRoot, liveSid, capsulePathAbs) {
+  try {
+    const boot = JSON.parse(readFileSync(path.join(String(memoryRoot), 'runtime', 'boot-evidence.json'), 'utf8'));
+    if (String(boot?.sid || '') !== String(liveSid || '')) return false;
+    if (String(boot?.source || '') === 'clear') return false;
+  } catch { return false; }
+  try {
+    const doc = readFileSync(String(capsulePathAbs), 'utf8');
+    const block = doc.match(FRONTMATTER_RE)?.[2];
+    if (!block) return false;
+    if (CONSUMED_STATUS_RE.test(block)) return false;
+  } catch { return false; }
+  return true;
+}
+
+// curatedWindowMs — the ONE owner of the curated freshness window.
+// SCW_CURATED_WIN_MS (ms) when set to a positive number, else 45 min.
+export function curatedWindowMs() {
+  return Number(process.env.SCW_CURATED_WIN_MS) > 0
+    ? Number(process.env.SCW_CURATED_WIN_MS) : 45 * 60 * 1000;
+}
+
+// resumeFlipShouldDefer — the boot-native resume-flip consumed curated closes on
+// NON-CLEAR rotation boots, flipping the exact status:active signal
+// crossSessionCuratedAllowed needs, before the first autofire poll — re-creating
+// the livelock end-to-end. A curated close still inside its seal window, observed
+// by a rotation boot that did NOT cross a clear, is AWAITING SEAL — nobody
+// resumed it; consuming it is wrong. The flip defers. On source=clear the flip
+// always fires: that boot-native consumption closes the Case-A single-record
+// blind spot and must be preserved. A lapsed close flips as before.
+export function resumeFlipShouldDefer(pointer, source) {
+  if (String(source || '') === 'clear') return false;
+  if (pointer?.trigger !== 'curated-close' && pointer?.trigger !== 'manual-close') return false;
+  const fin = Date.parse(String(pointer?.finalized_at || ''));
+  if (!Number.isFinite(fin)) return false;
+  return (Date.now() - fin) < curatedWindowMs();
 }

--- a/daemons/sessionstart-reinject.mjs
+++ b/daemons/sessionstart-reinject.mjs
@@ -38,7 +38,7 @@
 
 import { readFileSync, existsSync, appendFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
-import { memRoot as resolveMemRoot, flipCapsuleToResumed } from './lifecycle-common.mjs';
+import { memRoot as resolveMemRoot, flipCapsuleToResumed, stampBootEvidence, resumeFlipShouldDefer } from './lifecycle-common.mjs';
 
 const TOP_LINKS = 5;
 
@@ -79,10 +79,10 @@ function activeCapsule(root) {
     const bs = JSON.parse(readFileSync(path.join(MEM, 'BODY_STATE.json'), 'utf8'));
     const c = bs?.state?.last_capsule;
     const cap = c && c.status === 'active' ? c : null;
-    if (!cap?.path) return { path: null, dangling: false };
+    if (!cap?.path) return { path: null, dangling: false, pointer: null };
     const p = path.isAbsolute(cap.path) ? cap.path : path.join(root, cap.path);
-    if (existsSync(p)) return { path: p, dangling: false };
-    return { path: p, dangling: true };
+    if (existsSync(p)) return { path: p, dangling: false, pointer: cap };
+    return { path: p, dangling: true, pointer: cap };
   } catch {
     return { path: null, dangling: false };
   }
@@ -143,6 +143,13 @@ try {
   const root = process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || payload.cwd || '';
   if (!root) process.exit(0);
   const source = String(payload.source || 'startup');
+
+  // BOOT EVIDENCE (board c1f777e9): stamp how THIS session booted, every source,
+  // before anything else — crossSessionCuratedAllowed reads it as the Case-A
+  // discriminator for cross-session curated closes. Fail-open: a stamp failure
+  // must never break a session start.
+  try { stampBootEvidence(resolveMemRoot(root), String(payload.session_id || ''), source); }
+  catch (e) { logErr(root, `boot-evidence stamp failed: ${e?.message || e}`); }
 
   // CLOCK — ground the waking session in real day/time BEFORE any orientation. A
   // bare wake fires no UserPromptSubmit, so a prompt-time clock injection can't
@@ -220,7 +227,19 @@ try {
     // Compact is NOT a resume — the same session continues, and flipping
     // mid-cycle would disarm an auto-refresh watcher's capsule-ready gate — so
     // startup/resume/clear only.
-    if (source !== 'compact') {
+    // A curated close awaiting seal must NOT be consumed by a rotation boot —
+    // deferring keeps the close status:active for the autofire's consumed-gate.
+    // source=clear always flips (Case-A boot-native consumption, preserved).
+    // Gated on the CAPSULE's own frontmatter status (round-2 R2-2): a non-active
+    // capsule was never going to flip, so announcing a defer for it is noise —
+    // the pointer's status can go stale against the file. Compact never flips
+    // and never announces (unchanged).
+    const flipDeferred = fm(doc, 'status') === 'active'
+      && source !== 'compact'
+      && resumeFlipShouldDefer(cap.pointer, source);
+    if (flipDeferred) {
+      out.push(`   [resume-flip] deferred — curated close awaiting seal (within window, non-clear boot); not consumed.`);
+    } else if (source !== 'compact') {
       const result = flipCapsuleToResumed(cap.path, payload.session_id);
       if (result.outcome === 'flipped') {
         out.push(`   [resume-flip] capsule marked resumed — finalize-lock released, rolling repoints re-armed.`);

--- a/daemons/stop-capsule-writer.mjs
+++ b/daemons/stop-capsule-writer.mjs
@@ -26,7 +26,7 @@ import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { memRoot as resolveMemRoot } from './lifecycle-common.mjs';
+import { memRoot as resolveMemRoot, crossSessionCuratedAllowed, curatedWindowMs } from './lifecycle-common.mjs';
 
 const SELF = fileURLToPath(import.meta.url);
 
@@ -475,12 +475,25 @@ ${ANCHORS.rows}
       const cur = JSON.parse(readFileSync(path.join(MEM, 'BODY_STATE.json'), 'utf8'))?.state?.last_capsule;
       if (!cur) return false;
       if (cur.trigger !== 'curated-close' && cur.trigger !== 'manual-close') return false;
-      if (String(cur.session_id || '') !== sid) return false;
       const fin = Date.parse(String(cur.finalized_at || ''));
       if (!Number.isFinite(fin)) return false;
-      const win = Number(process.env.SCW_CURATED_WIN_MS) > 0
-        ? Number(process.env.SCW_CURATED_WIN_MS) : 45 * 60 * 1000;
-      return (Date.now() - fin) < win;
+      if ((Date.now() - fin) >= curatedWindowMs()) return false;
+      if (String(cur.session_id || '') !== sid) {
+        // A session that rotated WITHOUT a clear keeps its curated close
+        // authoritative — raw equality made the close invisible after rotation and
+        // the stop-delta clobbered it every turn. Case-A stays safe: a clear-born
+        // session, stale/absent boot evidence, or a consumed (status:resumed)
+        // capsule all fall back to the old exclusion. A falsy session_id (the
+        // stamper's own no-sid-resolvable branch) is never cross-session eligible —
+        // hard reject, as raw !== always did. Window checked above (cheap) before
+        // the helper's file reads.
+        if (!cur.session_id) return false;
+        const capAbs = typeof cur.path === 'string' && cur.path.trim() !== ''
+          ? (path.isAbsolute(cur.path) ? cur.path : path.resolve(root, cur.path))
+          : null;
+        if (!capAbs || !crossSessionCuratedAllowed(MEM, sid, capAbs)) return false;
+      }
+      return true;
     } catch { return false; }
   }
   const pointer = {
@@ -609,13 +622,19 @@ async function launchStopAutofire() {
         ? (path.isAbsolute(pointer.path) ? pointer.path : path.resolve(root, pointer.path))
         : null;
       shouldLaunch = pointer?.trigger === 'curated-close'
-        && pointer.session_id === sid
         && Number.isFinite(finalizedAtMs)
         && capsulePath !== null
         && existsSync(capsulePath)
         && typeof launchedAt === 'number'
         && Number.isFinite(launchedAt)
-        && finalizedAtMs > launchedAt;
+        && finalizedAtMs > launchedAt
+        // Same cross-session acceptance as curatedPointerWins / readCuratedPointer —
+        // a rotated-but-not-cleared close re-launches the autofire too, instead of
+        // waiting out request.expires_at.
+        && (pointer.session_id === sid
+          || (Boolean(pointer.session_id)
+            && (Date.now() - finalizedAtMs) < curatedWindowMs()
+            && crossSessionCuratedAllowed(memory, sid, capsulePath)));
     }
     if (!shouldLaunch) return;
 

--- a/daemons/tests/curated-cross-session-rotation.test.mjs
+++ b/daemons/tests/curated-cross-session-rotation.test.mjs
@@ -1,0 +1,460 @@
+// curated-cross-session-rotation.test.mjs — the two-verb refresh livelock fix
+// (upstream board c1f777e9).
+//
+// The livelock: a valid finalized curated-close pointer became INVISIBLE to both
+// the stop-writer's clobber protection (curatedPointerWins) and the autofire's
+// curated preference (readCuratedPointer) the moment the session id rotated away
+// from the stamping session — both sites gated on raw session_id equality. The
+// rolling skeleton then won the pointer every turn, the skeleton gate deferred
+// every autofire poll, and the seal never ran.
+//
+// Post-fix, a curated-close pointer stamped by a DIFFERENT session stays
+// authoritative iff ALL of:
+//   (1) trigger curated-close + finalized_at real + within SCW_CURATED_WIN_MS;
+//   (2) boot-evidence.json proves the LIVE session was not born from a clear
+//       (sid === live sid AND source !== 'clear'); stale/absent evidence fails
+//       CLOSED (the old cross-session behavior);
+//   (3) the pointed-at capsule is not status:resumed (a consumed close must never
+//       be re-protected or re-sealed).
+// boot-evidence.json is stamped by sessionstart-reinject.mjs on EVERY source —
+// the S0 tests prove that wiring through the real daemon.
+//
+// Runs the REAL daemons against temp-dir fixtures — no mocking. Override under
+// test with SCW_DAEMON / SENSOR_DAEMON / SSR_DAEMON env vars.
+'use strict';
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCW = process.env.SCW_DAEMON || path.resolve(__dirname, '..', 'stop-capsule-writer.mjs');
+const SENSOR = process.env.SENSOR_DAEMON || path.resolve(__dirname, '..', 'ctx-refresh-sensor.mjs');
+const SSR = process.env.SSR_DAEMON || path.resolve(__dirname, '..', 'sessionstart-reinject.mjs');
+
+let pass = 0;
+let fail = 0;
+function ok(cond, name, detail = '') {
+  if (cond) { pass++; console.log(`  PASS  ${name}`); }
+  else { fail++; console.log(`  FAIL  ${name}${detail ? `: ${detail}` : ''}`); }
+}
+
+const LIVE_SID = 'sess-live-2222';
+const OLD_SID = 'sess-old-1111';
+
+const BODY = `\n## Done (don't redo)\n<!-- swe:done -->\n\n## Pending-Gates\n<!-- swe:gates -->\n`;
+
+// A curated close capsule. status 'active' + real waiting_on = finalized
+// open-thread close (the exact livelock shape: valid, sealable, waiting on a gate).
+const curatedCap = (id, status, waitingOn) =>
+  `---\nid: ${id}\nstatus: ${status}\nobjective: "curated close of the session"\nwaiting_on: ${waitingOn}\nresume_trigger: none\nnext_valid_action: "act on waiting_on"\n---\n${BODY}`;
+
+// The stop-writer's own skeleton shape (waiting_on null — finalize never ran).
+const skeletonCap = (id) =>
+  `---\nid: ${id}\nparent_capsule_id: null\nstatus: active\nobjective: "Auto-captured working state"\nwaiting_on: null\nresume_trigger: compact\ntrigger: stop-delta\nnext_valid_action: "Re-ground and continue"\ntags: [capsule, autosave]\n---\n${BODY}`;
+
+function mkSeat(label) {
+  const base = path.join(os.tmpdir(), `ccsr-${label}-${process.pid}`);
+  rmSync(base, { recursive: true, force: true });
+  const root = path.join(base, 'aigent-root');
+  mkdirSync(path.join(root, 'memory', 'capsules'), { recursive: true });
+  mkdirSync(path.join(root, 'memory', 'runtime', 'stop-writer'), { recursive: true });
+  return { base, root };
+}
+
+function writeBootEvidence(root, sid, source) {
+  writeFileSync(
+    path.join(root, 'memory', 'runtime', 'boot-evidence.json'),
+    JSON.stringify({ sid, source, ts: Date.now() }, null, 1),
+  );
+}
+
+// Single-operator pointer convention: memory/BODY_STATE.json state.last_capsule.
+function writeCuratedPointer(root, { sessionId = OLD_SID, finalizedAgoMs = 5 * 60e3, capRel = 'memory/capsules/capsule-CUR.md' } = {}) {
+  writeFileSync(path.join(root, 'memory', 'BODY_STATE.json'), JSON.stringify({
+    state: {
+      last_capsule: {
+        id: 'capsule-CUR', path: capRel, objective: 'closed clean', status: 'complete',
+        created_at: new Date().toISOString(), trigger: 'curated-close',
+        finalized_at: new Date(Date.now() - finalizedAgoMs).toISOString(), session_id: sessionId,
+      },
+    },
+  }));
+}
+
+function readPointer(root) {
+  return JSON.parse(readFileSync(path.join(root, 'memory', 'BODY_STATE.json'), 'utf8')).state.last_capsule;
+}
+
+// Drive the REAL stop-writer worker one turn for the LIVE session.
+function runStopWriter(root, base) {
+  const capsuleB = path.join(root, 'memory', 'capsules', 'capsule-B.md');
+  writeFileSync(
+    path.join(root, 'memory', 'runtime', 'stop-writer', `${LIVE_SID}.json`),
+    JSON.stringify({ offset: 0, capsule_path: capsuleB, last_delta_sha: null }),
+  );
+  const transcript = path.join(base, `transcript-${LIVE_SID}.jsonl`);
+  writeFileSync(transcript, JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'delta ' + LIVE_SID }] } }) + '\n');
+  const payload = JSON.stringify({ __root: root, session_id: LIVE_SID, transcript_path: transcript });
+  return execFileSync(process.execPath, [SCW, '--worker', payload], { encoding: 'utf8', env: { ...process.env } });
+}
+
+// Drive the REAL autofire worker for the LIVE session (legacy mode). The rolling
+// stop-writer capsule for LIVE_SID is a skeleton, so any outcome OTHER than
+// skipped_skeleton proves the worker resolved the curated capsule instead.
+function runAutofire(root) {
+  const rolling = path.join(root, 'memory', 'capsules', 'capsule-ROLL.md');
+  writeFileSync(rolling, skeletonCap('capsule-ROLL'));
+  writeFileSync(
+    path.join(root, 'memory', 'runtime', 'stop-writer', `${LIVE_SID}.json`),
+    JSON.stringify({ capsule_path: rolling }),
+  );
+  const payload = Buffer.from(JSON.stringify({ root, sid: LIVE_SID, eventId: null, transcriptPath: null }), 'utf8')
+    .toString('base64url');
+  const r = spawnSync(process.execPath, [SENSOR, '--autofire-worker', payload], {
+    encoding: 'utf8',
+    windowsHide: true,
+    env: { ...process.env, AIGENT_ROOT: root, CLAUDE_PROJECT_DIR: root },
+  });
+  return { r, rolling };
+}
+
+function lastAutofireEntry(root) {
+  const p = path.join(root, 'memory', 'runtime', 'capsule-verb-autofire.jsonl');
+  try {
+    const entries = readFileSync(p, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+    return entries[entries.length - 1] ?? null;
+  } catch { return null; }
+}
+
+// Drive the REAL sessionstart-reinject for a given boot source.
+function runReinject(root, sid, source) {
+  return execFileSync(process.execPath, [SSR], {
+    encoding: 'utf8',
+    input: JSON.stringify({ source, session_id: sid, cwd: root }),
+    env: { ...process.env, AIGENT_ROOT: root, CLAUDE_PROJECT_DIR: root },
+  });
+}
+
+console.log(`── curated cross-session rotation (livelock fix) — scw: ${SCW} ──`);
+
+// ─── S0: boot-evidence stamping through the REAL reinject (every source) ───
+
+// S0-A: a resume boot stamps {sid, source:'resume'}.
+{
+  const { base, root } = mkSeat('s0a');
+  runReinject(root, LIVE_SID, 'resume');
+  const p = path.join(root, 'memory', 'runtime', 'boot-evidence.json');
+  ok(existsSync(p), 'S0-A stamp: boot-evidence.json written on a resume boot');
+  const boot = existsSync(p) ? JSON.parse(readFileSync(p, 'utf8')) : {};
+  ok(boot.sid === LIVE_SID && boot.source === 'resume',
+    'S0-A stamp: records the live sid + source verbatim', JSON.stringify(boot));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S0-B: a clear boot stamps source:'clear' (the Case-A record).
+{
+  const { base, root } = mkSeat('s0b');
+  runReinject(root, LIVE_SID, 'clear');
+  const p = path.join(root, 'memory', 'runtime', 'boot-evidence.json');
+  const boot = existsSync(p) ? JSON.parse(readFileSync(p, 'utf8')) : {};
+  ok(boot.sid === LIVE_SID && boot.source === 'clear',
+    'S0-B stamp: a clear boot is recorded as source=clear', JSON.stringify(boot));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S0-C: SEAT_BOOT_EVIDENCE_SKIP=1 children never overwrite the seat's record.
+{
+  const { base, root } = mkSeat('s0c');
+  writeBootEvidence(root, LIVE_SID, 'resume');
+  execFileSync(process.execPath, [SSR], {
+    encoding: 'utf8',
+    input: JSON.stringify({ source: 'startup', session_id: 'sess-child-9999', cwd: root }),
+    env: { ...process.env, AIGENT_ROOT: root, CLAUDE_PROJECT_DIR: root, SEAT_BOOT_EVIDENCE_SKIP: '1' },
+  });
+  const boot = JSON.parse(readFileSync(path.join(root, 'memory', 'runtime', 'boot-evidence.json'), 'utf8'));
+  ok(boot.sid === LIVE_SID && boot.source === 'resume',
+    'S0-C skip: a SEAT_BOOT_EVIDENCE_SKIP child leaves the seat record untouched', JSON.stringify(boot));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ─── SITE 1: stop-capsule-writer curatedPointerWins() ───
+
+// S1-A ROTATION WITHOUT CLEAR (the livelock, RED pre-fix): curated pointer stamped
+// by OLD_SID; live session booted source=resume. Stop-delta must NOT clobber it.
+{
+  const { base, root } = mkSeat('s1a');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'), curatedCap('capsule-CUR', 'complete', 'null'));
+  writeCuratedPointer(root);
+  writeBootEvidence(root, LIVE_SID, 'resume');
+  const out = runStopWriter(root, base);
+  const after = readPointer(root);
+  ok(out.includes('SWE_OUTCOME:flushed'), 'S1-A rotation-no-clear: worker flushed');
+  ok(after.id === 'capsule-CUR' && after.trigger === 'curated-close',
+    'S1-A rotation-no-clear: rotated-but-not-cleared curated close survives the stop-delta tail',
+    JSON.stringify(after));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S1-B CLEAR-BORN SESSION (Case-A guard): live session booted source=clear —
+// the rotation crossed a clear; clobber is CORRECT.
+{
+  const { base, root } = mkSeat('s1b');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'), curatedCap('capsule-CUR', 'complete', 'null'));
+  writeCuratedPointer(root);
+  writeBootEvidence(root, LIVE_SID, 'clear');
+  runStopWriter(root, base);
+  const after = readPointer(root);
+  ok(after.id !== 'capsule-CUR' && after.trigger === 'stop-delta',
+    'S1-B clear-born: a post-clear session repoints past the pre-clear curated close (Case-A preserved)',
+    JSON.stringify(after));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S1-C CONSUMED CAPSULE: rotation without clear, but the capsule is status:resumed.
+{
+  const { base, root } = mkSeat('s1c');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'), curatedCap('capsule-CUR', 'resumed', '"still open"'));
+  writeCuratedPointer(root);
+  writeBootEvidence(root, LIVE_SID, 'resume');
+  runStopWriter(root, base);
+  const after = readPointer(root);
+  ok(after.id !== 'capsule-CUR' && after.trigger === 'stop-delta',
+    'S1-C consumed: a status:resumed capsule is never re-protected cross-session',
+    JSON.stringify(after));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S1-D NO BOOT EVIDENCE (fail-closed): cross-session clobber stays allowed.
+{
+  const { base, root } = mkSeat('s1d');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'), curatedCap('capsule-CUR', 'complete', 'null'));
+  writeCuratedPointer(root);
+  runStopWriter(root, base);
+  const after = readPointer(root);
+  ok(after.id !== 'capsule-CUR' && after.trigger === 'stop-delta',
+    'S1-D no-evidence: absent boot-evidence fails closed (old cross-session behavior)',
+    JSON.stringify(after));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S1-E STALE BOOT EVIDENCE: record belongs to some OTHER session → fail closed.
+{
+  const { base, root } = mkSeat('s1e');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'), curatedCap('capsule-CUR', 'complete', 'null'));
+  writeCuratedPointer(root);
+  writeBootEvidence(root, 'sess-somebody-else', 'resume');
+  runStopWriter(root, base);
+  const after = readPointer(root);
+  ok(after.id !== 'capsule-CUR' && after.trigger === 'stop-delta',
+    'S1-E stale-evidence: boot-evidence for a different sid fails closed',
+    JSON.stringify(after));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S1-F WINDOW LAPSE: rotation without clear but finalized 2h ago — still bounded.
+{
+  const { base, root } = mkSeat('s1f');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'), curatedCap('capsule-CUR', 'complete', 'null'));
+  writeCuratedPointer(root, { finalizedAgoMs: 2 * 3600e3 });
+  writeBootEvidence(root, LIVE_SID, 'resume');
+  runStopWriter(root, base);
+  const after = readPointer(root);
+  ok(after.id !== 'capsule-CUR' && after.trigger === 'stop-delta',
+    'S1-F window-lapse: cross-session protection stays window-bounded',
+    JSON.stringify(after));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ─── SITE 2: ctx-refresh-sensor readCuratedPointer() / the autofire seal ───
+
+// S2-A THE LIVELOCK REPRO (RED pre-fix): finalized curated close stamped by
+// OLD_SID; session rotated WITHOUT a clear; rolling capsule is a skeleton. The
+// autofire must resolve the CURATED capsule — not defer on the skeleton forever.
+{
+  const { base, root } = mkSeat('s2a');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'),
+    curatedCap('capsule-CUR', 'active', '"review gate on the staged package"'));
+  writeCuratedPointer(root);
+  writeBootEvidence(root, LIVE_SID, 'resume');
+  const { r } = runAutofire(root);
+  ok(r.status === 0, 'S2-A rotation-no-clear: worker exits 0', r.stderr || '');
+  const last = lastAutofireEntry(root);
+  ok(!!last && last.outcome !== 'skipped_skeleton',
+    `S2-A rotation-no-clear: autofire seals the curated close instead of deferring on the rolling skeleton (outcome ${last?.outcome})`,
+    JSON.stringify(last));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S2-B CLEAR-BORN SESSION (Case-A guard): source=clear → excluded → skeleton defer.
+{
+  const { base, root } = mkSeat('s2b');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'),
+    curatedCap('capsule-CUR', 'active', '"review gate on the staged package"'));
+  writeCuratedPointer(root);
+  writeBootEvidence(root, LIVE_SID, 'clear');
+  const { rolling } = runAutofire(root);
+  const last = lastAutofireEntry(root);
+  ok(!!last && last.outcome === 'skipped_skeleton' && last.capsule_path === rolling,
+    'S2-B clear-born: pre-clear curated close stays excluded; falls back to the rolling anchor',
+    JSON.stringify(last));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S2-C CONSUMED CAPSULE: rotation without clear, capsule status:resumed → excluded.
+{
+  const { base, root } = mkSeat('s2c');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'),
+    curatedCap('capsule-CUR', 'resumed', '"still open"'));
+  writeCuratedPointer(root);
+  writeBootEvidence(root, LIVE_SID, 'resume');
+  const { rolling } = runAutofire(root);
+  const last = lastAutofireEntry(root);
+  ok(!!last && last.outcome === 'skipped_skeleton' && last.capsule_path === rolling,
+    'S2-C consumed: a status:resumed capsule is never re-sealed cross-session',
+    JSON.stringify(last));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S2-D NO BOOT EVIDENCE: fail closed → rolling skeleton → defer.
+{
+  const { base, root } = mkSeat('s2d');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'),
+    curatedCap('capsule-CUR', 'active', '"review gate on the staged package"'));
+  writeCuratedPointer(root);
+  const { rolling } = runAutofire(root);
+  const last = lastAutofireEntry(root);
+  ok(!!last && last.outcome === 'skipped_skeleton' && last.capsule_path === rolling,
+    'S2-D no-evidence: absent boot-evidence fails closed at the autofire too',
+    JSON.stringify(last));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S2-E SAME-SESSION FAST PATH UNTOUCHED: pointer stamped by the LIVE session —
+// accepted with no boot-evidence at all (pre-fix behavior, must not regress).
+{
+  const { base, root } = mkSeat('s2e');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'),
+    curatedCap('capsule-CUR', 'active', '"review gate on the staged package"'));
+  writeCuratedPointer(root, { sessionId: LIVE_SID });
+  const { r } = runAutofire(root);
+  ok(r.status === 0, 'S2-E same-session: worker exits 0', r.stderr || '');
+  const last = lastAutofireEntry(root);
+  ok(!!last && last.outcome !== 'skipped_skeleton',
+    `S2-E same-session: live-session curated pointer accepted without boot-evidence (outcome ${last?.outcome})`,
+    JSON.stringify(last));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ─── F2: null-session pointers stay HARD-REJECTED ───
+// curated-close-pointer.mjs deliberately stamps session_id:null when no --session
+// and no stop-writer record exists (fresh install / wiped runtime). Raw !==
+// accidentally hard-rejected these; the cross-session branch must never
+// conditionally accept them, even with qualifying boot-evidence.
+
+// S1-G (site 1): null-sid pointer + qualifying evidence → clobber still allowed.
+{
+  const { base, root } = mkSeat('s1g');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'), curatedCap('capsule-CUR', 'complete', 'null'));
+  writeCuratedPointer(root, { sessionId: null });
+  writeBootEvidence(root, LIVE_SID, 'resume');
+  runStopWriter(root, base);
+  const after = readPointer(root);
+  ok(after.id !== 'capsule-CUR' && after.trigger === 'stop-delta',
+    'S1-G null-sid: a session_id:null pointer is never cross-session protected',
+    JSON.stringify(after));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S2-F (site 2): null-sid pointer + qualifying evidence → skeleton defer.
+{
+  const { base, root } = mkSeat('s2f');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-CUR.md'), curatedCap('capsule-CUR', 'complete', 'null'));
+  writeCuratedPointer(root, { sessionId: null });
+  writeBootEvidence(root, LIVE_SID, 'resume');
+  const { rolling } = runAutofire(root);
+  const last = lastAutofireEntry(root);
+  ok(!!last && last.outcome === 'skipped_skeleton' && last.capsule_path === rolling,
+    'S2-F null-sid: a session_id:null pointer is never cross-session sealed',
+    JSON.stringify(last));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ─── S3: THE SHIP-BAR REPRO — real stamper + real SessionStart flip ───
+// Drives the REAL curated-close-pointer.mjs stamping, the REAL merged
+// sessionstart-reinject (which stamps boot-evidence AND owns the resume-flip),
+// then the REAL autofire — proving the seal fires within one cycle. The
+// structural gap this closes: fixtures that write pointers directly and never
+// run the real SessionStart cannot see the flip consuming the close before the
+// first poll.
+
+const CCP = process.env.CCP_DAEMON || path.resolve(__dirname, '..', 'curated-close-pointer.mjs');
+
+function capsuleStatus(root, rel) {
+  const doc = readFileSync(path.join(root, rel), 'utf8');
+  return (doc.match(/^status:[ \t]*['"]?(\S+?)['"]?[ \t]*$/m) || [])[1] || '';
+}
+
+function runRealStamp(root, capRel, sid) {
+  // The single-operator stamper spread-merges into BODY_STATE.json — seed it.
+  const bs = path.join(root, 'memory', 'BODY_STATE.json');
+  if (!existsSync(bs)) writeFileSync(bs, JSON.stringify({ state: {} }));
+  return execFileSync(process.execPath, [CCP, capRel, '--session', sid],
+    { encoding: 'utf8', cwd: root, env: { ...process.env, AIGENT_ROOT: root, CLAUDE_PROJECT_DIR: root } });
+}
+
+// S3-A: the livelock end to end through the REAL machinery. Session OLD stamps a
+// curated close (real stamper, real status:active capsule) → rotation to LIVE via
+// a non-clear boot (real reinject: boot-evidence stamp + flip decision) →
+// autofire polls once → MUST seal the close, not skip.
+{
+  const { base, root } = mkSeat('s3a');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-REAL.md'),
+    curatedCap('capsule-REAL', 'active', '"review gate on the staged package"'));
+  runRealStamp(root, 'memory/capsules/capsule-REAL.md', OLD_SID);
+  const ptr = JSON.parse(readFileSync(path.join(root, 'memory', 'BODY_STATE.json'), 'utf8')).state.last_capsule;
+  ok(ptr.trigger === 'curated-close' && ptr.session_id === OLD_SID && ptr.status === 'active',
+    'S3-A real-stamp: pointer carries the REAL schema (trigger, sid, status:active)', JSON.stringify(ptr));
+
+  runReinject(root, LIVE_SID, 'resume');
+  ok(capsuleStatus(root, 'memory/capsules/capsule-REAL.md') === 'active',
+    'S3-A real-flip: a curated close awaiting seal is NOT consumed by a rotation boot',
+    capsuleStatus(root, 'memory/capsules/capsule-REAL.md'));
+
+  const { r } = runAutofire(root);
+  ok(r.status === 0, 'S3-A: autofire worker exits 0', r.stderr || '');
+  const last = lastAutofireEntry(root);
+  ok(!!last && last.outcome !== 'skipped_skeleton',
+    `S3-A SHIP BAR: seal fires within ONE cycle through the real stamp+flip (outcome ${last?.outcome})`,
+    JSON.stringify(last));
+  rmSync(base, { recursive: true, force: true });
+}
+
+// S3-B: Case-A stays closed end to end — a CLEAR boot consumes the close (real
+// reinject flip on the clear path) and the autofire correctly falls back.
+{
+  const { base, root } = mkSeat('s3b');
+  writeFileSync(path.join(root, 'memory', 'capsules', 'capsule-REAL.md'),
+    curatedCap('capsule-REAL', 'active', '"review gate on the staged package"'));
+  runRealStamp(root, 'memory/capsules/capsule-REAL.md', OLD_SID);
+  // stop-writer record for OLD (the session being cleared) so the clear-barrier resolves it
+  writeFileSync(path.join(root, 'memory', 'runtime', 'stop-writer', `${OLD_SID}.json`),
+    JSON.stringify({ capsule_path: path.join(root, 'memory', 'capsules', 'capsule-REAL.md') }));
+
+  runReinject(root, LIVE_SID, 'clear');
+  ok(capsuleStatus(root, 'memory/capsules/capsule-REAL.md') === 'resumed',
+    'S3-B clear-boot: the clear-path flip still consumes the close (Case-A trace intact)',
+    capsuleStatus(root, 'memory/capsules/capsule-REAL.md'));
+
+  const { rolling } = runAutofire(root);
+  const last = lastAutofireEntry(root);
+  ok(!!last && last.outcome === 'skipped_skeleton' && last.capsule_path === rolling,
+    'S3-B Case-A: post-clear session never seals the pre-clear close',
+    JSON.stringify(last));
+  rmSync(base, { recursive: true, force: true });
+}
+
+console.log(`\n${pass} passed, ${fail} failed.`);
+process.exit(fail === 0 ? 0 : 1);

--- a/daemons/tests/lifecycle-flip.test.mjs
+++ b/daemons/tests/lifecycle-flip.test.mjs
@@ -10,8 +10,11 @@
 //   - CONFIRMED-5: already-resumed is STEADY-STATE (not drift, not an error)
 //   - malformed frontmatter logs, never a silent no-op
 //   - compact is NOT a resume — capsule untouched
-//   - startup, resume, and clear ALL flip (folding what used to be two separate
-//     per-source scripts into this one hook's source-agnostic anchor step)
+//   - clear ALWAYS flips (boot-native Case-A consumption); startup/resume flip
+//     UNLESS the pointer is a curated close inside its seal window — that close
+//     is AWAITING SEAL and the flip DEFERS (the livelock fix: consuming it
+//     handed the autofire's consumed-gate the exact close it protects). A
+//     stale-window or non-curated pointer flips on rotation boots as before.
 //
 // FIXTURE SHAPE: field list/order and the null-placeholder pair mirror a real
 // autosave capsule's frontmatter shape (see stop-capsule-writer.mjs's skeleton()).
@@ -76,6 +79,10 @@ function fixture(label, opts = {}) {
   mkdirSync(capDir, { recursive: true });
   const capPath = path.join(capDir, 'test-capsule.md');
   writeFileSync(capPath, realFrontmatter(opts));
+  // Pointer defaults to the curated-close-in-window shape (a close AWAITING
+  // SEAL — the defer path). Flip-mechanics tests override pointerTrigger or
+  // pointerFinalizedAgoMs to stay on the flip path.
+  const { pointerTrigger = 'curated-close', pointerFinalizedAgoMs = 0 } = opts;
   writeFileSync(path.join(root, 'memory', 'BODY_STATE.json'), JSON.stringify({
     state: {
       last_capsule: {
@@ -83,9 +90,9 @@ function fixture(label, opts = {}) {
         path: 'memory/capsules/test-capsule.md',
         status: 'active',
         objective: 'prove the flip',
-        trigger: 'curated-close',
+        trigger: pointerTrigger,
         session_id: 'prev-sid',
-        finalized_at: new Date().toISOString(),
+        finalized_at: new Date(Date.now() - pointerFinalizedAgoMs).toISOString(),
       },
     },
   }));
@@ -201,16 +208,27 @@ console.log('-- lifecycle-flip suite --');
   rmSync(base, { recursive: true, force: true });
 }
 
-// 6. source=startup flips too (folds what used to be a separate cold-start script
-// into this one hook's source-agnostic anchor step).
+// 6. source=startup on a curated-close-in-window pointer DEFERS (the livelock
+// fix): the close is awaiting seal — announced as deferred, capsule untouched.
 {
   const { base, root, capPath } = fixture('startup');
+  const before = readFileSync(capPath, 'utf8');
   const r = runReinject(root, 'startup', 'newsid-7777');
   const doc = readFileSync(capPath, 'utf8');
   ok(r.status === 0, 'startup run exits 0', r.stderr || '');
   ok(/ACTIVE CAPSULE/.test(r.stdout), 'pointer table still prints on startup');
-  ok(/resume-flip.*finalize-lock released/.test(r.stdout), 'flip announced on startup');
-  ok(/^status: resumed$/m.test(doc), 'frontmatter status flipped to resumed (startup)');
+  ok(/resume-flip\] deferred/.test(r.stdout), 'defer announced on startup (curated close awaiting seal)');
+  ok(doc === before, 'deferred flip leaves the capsule byte-identical (still status: active)');
+  rmSync(base, { recursive: true, force: true });
+}
+
+// 6b. source=startup with a NON-curated pointer still flips (mechanics intact).
+{
+  const { base, root, capPath } = fixture('startup-noncurated', { pointerTrigger: 'refresh-cycle' });
+  const r = runReinject(root, 'startup', 'newsid-7777');
+  const doc = readFileSync(capPath, 'utf8');
+  ok(/resume-flip.*finalize-lock released/.test(r.stdout), 'flip announced on startup (non-curated pointer)');
+  ok(/^status: resumed$/m.test(doc), 'frontmatter status flipped to resumed (startup, non-curated)');
   const stamps = stampLines(doc);
   ok(stamps.length === 2, `exactly one resumed_at + one resumed_by_session line survives (startup dedupe), got ${stamps.length}`, JSON.stringify(stamps));
   ok(/^resumed_by_session: newsid-7/.test(stamps[1] || ''), 'resume stamps written', JSON.stringify(stamps));
@@ -218,13 +236,26 @@ console.log('-- lifecycle-flip suite --');
   rmSync(base, { recursive: true, force: true });
 }
 
-// 7. source=resume flips identically.
+// 6c. source=startup with a curated pointer past its seal window still flips —
+// cross-session protection stays window-bounded.
+{
+  const { base, root, capPath } = fixture('startup-stale', { pointerFinalizedAgoMs: 2 * 3600e3 });
+  const r = runReinject(root, 'startup', 'newsid-7777');
+  const doc = readFileSync(capPath, 'utf8');
+  ok(/resume-flip.*finalize-lock released/.test(r.stdout), 'flip announced on startup (window lapsed)');
+  ok(/^status: resumed$/m.test(doc), 'frontmatter status flipped to resumed (startup, stale window)');
+  rmSync(base, { recursive: true, force: true });
+}
+
+// 7. source=resume defers identically on a curated-close-in-window pointer.
 {
   const { base, root, capPath } = fixture('resume');
+  const before = readFileSync(capPath, 'utf8');
   const r = runReinject(root, 'resume', 'newsid-8888');
   const doc = readFileSync(capPath, 'utf8');
   ok(r.status === 0, 'resume run exits 0', r.stderr || '');
-  ok(/^status: resumed$/m.test(doc), 'frontmatter status flipped to resumed (source=resume)');
+  ok(/resume-flip\] deferred/.test(r.stdout), 'defer announced on resume (curated close awaiting seal)');
+  ok(doc === before, 'deferred flip leaves the capsule byte-identical (source=resume)');
   rmSync(base, { recursive: true, force: true });
 }
 


### PR DESCRIPTION
## What

v0.9.0 shipped the two-verb lifecycle with a livelock: a seat whose session rotated **without** a clear could hold a valid finalized curated close that neither the stop-writer's clobber protection nor the autofire sealer could see (raw `session_id === sid` equality at three sites) — while the boot-time resume-flip consumed the exact close the sealer still needed. Observed on the reference fleet as ~7h of `skipped_skeleton` → `hold_starvation` abort/re-arm cycles until an operator clear.

## How

- **`crossSessionCuratedAllowed()`** (lifecycle-common): a cross-session curated pointer stays authoritative iff it's inside its seal window **+** `boot-evidence.json` proves the live session was *not born from a clear* **+** the capsule isn't already consumed (`status: resumed`). Falsy pointer `session_id` hard-rejected.
- **`stampBootEvidence()`**: this repo shipped with no boot evidence at all — now stamped from the merged SessionStart hook on every source, so existing installs get it on a plain `git pull` (no settings migration). Schema `{sid, source, nonce, ts}`.
- **`resumeFlipShouldDefer()`**: the resume-flip defers for a curated close inside its seal window on non-clear rotation boots; clear boots always consume (Case-A semantics preserved).
- All three session-equality sites share the discriminator; consumed-status regex + window computation centralized.

## Verification

- Red-first: rotation suite fails exactly on the livelock signatures against pristine daemons; 26/26 post-fix — including an **S3 realism group that drives the real pointer stamper, the real SessionStart flip, and the real autofire worker**.
- lifecycle-flip suite reconciled to the defer contract: 48/48.
- Full daemons suite: all 13 suites exit 0 on pristine master + this patch.
- Three-round independent review gate (finder fan-out + adversarial verifiers) before merge; round-1 caught the resume-flip interaction that fixture-only tests structurally missed.

Board: c1f777e9 · Authored by the davinci seat, gated by titus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Px59mThvCXn7HWH5tz4XRt