### PR TITLE
feat(install): remote bootstrap one-liner (web-install.sh + web-install.ps1)

### DIFF
--- a/scripts/web-install.ps1
+++ b/scripts/web-install.ps1
@@ -10,14 +10,25 @@
 # PowerShell 5.1 and PowerShell 7+ compatible. No param() block (breaks
 # under "irm | iex"), no Read-Host, no interactive prompts. Safe to re-run.
 #
-# All logic lives inside a function and uses 'return' instead of 'exit' so
-# that a failure never closes the caller's interactive shell when this
-# script arrives via "irm | iex". 'exit' only fires when this file is run
-# directly as a .ps1 (a real child process, where closing it is correct).
+# All logic lives inside a function and uses 'return' instead of 'exit', and
+# 'exit' only runs at the very end, gated on $MyInvocation.MyCommand.Path.
+# That gate is non-empty whenever this text is loaded FROM A FILE -- both
+# "pwsh -File web-install.ps1" (a real child process, where exiting is
+# correct) and dot-sourcing a saved copy into the CURRENT session (where
+# calling exit would still close the caller's shell, same as it would for
+# any dot-sourced script). It is empty only when the text arrives inline via
+# "irm | iex", which is the one-liner this script ships as -- that is the
+# case this gate exists to protect, and it is exercised by that command.
+# Prefer "& .\web-install.ps1" (or just double-click / pwsh -File) over
+# dot-sourcing a saved copy if you want exit codes to never touch your shell.
 
 function Invoke-AigentOSInstall {
     $repoUrl = 'https://github.com/wrg32786/aigent-os.git'
-    $repoMatch = 'wrg32786/aigent-os'
+
+    function TrimGitSuffix([string]$url) {
+        if ($url -and $url.EndsWith('.git')) { return $url.Substring(0, $url.Length - 4) }
+        return $url
+    }
 
     if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
         Write-Host ""
@@ -43,9 +54,24 @@ function Invoke-AigentOSInstall {
         return 1
     }
 
+    # If $HOME is unset or empty (uncommon, but possible in some restricted
+    # or non-interactive hosts), Join-Path collapses this to the relative
+    # path ".\aigent-os" resolved against the current directory instead of
+    # the user's home -- not dangerous, just possibly not where they expect.
     $targetDir = $env:AIGENT_OS_DIR
     if ([string]::IsNullOrWhiteSpace($targetDir)) {
         $targetDir = Join-Path $HOME 'aigent-os'
+    }
+
+    # A directory starting with "-" would be misread as an option by any
+    # command that takes it as a positional argument (e.g. git clone).
+    # Reject it outright rather than relying solely on "--" below.
+    if ($targetDir.StartsWith('-')) {
+        Write-Host ""
+        Write-Host "[aigent-OS installer] ERROR: `$env:AIGENT_OS_DIR must not start with '-' (got: $targetDir)."
+        Write-Host "Use an absolute path instead."
+        Write-Host ""
+        return 1
     }
 
     if (Test-Path -LiteralPath $targetDir -PathType Leaf) {
@@ -68,7 +94,12 @@ function Invoke-AigentOSInstall {
         $null = & git -C $targetDir rev-parse --is-inside-work-tree 2>$null
         if ($LASTEXITCODE -eq 0) {
             $remoteUrl = & git -C $targetDir remote get-url origin 2>$null
-            if ($LASTEXITCODE -eq 0 -and $remoteUrl -match [regex]::Escape($repoMatch)) {
+            # Exact match only (not a substring/regex test): the local git
+            # config at $targetDir is attacker-controlled input. A loose match
+            # would accept any origin that merely CONTAINS our org/repo name
+            # (a redirect URL, a query string, a lookalike subdomain) without
+            # actually being our repo. Normalize a trailing .git either side.
+            if ($LASTEXITCODE -eq 0 -and (TrimGitSuffix $remoteUrl) -eq (TrimGitSuffix $repoUrl)) {
                 $isOurRepo = $true
             }
         }
@@ -86,6 +117,18 @@ function Invoke-AigentOSInstall {
 
     if ($isOurRepo) {
         Write-Host "Existing aigent-OS checkout found at $targetDir. Pulling latest..."
+        # Pin origin to the canonical URL before pulling. The gate check above
+        # decides whether this looks like our checkout, but the actual fetch
+        # never relies on trusting whatever the local git config had
+        # configured -- it always pulls from the URL this script hardcodes.
+        & git -C $targetDir remote set-url origin $repoUrl
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host ""
+            Write-Host "[aigent-OS installer] ERROR: could not set the origin remote in $targetDir."
+            Write-Host "Resolve manually, then re-run."
+            Write-Host ""
+            return 1
+        }
         & git -C $targetDir pull --ff-only
         if ($LASTEXITCODE -ne 0) {
             Write-Host ""
@@ -96,7 +139,7 @@ function Invoke-AigentOSInstall {
         }
     } else {
         Write-Host "Cloning aigent-OS into $targetDir ..."
-        & git clone $repoUrl $targetDir
+        & git clone -- $repoUrl $targetDir
         if ($LASTEXITCODE -ne 0) {
             Write-Host ""
             Write-Host "[aigent-OS installer] ERROR: git clone failed. Check your network connection and try again."
@@ -122,7 +165,10 @@ $aigentInstallExitCode = Invoke-AigentOSInstall
 # Only exit the process when this file is actually running as a script file
 # (a dedicated child process). When the same text arrives via "irm | iex",
 # $MyInvocation.MyCommand.Path is empty and calling exit here would close
-# the user's interactive shell -- so it's skipped.
+# the user's interactive shell -- so it's skipped. See the header comment
+# above: this same emptiness gate does NOT distinguish dot-sourcing a saved
+# copy from a real child process -- dot-sourcing still sets a non-empty
+# path, so exit still fires there too.
 if ($MyInvocation.MyCommand.Path) {
     exit $aigentInstallExitCode
 }

--- a/scripts/web-install.ps1
+++ b/scripts/web-install.ps1
@@ -1,0 +1,128 @@
+# aigent-OS remote installer (Windows)
+# Fetches aigent-OS onto disk. Run via:
+#   irm https://tools.theaigent.xyz/os/install.ps1 | iex
+#
+# This script only clones/updates the aigent-OS checkout. It does not run
+# the framework installer itself -- that stays a separate, inspectable local
+# step (bash install.sh), per docs/install-security.md's "no remote-fetch-
+# and-execute" guarantee for the framework installer.
+#
+# PowerShell 5.1 and PowerShell 7+ compatible. No param() block (breaks
+# under "irm | iex"), no Read-Host, no interactive prompts. Safe to re-run.
+#
+# All logic lives inside a function and uses 'return' instead of 'exit' so
+# that a failure never closes the caller's interactive shell when this
+# script arrives via "irm | iex". 'exit' only fires when this file is run
+# directly as a .ps1 (a real child process, where closing it is correct).
+
+function Invoke-AigentOSInstall {
+    $repoUrl = 'https://github.com/wrg32786/aigent-os.git'
+    $repoMatch = 'wrg32786/aigent-os'
+
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Write-Host ""
+        Write-Host "[aigent-OS installer] ERROR: git was not found on your PATH."
+        Write-Host ""
+        Write-Host "git is required to download aigent-OS. Install it, then re-run this command:"
+        Write-Host "  winget install --id Git.Git -e"
+        Write-Host "  or: https://git-scm.com/downloads"
+        Write-Host ""
+        return 1
+    }
+
+    if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
+        Write-Host ""
+        Write-Host "[aigent-OS installer] ERROR: Claude Code was not found on your PATH."
+        Write-Host ""
+        Write-Host "aigent-OS runs inside Claude Code, so it needs to be installed first:"
+        Write-Host "  npm install -g @anthropic-ai/claude-code"
+        Write-Host ""
+        Write-Host "No Node.js/npm, or want another install option? See https://claude.ai/code"
+        Write-Host "Then re-run this command."
+        Write-Host ""
+        return 1
+    }
+
+    $targetDir = $env:AIGENT_OS_DIR
+    if ([string]::IsNullOrWhiteSpace($targetDir)) {
+        $targetDir = Join-Path $HOME 'aigent-os'
+    }
+
+    if (Test-Path -LiteralPath $targetDir -PathType Leaf) {
+        Write-Host ""
+        Write-Host "[aigent-OS installer] ERROR: $targetDir already exists and is a file, not a directory."
+        Write-Host 'Set $env:AIGENT_OS_DIR to a different path and re-run this command.'
+        Write-Host ""
+        return 1
+    }
+
+    $dirExists = Test-Path -LiteralPath $targetDir -PathType Container
+    $dirEmpty = $true
+    if ($dirExists) {
+        $existingItems = Get-ChildItem -LiteralPath $targetDir -Force -ErrorAction SilentlyContinue
+        $dirEmpty = (($existingItems | Measure-Object).Count -eq 0)
+    }
+
+    $isOurRepo = $false
+    if ($dirExists -and -not $dirEmpty) {
+        $null = & git -C $targetDir rev-parse --is-inside-work-tree 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            $remoteUrl = & git -C $targetDir remote get-url origin 2>$null
+            if ($LASTEXITCODE -eq 0 -and $remoteUrl -match [regex]::Escape($repoMatch)) {
+                $isOurRepo = $true
+            }
+        }
+    }
+
+    if ($dirExists -and -not $dirEmpty -and -not $isOurRepo) {
+        Write-Host ""
+        Write-Host "[aigent-OS installer] ERROR: $targetDir already exists and is not an aigent-OS checkout."
+        Write-Host "Nothing was changed. Point somewhere else with:"
+        Write-Host '  $env:AIGENT_OS_DIR = "C:\path\you\want"'
+        Write-Host "then re-run this command."
+        Write-Host ""
+        return 1
+    }
+
+    if ($isOurRepo) {
+        Write-Host "Existing aigent-OS checkout found at $targetDir. Pulling latest..."
+        & git -C $targetDir pull --ff-only
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host ""
+            Write-Host "[aigent-OS installer] ERROR: git pull failed in $targetDir."
+            Write-Host "Check for local changes or a diverged branch, resolve manually, then re-run."
+            Write-Host ""
+            return 1
+        }
+    } else {
+        Write-Host "Cloning aigent-OS into $targetDir ..."
+        & git clone $repoUrl $targetDir
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host ""
+            Write-Host "[aigent-OS installer] ERROR: git clone failed. Check your network connection and try again."
+            Write-Host ""
+            return 1
+        }
+    }
+
+    Write-Host ""
+    Write-Host "aigent-OS is ready at: $targetDir"
+    Write-Host ""
+    Write-Host "Next steps:"
+    Write-Host "  1. cd `"$targetDir`""
+    Write-Host "  2. bash install.sh"
+    Write-Host "  3. Open Claude Code in that directory (or run: claude)"
+    Write-Host "     First time in this directory, run /start to complete setup."
+    Write-Host ""
+    return 0
+}
+
+$aigentInstallExitCode = Invoke-AigentOSInstall
+
+# Only exit the process when this file is actually running as a script file
+# (a dedicated child process). When the same text arrives via "irm | iex",
+# $MyInvocation.MyCommand.Path is empty and calling exit here would close
+# the user's interactive shell -- so it's skipped.
+if ($MyInvocation.MyCommand.Path) {
+    exit $aigentInstallExitCode
+}

--- a/scripts/web-install.sh
+++ b/scripts/web-install.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# aigent-OS remote installer (macOS/Linux)
+# Fetches aigent-OS onto disk. Run via:
+#   curl -fsSL https://tools.theaigent.xyz/os/install | sh
+#
+# This script only clones/updates the aigent-OS checkout. It does not run
+# the framework installer itself -- that stays a separate, inspectable local
+# step (bash install.sh), per docs/install-security.md's "no remote-fetch-
+# and-execute" guarantee for the framework installer.
+#
+# POSIX sh. No bashisms, no sudo, no interactive prompts. Safe to re-run.
+
+set -eu
+
+REPO_URL="https://github.com/wrg32786/aigent-os.git"
+REPO_MATCH="wrg32786/aigent-os"
+
+fail() {
+  printf '\n[aigent-OS installer] ERROR: %s\n\n' "$*" >&2
+  exit 1
+}
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+dir_is_empty() {
+  [ -z "$(ls -A "$1" 2>/dev/null)" ]
+}
+
+is_our_repo() {
+  git -C "$1" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+  remote_url="$(git -C "$1" remote get-url origin 2>/dev/null)" || return 1
+  case "$remote_url" in
+    *"$REPO_MATCH"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if ! command_exists git; then
+  printf '\n[aigent-OS installer] ERROR: git was not found on your PATH.\n\n'
+  printf 'git is required to download aigent-OS. Install it, then re-run this command:\n'
+  printf '  macOS:         xcode-select --install   (or: brew install git)\n'
+  printf '  Debian/Ubuntu: sudo apt-get install git\n'
+  printf '  Fedora:        sudo dnf install git\n'
+  printf '  Other:         https://git-scm.com/downloads\n\n'
+  exit 1
+fi
+
+if ! command_exists claude; then
+  printf '\n[aigent-OS installer] ERROR: Claude Code was not found on your PATH.\n\n'
+  printf 'aigent-OS runs inside Claude Code, so it needs to be installed first:\n'
+  printf '  npm install -g @anthropic-ai/claude-code\n\n'
+  printf 'No Node.js/npm, or want another install option? See https://claude.ai/code\n'
+  printf 'Then re-run this command.\n\n'
+  exit 1
+fi
+
+TARGET_DIR="${AIGENT_OS_DIR:-$HOME/aigent-os}"
+
+if [ -e "$TARGET_DIR" ] && [ ! -d "$TARGET_DIR" ]; then
+  fail "$TARGET_DIR already exists and is a file, not a directory.
+Set AIGENT_OS_DIR to a different path and re-run this command."
+fi
+
+IS_OUR_REPO=0
+if [ -d "$TARGET_DIR" ] && ! dir_is_empty "$TARGET_DIR"; then
+  if is_our_repo "$TARGET_DIR"; then
+    IS_OUR_REPO=1
+  else
+    fail "$TARGET_DIR already exists and is not an aigent-OS checkout.
+Nothing was changed. Point somewhere else with:
+  AIGENT_OS_DIR=/path/you/want curl -fsSL https://tools.theaigent.xyz/os/install | sh"
+  fi
+fi
+
+if [ "$IS_OUR_REPO" -eq 1 ]; then
+  printf 'Existing aigent-OS checkout found at %s. Pulling latest...\n' "$TARGET_DIR"
+  if ! git -C "$TARGET_DIR" pull --ff-only; then
+    fail "git pull failed in $TARGET_DIR.
+Check for local changes or a diverged branch, resolve manually, then re-run."
+  fi
+else
+  printf 'Cloning aigent-OS into %s ...\n' "$TARGET_DIR"
+  if ! git clone "$REPO_URL" "$TARGET_DIR"; then
+    fail "git clone failed. Check your network connection and try again."
+  fi
+fi
+
+printf '\naigent-OS is ready at: %s\n\n' "$TARGET_DIR"
+printf 'Next steps:\n'
+printf '  1. cd %s\n' "$TARGET_DIR"
+printf '  2. bash install.sh\n'
+printf '  3. Open Claude Code in that directory (or run: claude)\n'
+printf '     First time in this directory, run /start to complete setup.\n\n'

--- a/scripts/web-install.sh
+++ b/scripts/web-install.sh
@@ -9,6 +9,14 @@
 # and-execute" guarantee for the framework installer.
 #
 # POSIX sh. No bashisms, no sudo, no interactive prompts. Safe to re-run.
+#
+# Everything below is wrapped in main() and only invoked via the literal
+# "main \"$@\"" on the last line, so a truncated curl|sh stream (connection
+# drop mid-download) either fails as an incomplete function definition or,
+# if it happens to cut off right after main() closes but before the call
+# line is reached, simply defines the function and does nothing. Either
+# way a partial script never half-executes. Mirrors the same function +
+# single-invocation shape used in web-install.ps1.
 
 set -eu
 
@@ -31,65 +39,93 @@ dir_is_empty() {
 is_our_repo() {
   git -C "$1" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
   remote_url="$(git -C "$1" remote get-url origin 2>/dev/null)" || return 1
+  # Exact match only (not a substring test): the local git config at $1 is
+  # attacker-controlled input. A substring test like *"$REPO_MATCH"* would
+  # accept any origin that merely CONTAINS "wrg32786/aigent-os" somewhere
+  # (a redirect URL, a query string, a lookalike subdomain) without actually
+  # being our repo. Normalize a trailing .git on either side, nothing else.
   case "$remote_url" in
-    *"$REPO_MATCH"*) return 0 ;;
+    "$REPO_URL" | "${REPO_URL%.git}") return 0 ;;
     *) return 1 ;;
   esac
 }
 
-if ! command_exists git; then
-  printf '\n[aigent-OS installer] ERROR: git was not found on your PATH.\n\n'
-  printf 'git is required to download aigent-OS. Install it, then re-run this command:\n'
-  printf '  macOS:         xcode-select --install   (or: brew install git)\n'
-  printf '  Debian/Ubuntu: sudo apt-get install git\n'
-  printf '  Fedora:        sudo dnf install git\n'
-  printf '  Other:         https://git-scm.com/downloads\n\n'
-  exit 1
-fi
+main() {
+  if ! command_exists git; then
+    printf '\n[aigent-OS installer] ERROR: git was not found on your PATH.\n\n'
+    printf 'git is required to download aigent-OS. Install it, then re-run this command:\n'
+    printf '  macOS:         xcode-select --install   (or: brew install git)\n'
+    printf '  Debian/Ubuntu: sudo apt-get install git\n'
+    printf '  Fedora:        sudo dnf install git\n'
+    printf '  Other:         https://git-scm.com/downloads\n\n'
+    exit 1
+  fi
 
-if ! command_exists claude; then
-  printf '\n[aigent-OS installer] ERROR: Claude Code was not found on your PATH.\n\n'
-  printf 'aigent-OS runs inside Claude Code, so it needs to be installed first:\n'
-  printf '  npm install -g @anthropic-ai/claude-code\n\n'
-  printf 'No Node.js/npm, or want another install option? See https://claude.ai/code\n'
-  printf 'Then re-run this command.\n\n'
-  exit 1
-fi
+  if ! command_exists claude; then
+    printf '\n[aigent-OS installer] ERROR: Claude Code was not found on your PATH.\n\n'
+    printf 'aigent-OS runs inside Claude Code, so it needs to be installed first:\n'
+    printf '  npm install -g @anthropic-ai/claude-code\n\n'
+    printf 'No Node.js/npm, or want another install option? See https://claude.ai/code\n'
+    printf 'Then re-run this command.\n\n'
+    exit 1
+  fi
 
-TARGET_DIR="${AIGENT_OS_DIR:-$HOME/aigent-os}"
+  # If $HOME is unset (rare -- some minimal/containerized shells), this
+  # collapses to the absolute path "/aigent-os". git will surface a clear
+  # permission or not-found error there rather than silently doing anything
+  # unsafe, but it will not be the directory the user expected.
+  TARGET_DIR="${AIGENT_OS_DIR:-$HOME/aigent-os}"
 
-if [ -e "$TARGET_DIR" ] && [ ! -d "$TARGET_DIR" ]; then
-  fail "$TARGET_DIR already exists and is a file, not a directory.
+  # A directory starting with "-" would be misread as an option by any
+  # command that takes it as a positional argument (e.g. git clone). Reject
+  # it outright rather than relying solely on the "--" below.
+  case "$TARGET_DIR" in
+    -*) fail "AIGENT_OS_DIR must not start with '-' (got: $TARGET_DIR).
+Use an absolute path instead, e.g. AIGENT_OS_DIR=\"\$HOME/aigent-os\"." ;;
+  esac
+
+  if [ -e "$TARGET_DIR" ] && [ ! -d "$TARGET_DIR" ]; then
+    fail "$TARGET_DIR already exists and is a file, not a directory.
 Set AIGENT_OS_DIR to a different path and re-run this command."
-fi
+  fi
 
-IS_OUR_REPO=0
-if [ -d "$TARGET_DIR" ] && ! dir_is_empty "$TARGET_DIR"; then
-  if is_our_repo "$TARGET_DIR"; then
-    IS_OUR_REPO=1
-  else
-    fail "$TARGET_DIR already exists and is not an aigent-OS checkout.
+  IS_OUR_REPO=0
+  if [ -d "$TARGET_DIR" ] && ! dir_is_empty "$TARGET_DIR"; then
+    if is_our_repo "$TARGET_DIR"; then
+      IS_OUR_REPO=1
+    else
+      fail "$TARGET_DIR already exists and is not an aigent-OS checkout.
 Nothing was changed. Point somewhere else with:
   AIGENT_OS_DIR=/path/you/want curl -fsSL https://tools.theaigent.xyz/os/install | sh"
+    fi
   fi
-fi
 
-if [ "$IS_OUR_REPO" -eq 1 ]; then
-  printf 'Existing aigent-OS checkout found at %s. Pulling latest...\n' "$TARGET_DIR"
-  if ! git -C "$TARGET_DIR" pull --ff-only; then
-    fail "git pull failed in $TARGET_DIR.
+  if [ "$IS_OUR_REPO" -eq 1 ]; then
+    printf 'Existing aigent-OS checkout found at %s. Pulling latest...\n' "$TARGET_DIR"
+    # Pin origin to the canonical URL before pulling. The gate check above
+    # decides whether this looks like our checkout, but the actual fetch
+    # never relies on trusting whatever the local git config had configured
+    # -- it always pulls from the URL this script itself hardcodes.
+    if ! git -C "$TARGET_DIR" remote set-url origin "$REPO_URL"; then
+      fail "could not set the origin remote in $TARGET_DIR. Resolve manually, then re-run."
+    fi
+    if ! git -C "$TARGET_DIR" pull --ff-only; then
+      fail "git pull failed in $TARGET_DIR.
 Check for local changes or a diverged branch, resolve manually, then re-run."
+    fi
+  else
+    printf 'Cloning aigent-OS into %s ...\n' "$TARGET_DIR"
+    if ! git clone -- "$REPO_URL" "$TARGET_DIR"; then
+      fail "git clone failed. Check your network connection and try again."
+    fi
   fi
-else
-  printf 'Cloning aigent-OS into %s ...\n' "$TARGET_DIR"
-  if ! git clone "$REPO_URL" "$TARGET_DIR"; then
-    fail "git clone failed. Check your network connection and try again."
-  fi
-fi
 
-printf '\naigent-OS is ready at: %s\n\n' "$TARGET_DIR"
-printf 'Next steps:\n'
-printf '  1. cd %s\n' "$TARGET_DIR"
-printf '  2. bash install.sh\n'
-printf '  3. Open Claude Code in that directory (or run: claude)\n'
-printf '     First time in this directory, run /start to complete setup.\n\n'
+  printf '\naigent-OS is ready at: %s\n\n' "$TARGET_DIR"
+  printf 'Next steps:\n'
+  printf '  1. cd %s\n' "$TARGET_DIR"
+  printf '  2. bash install.sh\n'
+  printf '  3. Open Claude Code in that directory (or run: claude)\n'
+  printf '     First time in this directory, run /start to complete setup.\n\n'
+}
+
+main "$@"


### PR DESCRIPTION
One-liner clone bootstrap serving tools.theaigent.xyz/os/install and /os/install.ps1.

- Deliberately separate from root install.sh, preserving docs/install-security.md's no-remote-fetch-and-execute guarantee for the framework installer — these scripts only clone/ff-pull the checkout and print the documented next steps.
- Preflights git + Claude Code with friendly guidance; refuses non-repo target dirs; no sudo, no prompts; idempotent re-run.
- Security-gated (Rule-26, 2 rounds): main()-wrapped against truncated-stream execution (cut-point proofs at 3 sizes), exact-URL origin trust + set-url before pull (substring-hijack proven then closed), `--` separators + leading-dash rejection, ps1 iex-safety (function-wrapped, return-not-exit, no shell kill under irm|iex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Px59mThvCXn7HWH5tz4XRt