### PR TITLE
docs(install): fix stale two-verb language + document all three install paths

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,11 +2,29 @@
 
 **One step. The OS sets itself up.**
 
+## From a downloaded folder
+
 1. **Unzip** this folder anywhere you like.
 2. **Drag the folder into Claude Code** (or open Claude Code in this directory).
 3. **Say:** `install this`
 
 That's it. aigent-OS reads its own installer and sets itself up.
+
+## From a URL, no download
+
+Paste `https://github.com/wrg32786/aigent-os` into any Claude Code session and say `install this`. Claude clones the repo and follows this file.
+
+## Fastest: one-line bootstrap
+
+```bash
+curl -fsSL https://tools.theaigent.xyz/os/install | sh
+```
+
+```powershell
+irm https://tools.theaigent.xyz/os/install.ps1 | iex
+```
+
+This clones aigent-OS to `~/aigent-os` and prints the next steps: `cd` into it, run `bash install.sh`, then open Claude Code there.
 
 ---
 
@@ -14,7 +32,7 @@ That's it. aigent-OS reads its own installer and sets itself up.
 
 - aigent-OS copies its kernel files into place and writes a `.claude/settings.json` wired to your actual paths.
 - It installs semantic search if Node.js is present (optional — it works fine without it).
-- It tells you to start a fresh conversation and run `/open`. From there, just talk.
+- It tells you to start a fresh conversation and run `/start`.
 
 ---
 
@@ -23,10 +41,10 @@ That's it. aigent-OS reads its own installer and sets itself up.
 Start a new Claude Code conversation in this directory and type:
 
 ```
-/open
+/start
 ```
 
-aigent-OS boots with full context. Work normally — it handles routing, memory, and delegation. When you're done, run `/close` and it saves everything for next time.
+`/start` completes first-run setup and learns your context. After that, sessions resume themselves — no `/open`, no `/close`, ever. `/context-capsule` and `/resume` still exist if you want to force a checkpoint or reload on demand.
 
 **Optional:** open the `vault/` folder in [Obsidian](https://obsidian.md) to see your AI's knowledge graph visually.
 


### PR DESCRIPTION
- Removes retired /open and /close instructions (v0.9 two-verb lifecycle) — first run is /start; sessions resume themselves after.
- Documents the three install paths: downloaded folder + "install this", paste-URL + "install this", and the canonical one-line bootstraps (scripts/web-install.*, live on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Px59mThvCXn7HWH5tz4XRt