### PR TITLE
daemons: close_kind contract — finalize-freeze gate, completion stamp, checkpoint wiring (c1f777e9 v3)

### DIFF
--- a/daemons/capsule-verb.mjs
+++ b/daemons/capsule-verb.mjs
@@ -694,6 +694,18 @@ export async function runCapsuleVerb({
     '--reconciled', JSON.stringify(reconciled),
     '--reconcile-digest', digests.reconcile_digest,
     '--capsule-sha256', digests.capsule_sha256,
+    // R2-1(a) (gate round-2, board c1f777e9): every capture this verb makes —
+    // cycle-driven (RefreshRequest-gated autofire) or legacy non-cycle — is a
+    // MACHINERY capture, never an operator-authored session-completion close.
+    // Both are checkpoint-class by construction (see the capture-mode findings
+    // in davinci-vault handoff/livelock-fix-c1f777e9/): this verb has exactly
+    // one caller (ctx-refresh-sensor.mjs) and neither of its two call sites
+    // represents a completion close. Unconditional, not read from any input
+    // here — inventing a completion signal this verb doesn't actually have
+    // would be a guess. Non-waking regardless: the staged-close wake
+    // discriminator requires close_kind==='completion', so 'checkpoint' here
+    // can never fire it.
+    '--close-kind', 'checkpoint',
   ];
   if (cursor !== null) writerArgs.push('--captured-through-event', cursor);
   if (cursorOffset !== null) writerArgs.push('--captured-through-offset', String(cursorOffset));

--- a/daemons/curated-close-pointer.mjs
+++ b/daemons/curated-close-pointer.mjs
@@ -50,7 +50,7 @@
 
 import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
-import { memRoot, seatOf } from './lifecycle-common.mjs';
+import { memRoot, seatOf, CLOSE_KINDS } from './lifecycle-common.mjs';
 
 function fail(msg) {
   console.error(`[curated-close-pointer] REFUSED: ${msg}`);
@@ -102,7 +102,9 @@ if (ctoRaw !== null) {
 
 // close_kind is a CLOSED enum (unlike the free-form fields above) — refuse loudly on
 // an unrecognized value rather than stamping something no downstream reader expects.
-const CLOSE_KINDS = new Set(['checkpoint', 'completion', 'handoff']);
+// CLOSE_KINDS is single-sourced in lifecycle-common.mjs (gate round-2 advisory: three
+// unconnected literals across two repos) so this validation can never drift from
+// whatever set every production caller was written against.
 const closeKind = flagVal('--close-kind');
 if (closeKind !== null && !CLOSE_KINDS.has(closeKind)) {
   fail(`--close-kind must be one of ${[...CLOSE_KINDS].join('|')}, got: ${closeKind}`);

--- a/daemons/curated-close-pointer.mjs
+++ b/daemons/curated-close-pointer.mjs
@@ -8,7 +8,8 @@
 //   node curated-close-pointer.mjs <capsule-path> [--session <sid>] \
 //        [--cycle-token <tok>] [--reconciled <json>] \
 //        [--cycle-id <uuid>] [--context-epoch <n>] [--captured-through-event <id>] \
-//        [--capsule-sha256 <hex>] [--reconcile-digest <hex>]
+//        [--capsule-sha256 <hex>] [--reconcile-digest <hex>] \
+//        [--close-kind <checkpoint|completion|handoff>]
 //   (capsule-path is POSITIONAL and must come FIRST; flags follow.)
 //
 // Pointer schema (v3): additive, default-null fields — no behavior change when
@@ -25,6 +26,15 @@
 //   --capsule-sha256 <hex>        → capsule_sha256: evidence integrity.
 //   --reconcile-digest <hex>      → reconcile_digest: canonical evidence-object digest.
 // Nothing gates on any of these fields yet — this module only stamps schema.
+//
+// close_kind (board c1f777e9 gate round-1 F1 fix direction): an additional additive,
+// default-null field, but UNLIKE the fields above it is a CLOSED enum, not a
+// free-form value — an unrecognized --close-kind is refused loudly (fail()) rather
+// than silently accepted. Same freshness-overwrite invariant: a fresh stamp without
+// the flag OVERWRITES any prior close_kind. Absent/null close_kind is the fail-safe
+// default downstream (non-waking) — shipping this field alone changes no behavior.
+//   --close-kind <checkpoint|completion|handoff> → close_kind: the caller's stated
+//                                    intent for THIS close. Nothing gates on it yet.
 //
 // Pointer shape: aigent-OS is single-operator, so the pointer always lives at
 // <memRoot>/BODY_STATE.json's state.last_capsule — the same convention the
@@ -90,7 +100,15 @@ if (ctoRaw !== null) {
   capturedThroughOffset = n;
 }
 
-if (!capArg) fail('usage: curated-close-pointer.mjs <capsule-path> [--session <sid>] [--cycle-token <tok>] [--reconciled <json>] [--cycle-id <uuid>] [--context-epoch <n>] [--captured-through-event <id>] [--captured-through-offset <n>] [--capsule-sha256 <hex>] [--reconcile-digest <hex>]');
+// close_kind is a CLOSED enum (unlike the free-form fields above) — refuse loudly on
+// an unrecognized value rather than stamping something no downstream reader expects.
+const CLOSE_KINDS = new Set(['checkpoint', 'completion', 'handoff']);
+const closeKind = flagVal('--close-kind');
+if (closeKind !== null && !CLOSE_KINDS.has(closeKind)) {
+  fail(`--close-kind must be one of ${[...CLOSE_KINDS].join('|')}, got: ${closeKind}`);
+}
+
+if (!capArg) fail('usage: curated-close-pointer.mjs <capsule-path> [--session <sid>] [--cycle-token <tok>] [--reconciled <json>] [--cycle-id <uuid>] [--context-epoch <n>] [--captured-through-event <id>] [--captured-through-offset <n>] [--capsule-sha256 <hex>] [--reconcile-digest <hex>] [--close-kind <checkpoint|completion|handoff>]');
 
 const root = String(process.env.AIGENT_ROOT || process.env.CLAUDE_PROJECT_DIR || process.cwd());
 const seat = seatOf(root);
@@ -141,6 +159,9 @@ const pointer = {
   captured_through_offset: capturedThroughOffset,
   capsule_sha256: capsuleSha256,
   reconcile_digest: reconcileDigest,
+  // close_kind (board c1f777e9 F1): additive, default null, freshness-overwrite —
+  // same discipline as the fields above, but CLOSED enum (validated pre-write).
+  close_kind: closeKind,
 };
 
 const bsPath = path.join(MEM, 'BODY_STATE.json');
@@ -150,4 +171,4 @@ if (!bs?.state) fail('BODY_STATE.json has no .state — pointer not stamped');
 bs.state.last_capsule = { ...bs.state.last_capsule, ...pointer };
 writeFileSync(bsPath, JSON.stringify(bs, null, 2));
 
-console.log(`[curated-close-pointer] STAMPED ${seat}: ${id} (session ${sid ?? 'null'}, finalized ${pointer.finalized_at}, cycle_token ${cycleToken ?? 'null'}, cycle_id ${cycleId ?? 'null'}, context_epoch ${contextEpoch ?? 'null'}, captured_through_event_id ${capturedThroughEventId ?? 'null'}, captured_through_offset ${capturedThroughOffset ?? 'null'}, capsule_sha256 ${capsuleSha256 ?? 'null'}, reconcile_digest ${reconcileDigest ?? 'null'})`);
+console.log(`[curated-close-pointer] STAMPED ${seat}: ${id} (session ${sid ?? 'null'}, finalized ${pointer.finalized_at}, cycle_token ${cycleToken ?? 'null'}, cycle_id ${cycleId ?? 'null'}, context_epoch ${contextEpoch ?? 'null'}, captured_through_event_id ${capturedThroughEventId ?? 'null'}, captured_through_offset ${capturedThroughOffset ?? 'null'}, capsule_sha256 ${capsuleSha256 ?? 'null'}, reconcile_digest ${reconcileDigest ?? 'null'}, close_kind ${closeKind ?? 'null'})`);

--- a/daemons/lifecycle-common.mjs
+++ b/daemons/lifecycle-common.mjs
@@ -10,6 +10,12 @@
 import { readFileSync, writeFileSync, existsSync, appendFileSync, writeSync, mkdirSync, renameSync, rmSync } from 'node:fs';
 import path from 'node:path';
 
+// CLOSE_KINDS (gate round-1/2 F1/R2-1) — the ONE owner of the close_kind enum.
+// curated-close-pointer.mjs's --close-kind validation and every production
+// caller import this instead of re-typing the three literals (the gate's own
+// advisory: three unconnected literals across two repos).
+export const CLOSE_KINDS = new Set(['checkpoint', 'completion', 'handoff']);
+
 // seatId resolution: env override first (multi-instance forks), else the fixed
 // single-operator default. No path-based regex table — a single vault has nothing
 // to disambiguate.

--- a/daemons/stop-capsule-writer.mjs
+++ b/daemons/stop-capsule-writer.mjs
@@ -106,6 +106,16 @@ try {
   try { gate = await import('./capsule-content-gate.mjs'); }
   catch (e) { logErr(root, `content-gate import failed (gate skipped): ${e?.message || e}`); }
 
+  // R2-2 (gate round-2, board c1f777e9): same lazy + fail-open discipline as the
+  // content gate above — capsuleLeftSkeleton is the SAME predicate capsule-verb
+  // and ctx-refresh-sensor already gate finalize-readiness on; reusing it (not
+  // re-parsing frontmatter by hand) means this gate can never disagree with
+  // theirs about the same bytes. Import failure degrades to pre-gate behavior
+  // (old merge-in-place; logged, never blocks a turn).
+  let leftSkeleton = null;
+  try { ({ capsuleLeftSkeleton: leftSkeleton } = await import('./capsule-verb.mjs')); }
+  catch (e) { logErr(root, `capsule-verb import failed (finalize-freeze gate skipped): ${e?.message || e}`); }
+
   const MEM = memRoot(root);
   const RUNTIME = path.join(MEM, 'runtime', 'stop-writer');
   mkdirSync(RUNTIME, { recursive: true });
@@ -349,7 +359,35 @@ ${ANCHORS.rows}
 `;
   }
 
-  let doc = existsSync(capPath) ? readFileSync(capPath, 'utf8') : skeleton();
+  const capExisted = existsSync(capPath);
+  const originalCapPath = capPath;
+  const originalDoc = capExisted ? readFileSync(capPath, 'utf8') : skeleton();
+  let doc = originalDoc;
+
+  // R2-2 (gate round-2, board c1f777e9) FINALIZE-FREEZE: the documented recovery
+  // play "finalize the rolling capsule in place" turns THIS file into a curated
+  // close without ever repointing state.capsule_path — so without this gate the
+  // merge below would reopen a byte-frozen, already-hashed capsule and mutate
+  // it (capsule-verb's write-once sha256, capsule-verb.mjs:587, can never be
+  // re-stamped -> permanent capsule_invalid abort). A capsule that has left
+  // skeleton (real waiting_on) is finalized and stays byte-frozen from here on:
+  // this turn's delta rolls a FRESH auto-capsule instead, using the exact same
+  // path convention the "no capsule yet" branch above uses, disambiguated by
+  // this turn's own deltaSig (content-addressed, so it can never collide with
+  // the file being frozen). writeState() below persists this reroute for free
+  // — it always writes whatever capPath currently is.
+  //
+  // originalCapPath/originalDoc are kept SEPARATE from capPath/doc on purpose:
+  // the finalize-ADVANCE contract (below, thisFinalized) must keep judging THIS
+  // session's own identity against the capsule it actually finalized — the
+  // fresh companion file is a skeleton and would read as never-finalized,
+  // wrongly re-freezing the pointer on a stale target. Freezing the BYTES is
+  // orthogonal to advancing the POINTER.
+  const frozen = capExisted && leftSkeleton && leftSkeleton(originalDoc);
+  if (frozen) {
+    capPath = path.join(capDir, `${dateStr}-auto-${sid.slice(0, 8)}-${deltaSig}.md`);
+    doc = skeleton();
+  }
 
   // A bullet minus its `- ` prefix and volatile HH:MM stamp — dedup must not be
   // defeated by re-processing a span at a different wall-clock minute (a
@@ -496,9 +534,14 @@ ${ANCHORS.rows}
       return true;
     } catch { return false; }
   }
+  // R2-2: the pointer's IDENTITY is this session's designated capsule as it
+  // stood BEFORE any finalize-freeze reroute — a frozen capsule is still this
+  // session's own legitimate finalize; only its bytes stop being touched. Using
+  // the fresh companion skeleton here would read as never-finalized and wrongly
+  // re-freeze the pointer on a stale target (see frozen comment above).
   const pointer = {
-    id: path.basename(capPath, '.md'),
-    path: path.relative(root, capPath).replace(/\\/g, '/'),
+    id: path.basename(originalCapPath, '.md'),
+    path: path.relative(root, originalCapPath).replace(/\\/g, '/'),
     objective,
     status: 'active',
     created_at: new Date().toISOString(),
@@ -513,7 +556,7 @@ ${ANCHORS.rows}
   // until a human advances it by hand. Allow the repoint when this session's
   // capsule (the `doc` just written) is itself finalize-live — same
   // status:active + real-waiting_on predicate the guard uses.
-  const thisFm = doc.split(/^---\s*$/m)[1] || '';
+  const thisFm = originalDoc.split(/^---\s*$/m)[1] || '';
   const thisStatus = (thisFm.match(/^status:\s*(\S+)/m) || [])[1]?.trim() || '';
   const thisW = ((thisFm.match(/^waiting_on:\s*(.+)\s*$/m) || [])[1] || '').trim().toLowerCase();
   const thisFinalized = thisStatus === 'active' && !!thisW && thisW !== 'null' && thisW !== '~' && thisW !== '""' && thisW !== "''";

--- a/daemons/stop-capsule-writer.mjs
+++ b/daemons/stop-capsule-writer.mjs
@@ -373,9 +373,8 @@ ${ANCHORS.rows}
   // skeleton (real waiting_on) is finalized and stays byte-frozen from here on:
   // this turn's delta rolls a FRESH auto-capsule instead, using the exact same
   // path convention the "no capsule yet" branch above uses, disambiguated by
-  // this turn's own deltaSig (content-addressed, so it can never collide with
-  // the file being frozen). writeState() below persists this reroute for free
-  // — it always writes whatever capPath currently is.
+  // this turn's own deltaSig. writeState() below persists this reroute for
+  // free — it always writes whatever capPath currently is.
   //
   // originalCapPath/originalDoc are kept SEPARATE from capPath/doc on purpose:
   // the finalize-ADVANCE contract (below, thisFinalized) must keep judging THIS
@@ -383,9 +382,31 @@ ${ANCHORS.rows}
   // fresh companion file is a skeleton and would read as never-finalized,
   // wrongly re-freezing the pointer on a stale target. Freezing the BYTES is
   // orthogonal to advancing the POINTER.
+  //
+  // GUARDRAIL (Titus ruling, gate round-2 fold-in): fail-safe ordering. deltaSig
+  // content-addresses only THIS turn's delta — it is not scoped across every
+  // historical reroute this session may have made, so a recurring delta shape
+  // (the same files/errors/assistant text landing again on a later, non-
+  // consecutive turn) CAN reproduce the same fresh path. A pre-existing file
+  // there is a genuine collision: silently overwriting it would destroy
+  // whatever an earlier reroute already committed. The only safe move is to
+  // SKIP the merge entirely and leave the delta for a retry next turn — NEVER
+  // fall back to writing into the frozen file itself (that is exactly the bug
+  // this gate exists to prevent). Write failures on the fresh path are already
+  // fail-safe by construction below: capPath fully replaces the write target,
+  // so the tmp+rename fallback chain and its `outcome:'error:write-failed'`
+  // exit never reference originalCapPath, and state.capsule_path is only
+  // persisted after a committed write — an exhausted write retries fresh
+  // next turn, same as a collision.
   const frozen = capExisted && leftSkeleton && leftSkeleton(originalDoc);
   if (frozen) {
-    capPath = path.join(capDir, `${dateStr}-auto-${sid.slice(0, 8)}-${deltaSig}.md`);
+    const freshPath = path.join(capDir, `${dateStr}-auto-${sid.slice(0, 8)}-${deltaSig}.md`);
+    if (existsSync(freshPath)) {
+      logErr(root, `finalize-freeze: fresh-roll path collision at ${freshPath} — merge skipped this turn (frozen file never touched), will retry`);
+      outcome = 'noop:fresh-roll-collision';
+      process.exit(0);
+    }
+    capPath = freshPath;
     doc = skeleton();
   }
 
@@ -560,6 +581,22 @@ ${ANCHORS.rows}
   const thisStatus = (thisFm.match(/^status:\s*(\S+)/m) || [])[1]?.trim() || '';
   const thisW = ((thisFm.match(/^waiting_on:\s*(.+)\s*$/m) || [])[1] || '').trim().toLowerCase();
   const thisFinalized = thisStatus === 'active' && !!thisW && thisW !== 'null' && thisW !== '~' && thisW !== '""' && thisW !== "''";
+  // Completion stamp (Titus ruling, gate round-2 fold-in): thisFinalized IS the
+  // finalize-ADVANCE moment — this session's own designated capsule just left
+  // skeleton for real, whether written directly or reached via the R2-2 freeze
+  // reroute above. That is a voluntary completion close, not a cycle receipt —
+  // no cycle_id belongs on this stamp (this object never carries one). Explicit
+  // null when not finalizing (not merely omitted) so a spread-merge
+  // freshness-overwrites any stale value rather than leaking it through.
+  //
+  // ONE stamp per freeze episode falls out of the EXISTING guard below for
+  // free: once this write lands, state.capsule_path repoints to a fresh
+  // skeleton (R2-2), so the NEXT turn's thisFinalized is false (the fresh
+  // capsule is unfinalized) and pointerLockedByFinalize() holds the pointer on
+  // THIS now-finalized capsule (the "HELD" branch) — the pointer write is
+  // skipped entirely on every subsequent turn, so close_kind is never
+  // recomputed or re-stamped until a genuinely new finalize happens.
+  pointer.close_kind = thisFinalized ? 'completion' : null;
   if (curatedPointerWins()) {
     // this session was curated-closed inside the race window — pointer stays on
     // the curated capsule; the rolling auto-capsule content above is still saved

--- a/daemons/tests/capsule-content-gate.test.mjs
+++ b/daemons/tests/capsule-content-gate.test.mjs
@@ -100,9 +100,17 @@ console.log(`── capsule content gate — daemon: ${DAEMON} ──`);
 }
 
 // 4. OWNERSHIP: a capsule WITHOUT the autosave tag keeps its contract fields even
-//    when the writer merges delta bullets into it.
+//    when the writer merges delta bullets into it. waiting_on is null-family
+//    here on purpose (R2-2, gate round-2): a REAL waiting_on now means the
+//    writer freezes this file's bytes and reroutes the merge to a fresh
+//    companion capsule entirely (see stop-capsule-writer.pointer-advance.test.mjs's
+//    R2-2 cases) — that is a SEPARATE, orthogonal axis from the one this test
+//    targets (the autosave-tag ownership gate). A deliberate capsule with
+//    waiting_on:null (nothing blocks resume yet — the same shape the
+//    DELIB-NULL case uses) still isolates "no autosave tag -> frontmatter
+//    untouched" cleanly.
 {
-  const curated = `---\nid: curated-x\nstatus: active\nobjective: "continuation: coverage net at gate"\nwaiting_on: gates\nresume_trigger: open\ndefinition_hash: abc123\nnext_valid_action: "On resume: re-ground and act on the verdict"\ntags: [capsule, refresh-cycle]\n---\n\n## Done (don't redo)\n<!-- swe:done -->\n\n## Historical-Errors → Resolutions\n<!-- swe:errors -->\n\n## Historical-Rejected-Approaches\n<!-- swe:rejected -->\n\n## Files-Read / Files-Modified\n<!-- swe:files -->\n\n## Operating-Facts\n<!-- swe:facts -->\n\n## Pending-Gates\n<!-- swe:gates -->\n\n## Claimed-Rows\n<!-- swe:rows -->\n`;
+  const curated = `---\nid: curated-x\nstatus: active\nobjective: "continuation: coverage net at gate"\nwaiting_on: null\nresume_trigger: open\ndefinition_hash: abc123\nnext_valid_action: "On resume: re-ground and act on the verdict"\ntags: [capsule, refresh-cycle]\n---\n\n## Done (don't redo)\n<!-- swe:done -->\n\n## Historical-Errors → Resolutions\n<!-- swe:errors -->\n\n## Historical-Rejected-Approaches\n<!-- swe:rejected -->\n\n## Files-Read / Files-Modified\n<!-- swe:files -->\n\n## Operating-Facts\n<!-- swe:facts -->\n\n## Pending-Gates\n<!-- swe:gates -->\n\n## Claimed-Rows\n<!-- swe:rows -->\n`;
   const { doc } = runWriter({ sid: 'own-44444444', userText: REFRESH_CYCLE_INJECTION, existingCapsule: curated });
   ok(fm(doc, 'objective').includes('continuation'),
     'ownership: non-autosave capsule keeps its objective');

--- a/daemons/tests/capsule-verb.test.mjs
+++ b/daemons/tests/capsule-verb.test.mjs
@@ -298,6 +298,48 @@ test('full trusted stamp round-trips proofs and later no-flag stamp clears them'
   assert.equal(restamped.reconcile_digest, null);
 });
 
+test('close_kind stamps verbatim, defaults null, freshness-overwrites, and refuses an unrecognized value', async (t) => {
+  // board c1f777e9 gate round-1 F1 fix direction: "thread close intent through the
+  // pointer, e.g. close_kind: checkpoint|completion stamped by the verb." Same
+  // freshness-overwrite discipline the cycle_token/cycle_id fields already prove
+  // above: additive, default null, a fresh stamp with no flag OVERWRITES any prior
+  // value. Unlike those free-form fields, close_kind is a CLOSED enum — an
+  // unrecognized value is refused loudly rather than silently accepted.
+  const seat = mkSeat(os.tmpdir());
+  t.after(seat.cleanup);
+  const capsule = writeCapsule(seat, validCapsule('capsule-close-kind'));
+  const bsPath = path.join(seat.memory, 'BODY_STATE.json');
+  const readPointer = () => JSON.parse(readFileSync(bsPath, 'utf8')).state.last_capsule;
+  const stamp = (...extraArgs) => execFileSync(process.execPath, [CCP, capsule, ...extraArgs], {
+    cwd: seat.root,
+    env: { ...process.env, AIGENT_ROOT: seat.root },
+    encoding: 'utf8',
+  });
+
+  stamp();
+  assert.equal(readPointer().close_kind, null, 'default: close_kind stamped null with no flag');
+
+  for (const kind of ['checkpoint', 'completion', 'handoff']) {
+    stamp('--close-kind', kind);
+    assert.equal(readPointer().close_kind, kind, `round-trip: --close-kind ${kind} stamped verbatim`);
+  }
+
+  stamp();
+  assert.equal(readPointer().close_kind, null,
+    'freshness-overwrite: fresh no-flag stamp clears the prior close_kind (no replay)');
+
+  let invalidError = null;
+  try {
+    stamp('--close-kind', 'bogus');
+  } catch (e) {
+    invalidError = e;
+  }
+  assert.ok(invalidError, 'invalid --close-kind refused loudly (non-zero exit)');
+  assert.match(String(invalidError.stderr || ''), /REFUSED/);
+  assert.equal(readPointer().close_kind, null,
+    'invalid --close-kind never reaches disk (pointer unchanged from freshness-overwrite step)');
+});
+
 test('cycle stores only challenge digest and walks requested→capsuling→prepared', async (t) => {
   const seat = mkSeat(os.tmpdir(), { git: true });
   t.after(seat.cleanup);

--- a/daemons/tests/capsule-verb.test.mjs
+++ b/daemons/tests/capsule-verb.test.mjs
@@ -281,6 +281,10 @@ test('full trusted stamp round-trips proofs and later no-flag stamp clears them'
   assert.equal(pointer.captured_through_event_id, 'evt-73');
   assert.equal(pointer.captured_through_offset, null, 'non-cycle stamp: lone event id keeps legacy semantics, offset stays null');
   assert.equal(pointer.cycle_token, null);
+  // R2-1(a) (gate round-2): the REAL writerArgs path (capsule-verb.mjs:691-706,
+  // not a hand-typed CLI flag) must itself stamp close_kind — a legacy/non-cycle
+  // machinery capture is checkpoint-class, unconditionally, by construction.
+  assert.equal(pointer.close_kind, 'checkpoint', 'the trusted writer stamps close_kind through its own writerArgs, not just when a caller passes the flag by hand');
 
   execFileSync(process.execPath, [CCP, capsule], {
     cwd: seat.root,
@@ -296,6 +300,8 @@ test('full trusted stamp round-trips proofs and later no-flag stamp clears them'
   assert.equal(restamped.captured_through_offset, null);
   assert.equal(restamped.capsule_sha256, null);
   assert.equal(restamped.reconcile_digest, null);
+  assert.equal(restamped.close_kind, null,
+    'freshness-overwrite: a bare CLI restamp with no --close-kind clears the verb-stamped checkpoint (no replay)');
 });
 
 test('close_kind stamps verbatim, defaults null, freshness-overwrites, and refuses an unrecognized value', async (t) => {

--- a/daemons/tests/stop-capsule-writer.pointer-advance.test.mjs
+++ b/daemons/tests/stop-capsule-writer.pointer-advance.test.mjs
@@ -6,7 +6,7 @@
 // thisFinalized). Override the daemon under test with SCW_DAEMON=<abs path>.
 'use strict';
 
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import os from 'node:os';
@@ -54,13 +54,15 @@ function runScenario({ sid, capsuleBWaitingOn, capsuleAWaitingOn = '"prior final
   // so the daemon writes its own real auto-skeleton (trigger:stop-delta) when
   // skeletonB — the true clobber source.
   const capsuleB = path.join(capsules, 'capsule-B.md');
-  if (!skeletonB) writeFileSync(capsuleB, cap('capsule-B', capsuleBWaitingOn));
+  const capsuleBBefore = skeletonB ? null : cap('capsule-B', capsuleBWaitingOn);
+  if (capsuleBBefore !== null) writeFileSync(capsuleB, capsuleBBefore);
 
   const bodyStatePath = path.join(root, 'memory', 'BODY_STATE.json');
   writeFileSync(bodyStatePath, JSON.stringify({
     state: { last_capsule: { id: 'capsule-A', path: 'memory/capsules/capsule-A.md', status: 'active' } },
   }));
-  writeFileSync(path.join(runtime, `${sid}.json`), JSON.stringify({ offset: 0, capsule_path: capsuleB, last_delta_sha: null }));
+  const stateFile = path.join(runtime, `${sid}.json`);
+  writeFileSync(stateFile, JSON.stringify({ offset: 0, capsule_path: capsuleB, last_delta_sha: null }));
 
   const transcript = path.join(base, 'transcript.jsonl');
   writeFileSync(transcript, JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'integration delta ' + sid }] } }) + '\n');
@@ -69,18 +71,30 @@ function runScenario({ sid, capsuleBWaitingOn, capsuleAWaitingOn = '"prior final
   const out = execFileSync(process.execPath, [DAEMON, '--worker', payload], { encoding: 'utf8' });
 
   const pointerAfter = JSON.parse(readFileSync(bodyStatePath, 'utf8')).state.last_capsule;
+  const stateAfter = JSON.parse(readFileSync(stateFile, 'utf8'));
+  const capsuleBAfter = existsSync(capsuleB) ? readFileSync(capsuleB, 'utf8') : null;
   rmSync(base, { recursive: true, force: true });
-  return { pointerAfter, out };
+  return { pointerAfter, out, capsuleBBefore, capsuleBAfter, stateAfter, capsuleB };
 }
 
 console.log(`── stop-capsule-writer pointer-advance — daemon: ${DAEMON} ──`);
 
 // ADVANCE: this session's capsule is itself finalized → pointer moves to it.
+// This is also the REALISTIC shape of R2-2 (finalize-rolling-capsule-in-place):
+// capsule-B is pre-written already finalized AND state.capsule_path already
+// points at it (exactly what the recovery play produces) — so this scenario
+// must satisfy BOTH the pre-existing pointer-advance contract AND the new
+// R2-2 byte-freeze + repoint contract simultaneously.
 {
-  const { pointerAfter, out } = runScenario({ sid: 'adv-11111111', capsuleBWaitingOn: '"my own finalize — real"' });
+  const { pointerAfter, out, capsuleBBefore, capsuleBAfter, stateAfter, capsuleB } =
+    runScenario({ sid: 'adv-11111111', capsuleBWaitingOn: '"my own finalize — real"' });
   ok(out.includes('SWE_OUTCOME:flushed'), 'ADVANCE: worker flushed (reached the pointer logic)');
   ok(pointerAfter.path === 'memory/capsules/capsule-B.md',
     'ADVANCE: a finalized new capsule advances the pointer off the prior finalized one (finalize-advance, not clobber)');
+  ok(capsuleBAfter === capsuleBBefore,
+    'ADVANCE+R2-2: capsule-B is BYTE-FROZEN even though the pointer advances to it (freeze is orthogonal to advance)');
+  ok(stateAfter.capsule_path !== capsuleB,
+    'ADVANCE+R2-2: the stop-writer state record repoints capsule_path OFF capsule-B onto a fresh rolling file');
 }
 
 // HELD: this session's capsule is a skeleton (waiting_on:null) → pointer stays on A.
@@ -116,6 +130,70 @@ console.log(`── stop-capsule-writer pointer-advance — daemon: ${DAEMON} �
   ok(out.includes('SWE_OUTCOME:flushed'), 'PRECOMPACT-ADVANCE: worker flushed (reached the pointer logic)');
   ok(pointerAfter.path === 'memory/capsules/capsule-B.md',
     'PRECOMPACT-ADVANCE: a disposable autosave safety-net (waiting_on:null) does NOT freeze the pointer — this session\'s capsule advances past it (no stuck-pointer regression)');
+}
+
+// R2-2 (gate round-2, board c1f777e9): FINALIZE-IN-PLACE BYTE-FREEZE. The
+// documented recovery play "finalize the rolling capsule in place" turns the
+// FILE state.capsule_path already points at into a curated close, WITHOUT ever
+// repointing capsule_path itself. The next Stop hook's merge block re-opens
+// that same file, appends bullets, and mutates bytes the capsule-verb
+// write-once sha256 already committed to (capsule-verb.mjs:587) — a re-hash
+// mismatch that aborts every future refresh cycle as capsule_invalid, forever.
+// FIX: gate the merge on capsuleLeftSkeleton() — a finalized capsule is
+// byte-frozen from here on; this turn's delta rolls a FRESH auto-capsule
+// instead, and the stop-writer's own state record repoints to it.
+{
+  const base = mkdtempSync(path.join(os.tmpdir(), 'scw-r22-'));
+  const root = path.join(base, 'test-seat');
+  const capsules = path.join(root, 'memory', 'capsules');
+  const runtime = path.join(root, 'memory', 'runtime', 'stop-writer');
+  mkdirSync(capsules, { recursive: true });
+  mkdirSync(runtime, { recursive: true });
+
+  const sid = 'r22-55555555';
+  const finalizedPath = path.join(capsules, 'capsule-FINALIZED-IN-PLACE.md');
+  const finalizedBefore = cap('capsule-FINALIZED-IN-PLACE', '"recovery-play finalize — real waiting_on"');
+  writeFileSync(finalizedPath, finalizedBefore);
+
+  // state.capsule_path STILL points at the now-finalized file — exactly the
+  // recovery play's shape: no repoint happened, only the file's own
+  // frontmatter was hand-edited to leave skeleton.
+  writeFileSync(path.join(runtime, `${sid}.json`),
+    JSON.stringify({ offset: 0, capsule_path: finalizedPath, last_delta_sha: null }));
+  writeFileSync(path.join(root, 'memory', 'BODY_STATE.json'), JSON.stringify({
+    state: {
+      last_capsule: {
+        id: 'capsule-FINALIZED-IN-PLACE', path: 'memory/capsules/capsule-FINALIZED-IN-PLACE.md',
+        status: 'active', trigger: 'curated-close',
+        finalized_at: new Date(Date.now() - 5 * 60e3).toISOString(), session_id: sid,
+      },
+    },
+  }));
+
+  const transcript = path.join(base, 'transcript.jsonl');
+  writeFileSync(transcript,
+    JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'post-finalize turn ' + sid }] } }) + '\n');
+  const payload = JSON.stringify({ __root: root, session_id: sid, transcript_path: transcript });
+  const out = execFileSync(process.execPath, [DAEMON, '--worker', payload], { encoding: 'utf8' });
+
+  const finalizedAfter = readFileSync(finalizedPath, 'utf8');
+  const stateAfter = JSON.parse(readFileSync(path.join(runtime, `${sid}.json`), 'utf8'));
+  const freshPath = stateAfter.capsule_path;
+  const freshDoc = freshPath && existsSync(freshPath) ? readFileSync(freshPath, 'utf8') : '';
+
+  ok(out.includes('SWE_OUTCOME:flushed'), 'R2-2: worker flushed (reached the merge/pointer logic)');
+  ok(finalizedAfter === finalizedBefore,
+    'R2-2: the finalized-in-place capsule is BYTE-FROZEN — the post-finalize turn never mutates it');
+  ok(freshPath !== finalizedPath,
+    'R2-2: the stop-writer state record repoints capsule_path OFF the finalized file');
+  ok(freshPath !== null && existsSync(freshPath),
+    'R2-2: a fresh rolling capsule file was actually created on disk');
+  ok(/\bautosave\b/.test(freshDoc) && /^waiting_on:\s*null\s*$/m.test(freshDoc),
+    'R2-2: the fresh capsule is a genuine unfinalized skeleton (autosave tag, waiting_on:null)');
+  ok(freshDoc.includes('post-finalize turn ' + sid),
+    "R2-2: this turn's delta landed in the FRESH capsule, not dropped");
+
+  rmSync(base, { recursive: true, force: true });
 }
 
 console.log(`\n${pass} passed, ${fail} failed.`);

--- a/daemons/tests/stop-capsule-writer.pointer-advance.test.mjs
+++ b/daemons/tests/stop-capsule-writer.pointer-advance.test.mjs
@@ -6,14 +6,24 @@
 // thisFinalized). Override the daemon under test with SCW_DAEMON=<abs path>.
 'use strict';
 
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, appendFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import os from 'node:os';
 import path from 'node:path';
+import { createCycleRecord, writeCycleRecord, readCycleRecord } from '../refresh-cycle.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DAEMON = process.env.SCW_DAEMON || path.resolve(__dirname, '..', 'stop-capsule-writer.mjs');
+const sha256hex = (s) => createHash('sha256').update(s).digest('hex');
+// Mirrors the daemon's own sha12(JSON.stringify({...})) EXACTLY for a transcript
+// carrying only an assistant-text delta (no user turn, no tool_use) — the
+// simplest shape that still produces a real, deterministic deltaSig, so the
+// fresh-roll path it will compute can be predicted before running it.
+const deltaSigForAssistantOnly = (text) => sha256hex(JSON.stringify({
+  r: null, fr: [], fm: [], e: [], c: [], a: text.slice(0, 200), u: [],
+})).slice(0, 12);
 
 let pass = 0;
 let fail = 0;
@@ -192,6 +202,197 @@ console.log(`── stop-capsule-writer pointer-advance — daemon: ${DAEMON} �
     'R2-2: the fresh capsule is a genuine unfinalized skeleton (autosave tag, waiting_on:null)');
   ok(freshDoc.includes('post-finalize turn ' + sid),
     "R2-2: this turn's delta landed in the FRESH capsule, not dropped");
+
+  rmSync(base, { recursive: true, force: true });
+}
+
+// R2-2 GUARDRAIL 1 (Titus ruling, gate round-2 fold-in): an IN-FLIGHT refresh
+// cycle pins its OWN capsule_id/capsule_sha256 at prepare-time (refresh-cycle.mjs
+// — a file the stop-writer never imports or touches). Repointing
+// state.capsule_path (the STOP-WRITER's own bookkeeping for where to merge
+// ROLLING bullets) must have ZERO effect on that pinned receipt: the cycle
+// record must read back byte-identical, and the frozen file's bytes must still
+// hash to the record's pinned capsule_sha256 — proving the receipt resolves its
+// own pinned identity and never re-reads the repointed stop-writer record.
+{
+  const base = mkdtempSync(path.join(os.tmpdir(), 'scw-r22-g1-'));
+  const root = path.join(base, 'test-seat');
+  const capsules = path.join(root, 'memory', 'capsules');
+  const runtime = path.join(root, 'memory', 'runtime', 'stop-writer');
+  mkdirSync(capsules, { recursive: true });
+  mkdirSync(runtime, { recursive: true });
+
+  const sid = 'r22-g1-66666666';
+  const finalizedPath = path.join(capsules, 'capsule-CYCLE-PINNED.md');
+  const finalizedBefore = cap('capsule-CYCLE-PINNED', '"in-flight cycle finalize — real waiting_on"');
+  writeFileSync(finalizedPath, finalizedBefore);
+  const pinnedSha256 = createHash('sha256').update(finalizedBefore).digest('hex');
+
+  // The in-flight cycle receipt: prepared by an EARLIER capsule-verb run against
+  // this exact file, pinning its id + sha256. This module (refresh-cycle.mjs) is
+  // a completely separate file from anything the stop-writer touches.
+  const cycleRecord = createCycleRecord({
+    cycle_id: 'cyc-g1', lineage_id: 'lineage-g1', runtime_session: sid,
+    state: 'prepared', capsule_id: 'capsule-CYCLE-PINNED', capsule_sha256: pinnedSha256,
+  });
+  writeCycleRecord(root, sid, cycleRecord);
+
+  writeFileSync(path.join(runtime, `${sid}.json`),
+    JSON.stringify({ offset: 0, capsule_path: finalizedPath, last_delta_sha: null }));
+  writeFileSync(path.join(root, 'memory', 'BODY_STATE.json'), JSON.stringify({
+    state: {
+      last_capsule: {
+        id: 'capsule-CYCLE-PINNED', path: 'memory/capsules/capsule-CYCLE-PINNED.md',
+        status: 'active', trigger: 'curated-close',
+        finalized_at: new Date(Date.now() - 5 * 60e3).toISOString(), session_id: sid,
+      },
+    },
+  }));
+
+  const transcript = path.join(base, 'transcript.jsonl');
+  writeFileSync(transcript,
+    JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'post-finalize turn ' + sid }] } }) + '\n');
+  const payload = JSON.stringify({ __root: root, session_id: sid, transcript_path: transcript });
+  const out = execFileSync(process.execPath, [DAEMON, '--worker', payload], { encoding: 'utf8' });
+
+  const cycleRecordAfter = readCycleRecord(root, sid);
+  const rehash = createHash('sha256').update(readFileSync(finalizedPath, 'utf8')).digest('hex');
+
+  ok(out.includes('SWE_OUTCOME:flushed'), 'GUARDRAIL-1: worker flushed (reached the merge/pointer/repoint logic)');
+  ok(JSON.stringify(cycleRecordAfter) === JSON.stringify(cycleRecord),
+    'GUARDRAIL-1: the in-flight cycle record is byte-identical after the repoint — the stop-writer never touches refresh-cycle-<sid>.json');
+  ok(rehash === pinnedSha256,
+    'GUARDRAIL-1: the frozen file still hashes to the cycle record\'s pinned capsule_sha256 — the receipt verifies against ITS OWN pinned path/sha, unaffected by state.capsule_path\'s repoint');
+
+  rmSync(base, { recursive: true, force: true });
+}
+
+// R2-2 GUARDRAIL 2 (Titus ruling, gate round-2 fold-in): fail-safe ordering.
+// deltaSig content-addresses only THIS turn's delta, not every historical
+// reroute this session may have made — a recurring delta shape landing on a
+// later, non-consecutive turn CAN reproduce the same fresh-roll path. Plant a
+// file there ourselves to force the collision deterministically. The only safe
+// response is to SKIP the merge entirely (never overwrite the collision target,
+// never fall back to writing into the frozen file).
+{
+  const base = mkdtempSync(path.join(os.tmpdir(), 'scw-r22-g2-'));
+  const root = path.join(base, 'test-seat');
+  const capsules = path.join(root, 'memory', 'capsules');
+  const runtime = path.join(root, 'memory', 'runtime', 'stop-writer');
+  mkdirSync(capsules, { recursive: true });
+  mkdirSync(runtime, { recursive: true });
+
+  const sid = 'r22-g2-77777777';
+  const finalizedPath = path.join(capsules, 'capsule-COLLISION-SRC.md');
+  const finalizedBefore = cap('capsule-COLLISION-SRC', '"finalize — real waiting_on"');
+  writeFileSync(finalizedPath, finalizedBefore);
+
+  writeFileSync(path.join(runtime, `${sid}.json`),
+    JSON.stringify({ offset: 0, capsule_path: finalizedPath, last_delta_sha: null }));
+  writeFileSync(path.join(root, 'memory', 'BODY_STATE.json'), JSON.stringify({
+    state: {
+      last_capsule: {
+        id: 'capsule-COLLISION-SRC', path: 'memory/capsules/capsule-COLLISION-SRC.md',
+        status: 'active', trigger: 'curated-close',
+        finalized_at: new Date(Date.now() - 5 * 60e3).toISOString(), session_id: sid,
+      },
+    },
+  }));
+
+  const assistantText = 'post-finalize turn ' + sid;
+  const transcript = path.join(base, 'transcript.jsonl');
+  writeFileSync(transcript,
+    JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: assistantText }] } }) + '\n');
+
+  // Predict and plant the EXACT fresh-roll path this turn would compute, with
+  // sentinel content standing in for "whatever an earlier reroute committed".
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const deltaSig = deltaSigForAssistantOnly(assistantText);
+  const collisionPath = path.join(capsules, `${dateStr}-auto-${sid.slice(0, 8)}-${deltaSig}.md`);
+  const collisionSentinel = '---\nid: pre-existing-collision-target\nstatus: active\nwaiting_on: null\ntags: [capsule, autosave]\n---\nSENTINEL: must never be overwritten\n';
+  writeFileSync(collisionPath, collisionSentinel);
+
+  const payload = JSON.stringify({ __root: root, session_id: sid, transcript_path: transcript });
+  const out = execFileSync(process.execPath, [DAEMON, '--worker', payload], { encoding: 'utf8' });
+
+  const finalizedAfter = readFileSync(finalizedPath, 'utf8');
+  const collisionAfter = readFileSync(collisionPath, 'utf8');
+  const stateAfter = JSON.parse(readFileSync(path.join(runtime, `${sid}.json`), 'utf8'));
+
+  ok(!out.includes('SWE_OUTCOME:flushed'), 'GUARDRAIL-2: worker does NOT report flushed on a fresh-roll collision (merge skipped, not silently succeeded)');
+  ok(finalizedAfter === finalizedBefore,
+    'GUARDRAIL-2: the frozen file is untouched on collision (no fallback to merging into it)');
+  ok(collisionAfter === collisionSentinel,
+    'GUARDRAIL-2: the pre-existing file at the collision path is NOT silently overwritten');
+  ok(stateAfter.capsule_path === finalizedPath,
+    'GUARDRAIL-2: state.capsule_path is NOT repointed on a skipped turn — no false advance, next turn retries fresh');
+
+  rmSync(base, { recursive: true, force: true });
+}
+
+// COMPLETION STAMP (Titus ruling, gate round-2 fold-in): the R2-2 freeze branch
+// additionally stamps close_kind:'completion' (no cycle_id) exactly when it
+// advances the pointer to this session's own newly-finalized capsule — a
+// voluntary completion close, distinct from a machinery checkpoint (which
+// capsule-verb.mjs's writerArgs already stamps unconditionally). ONE stamp per
+// freeze episode: Stop 1 finalizes + stamps; Stop 2 and Stop 3 (same session)
+// merge into the fresh companion skeleton and must NOT re-stamp — the pointer
+// stays byte-identical to what Stop 1 produced, because pointerLockedByFinalize
+// holds it on the already-finalized capsule (same guard the ADVANCE/HELD tests
+// above already prove; this test asserts close_kind specifically survives it).
+{
+  const base = mkdtempSync(path.join(os.tmpdir(), 'scw-comp-'));
+  const root = path.join(base, 'test-seat');
+  const capsules = path.join(root, 'memory', 'capsules');
+  const runtime = path.join(root, 'memory', 'runtime', 'stop-writer');
+  mkdirSync(capsules, { recursive: true });
+  mkdirSync(runtime, { recursive: true });
+
+  const sid = 'comp-88888888';
+  const finalizedPath = path.join(capsules, 'capsule-COMPLETION.md');
+  writeFileSync(finalizedPath, cap('capsule-COMPLETION', '"finalized for completion stamp — real waiting_on"'));
+  writeFileSync(path.join(runtime, `${sid}.json`),
+    JSON.stringify({ offset: 0, capsule_path: finalizedPath, last_delta_sha: null }));
+  const bodyStatePath = path.join(root, 'memory', 'BODY_STATE.json');
+  writeFileSync(bodyStatePath, JSON.stringify({ state: {} }));
+  const transcript = path.join(base, 'transcript.jsonl');
+  writeFileSync(transcript, '');
+
+  function runTurn(turnText) {
+    appendFileSync(transcript,
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: turnText }] } }) + '\n');
+    const payload = JSON.stringify({ __root: root, session_id: sid, transcript_path: transcript });
+    return execFileSync(process.execPath, [DAEMON, '--worker', payload], { encoding: 'utf8' });
+  }
+  const readPointer = () => JSON.parse(readFileSync(bodyStatePath, 'utf8')).state.last_capsule;
+
+  // Stop 1: the finalize turn. capsule-COMPLETION already carries real
+  // waiting_on — finalize-in-place already happened before this Stop hook fires.
+  const out1 = runTurn('completion stop 1 ' + sid);
+  const pointerAfter1 = readPointer();
+
+  ok(out1.includes('SWE_OUTCOME:flushed'), 'COMPLETION: Stop 1 flushed');
+  ok(pointerAfter1.path === 'memory/capsules/capsule-COMPLETION.md',
+    "COMPLETION: Stop 1 advances the pointer to this session's newly-finalized capsule");
+  ok(pointerAfter1.close_kind === 'completion',
+    'COMPLETION: Stop 1 stamps close_kind:completion on the finalize-advance');
+  ok(pointerAfter1.cycle_id === undefined,
+    'COMPLETION: the completion stamp carries no cycle_id (voluntary close, not a cycle receipt)');
+
+  // Stop 2, Stop 3: same session, capsule-COMPLETION stays frozen (nothing
+  // re-touches it). Each turn's delta lands in a FRESH companion skeleton
+  // (R2-2) — the pointer must never be rewritten again.
+  const out2 = runTurn('completion stop 2 ' + sid);
+  const pointerAfter2 = readPointer();
+  const out3 = runTurn('completion stop 3 ' + sid);
+  const pointerAfter3 = readPointer();
+
+  ok(out2.includes('SWE_OUTCOME:flushed'), 'COMPLETION: Stop 2 flushed (merges into the fresh companion, not re-finalizing)');
+  ok(JSON.stringify(pointerAfter2) === JSON.stringify(pointerAfter1),
+    "COMPLETION: Stop 2 does NOT re-stamp the pointer — byte-identical to Stop 1's completion stamp");
+  ok(out3.includes('SWE_OUTCOME:flushed'), 'COMPLETION: Stop 3 flushed');
+  ok(JSON.stringify(pointerAfter3) === JSON.stringify(pointerAfter1),
+    'COMPLETION: Stop 3 STILL does not re-stamp — one completion stamp for the whole freeze episode');
 
   rmSync(base, { recursive: true, force: true });
 }

--- a/docs/two-verb-lifecycle.md
+++ b/docs/two-verb-lifecycle.md
@@ -82,11 +82,20 @@ This reflex depends on one integration: something must write `~/.claude/ctx-refr
 
 Behind an opt-in flag (`CAPSULE_VERB_AUTOFIRE=1`), the sensor can also drive the trusted writer automatically: it waits for the transcript to fall genuinely still (two identical capture-cursor reads separated by an age floor, guarding against reading mid-flush), then calls `runCapsuleVerb()` in dry-run mode by default. A real, request-gated cycle (`daemons/refresh-request.mjs` + `daemons/refresh-cycle.mjs`) exists for a controller that wants to mint a nonce-bound refresh challenge and verify the receipt — none of that fires unless something writes a `RefreshRequest` file, which, like the board adapter, ships as a seam rather than a default behavior.
 
+## Completion signal vs. checkpoint (close_kind)
+
+Two distinct wake-relevant signals exist, and it is easy to conflate them because both eventually touch the same pointer field (`close_kind`, at `state.last_capsule`).
+
+- **Checkpoint (machinery).** The autofire sensor's stillness-seal is a *checkpoint*, never a completion. When it drives the trusted writer (`runCapsuleVerb()` → `curated-close-pointer.mjs`), the writer's own `writerArgs` unconditionally stamp `close_kind: 'checkpoint'` — a cycle-driven capture and a legacy non-cycle capture are both machinery, regardless of the transcript-stillness mechanics that triggered them. A checkpoint stamp never, by itself, wakes anything downstream.
+- **Completion (voluntary close).** Finalizing the rolling capsule — the operator (or `/context-capsule`) writes a real `waiting_on` into the file `state.capsule_path` already points at — *is* the completion signal. The very next `Stop` hook's `stop-capsule-writer.mjs` observes that this session's own designated capsule has left skeleton (`capsuleLeftSkeleton()`), advances the pointer to it, and stamps `close_kind: 'completion'` with no `cycle_id` (a voluntary close is not a cycle receipt — the two are kept intentionally distinguishable so a downstream wake discriminator can require `close_kind === 'completion'` without ever matching a checkpoint). This stamp happens automatically, from the trusted stop-writer, not from the skill or the agent — the fence below still holds.
+- **One stamp per freeze episode.** Once the stop-writer stamps completion, it also reroutes `state.capsule_path` to a fresh, unfinalized companion capsule (the R2-2 byte-freeze: a finalized capsule's bytes are never touched again). Every subsequent `Stop` hook in the same session merges into that fresh skeleton — never finalized, never advancing the pointer — so the pointer, and its `close_kind: 'completion'` stamp, stay untouched until a genuinely new finalize happens. A session cannot double-fire its own completion signal by continuing to work after closing.
+- **Agents still never stamp anything themselves.** None of the above changes `/context-capsule`'s own fence (`Do NOT stamp digests, pointer, or cycle_token — trusted-writer territory`). The skill's whole job is still: reconcile, write the capsule with a real `waiting_on`, then stop. Finalizing the capsule *is* the completion signal — the stop-writer's automatic stamp is what turns that fact into machinery the rest of the system can key on.
+
 ## Operator sovereignty (never violate)
 
 - **The capsule is best-effort autosave, never a gate.** An operator `/clear` passes through whether or not a capsule landed. Nothing in this system should ever tell the operator to wait on capsule machinery.
 - **A session rotation satisfies any pending refresh cycle** — never re-arm or service a stale cycle against a fresh session.
-- **`/context-capsule` goes quiet after writing.** If an automated refresh cycle is active, the seal fires on transcript stillness; every extra tool call after the write resets that clock.
+- **`/context-capsule` goes quiet after writing.** If an automated refresh cycle is active, the seal fires on transcript stillness (the checkpoint path above); every extra tool call after the write resets that clock. Finalizing the capsule is a separate, immediate completion signal (previous section) and does not depend on stillness at all.
 
 ## Known issue (documented, not fixed here)
 

--- a/skills/context-capsule/SKILL.md
+++ b/skills/context-capsule/SKILL.md
@@ -18,6 +18,10 @@ related:
 
 The threshold-triggered refresh does NOT need this skill — if a fork wires a controller, it injects a RefreshRequest carrying cycle + challenge, and the autofire worker consumes your capsule when the transcript falls still. Invoke `/context-capsule` for the explicit cases: a mid-session checkpoint before risky work, a completion capsule when a thread ships, or a handoff.
 
+## The completion signal (you never stamp it — finalizing IS it)
+
+Whether this capsule reads as a *checkpoint* or a *completion* downstream is decided entirely by what you write in `waiting_on`, not by anything you invoke. Write a real `waiting_on` (a thread genuinely closing, a handoff) and the very next `Stop` hook's trusted stop-writer sees this session's own capsule has left skeleton, advances the pointer to it, and stamps `close_kind: completion` automatically — no `cycle_id`, because a voluntary close is not a cycle receipt. A mid-session checkpoint before risky work is the same STEP 2 write; it just isn't the session's final word, so nothing downstream reads it as completion. Full mechanics: docs/two-verb-lifecycle.md, "Completion signal vs. checkpoint (close_kind)". This does not loosen the fence below — you still never touch the pointer, digest, or cycle_token yourself.
+
 ## Operator sovereignty (never violate)
 
 - The capsule is **best-effort autosave, never a gate**. An operator `/clear` passes through whether or not a capsule landed; never tell the operator to wait on capsule machinery.


### PR DESCRIPTION
Upstream supervisor-lane v3 (3-round Rule-26 gate, 9 confirmed round-2 findings all closed):

- R2-2: stop-writer body merge gated on capsuleLeftSkeleton — finalized capsules are byte-frozen; post-finalize turns roll a fresh auto-capsule; receipts pin their own path+sha; fresh-roll collision fails safe (skip-merge-and-log).
- close_kind contract: closed enum (checkpoint|completion|handoff), single-sourced, refused loudly at write time; capsule-verb stamps checkpoint on all machinery captures; the freeze branch stamps completion once per episode (no cycle_id — voluntary close, never a cycle receipt).
- Docs contract updated in two-verb-lifecycle.md + context-capsule SKILL.md (finalize = immediate completion signal, independent of stillness).

Verified on this branch: pointer-advance 31/0 (guardrails + one-stamp-per-episode asserted), full suite sweep exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Px59mThvCXn7HWH5tz4XRt