### PR TITLE
docs(skill): context-capsule seal line — rolling file + cycle-bound receipt, stillness alone seals nothing

### DIFF
--- a/skills/context-capsule/SKILL.md
+++ b/skills/context-capsule/SKILL.md
@@ -26,7 +26,7 @@ Whether this capsule reads as a *checkpoint* or a *completion* downstream is dec
 
 - The capsule is **best-effort autosave, never a gate**. An operator `/clear` passes through whether or not a capsule landed; never tell the operator to wait on capsule machinery.
 - A session rotation satisfies the cycle — never re-arm or service a refresh cycle against a fresh session.
-- If a RefreshRequest is active: author the capsule, then **go quiet** — the seal fires on transcript stillness. Every extra tool call resets the clock.
+- If a RefreshRequest is active: author your close **into the rolling capsule file the pointer already targets** (finalize its `waiting_on`), then **go quiet**. The seal needs a cycle-bound receipt from the trusted writer — a hand-written side-file is invisible to the machinery, and stillness alone seals nothing.
 
 ## Fences (never cross)
 


### PR DESCRIPTION
One-line contract fix from the c1f777e9 v3 residual: finalize the ROLLING capsule the pointer targets; the seal is a cycle-bound receipt. Supersedes the conflicting standalone docs patch (retired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Px59mThvCXn7HWH5tz4XRt