### PR TITLE
docs: accuracy follow-up — final 4 feature-claim fixes + reviewer minors (board 009a61ad; Codex 50,56,57,58,59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Runs locally. `all-MiniLM-L6-v2` on your machine. **No API calls. No data leaves
 Forget vector databases. Your AI's memory is an **Obsidian vault** — the same tool you can open, read, search, and navigate yourself.
 
 - **Wikilinks** create a knowledge graph. `[[Project Alpha]]` connects to `[[People/Jane]]` connects to `[[Decision Log]]`. The graph IS the intelligence.
-- **Session continuity** without magic. `resume` reads the vault. `capsule` writes to it. Both fire on their own now — no command required. Everything persists. Everything is auditable.
+- **Session continuity** without magic. `resume` reads the vault. `capsule` writes to it. Both fire on their own now — no command required. The Stop autosave is best-effort — it fails open rather than blocking your session — and what it writes is plain Markdown you can open, read, and audit.
 - **Human-first.** You can read every thought your AI has ever had. No hidden embeddings. No opaque database. Markdown files in a folder.
 
 ### Model Routing — Smart Spend
@@ -577,7 +577,7 @@ aigent-OS measures that. Not as a punishment system — as a calibration system.
 - **Decision aging** — for every decision logged 30/60/90 days ago without an outcome captured, surface a one-line prompt. The principal answers in one word; the outcome appends to `DECISION_OUTCOMES.md`.
 - **Attention reconciliation** — last 7 days of daily notes vs `ACTIVE_PRIORITIES.md`. If a Tier 1 project is at <40% of intended share OR a non-priority project consumed >25% of attention, drift is flagged. Forces the principal to either re-prioritize or refocus.
 
-**The bet:** a framework that measures its own calibration compounds. A framework that doesn't, decays. v0.2.2 shipped the substrate; v0.5 shipped the analyzers — `AGENT_FITNESS.md` ledger and `daemons/agent-fitness-report.py` are live. Per-agent calibration ratios populate from real session transcripts automatically via Stop hook.
+**The bet:** a framework that measures its own calibration compounds. A framework that doesn't, decays. v0.2.2 shipped the substrate; v0.5 shipped the analyzers — the `AGENT_FITNESS.md` ledger and `daemons/agent-fitness-report.py` are live. Per-agent calibration ratios are populated on demand: run the extractor (`daemons/agent-fitness-extract.py`, then `agent-fitness-report.py`) over your session transcripts. No hook runs it automatically — the only Stop hook is the capsule autosave.
 
 This is the most credible single claim aigent-OS can make versus other personal-OS frameworks: **the first one that measures its own AI's calibration over time.**
 

--- a/daemons/memory-heat/README.md
+++ b/daemons/memory-heat/README.md
@@ -21,7 +21,7 @@ Output: `vault/memory/HEAT_INDEX.json`
 
 ## When it runs
 
-- **Automatically on `/close`** — the session close skill invokes this at the end so the next `/open` has a fresh prioritization signal.
+- **On demand only** — heat is not wired to a session hook. (Earlier builds invoked it from a `/close` skill; `/close` and `/open` are retired, so run it yourself when you want a fresh prioritization signal.)
 - **Manually** — run the command above any time after a big vault reorg or to test pin changes.
 
 ## Pinning

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -32,7 +32,7 @@ grep -c "__AIGENT_ROOT__" .claude/settings.json  # should print 0
 | `hooks/auto-capture.sh` | PostToolUse | Logs actions to daily note automatically |
 | `daemons/caddy-detect-new-skill.sh` | PostToolUse (Write/Edit) | Detects new skill files, prompts `/caddy-enroll` |
 | `hooks/session-capture-summary.sh` | Stop | Writes session summary at conversation end |
-| `hooks/session-end-check.sh` | Stop | Legacy end-of-session check — superseded by the rolling capsule autosave (`daemons/stop-capsule-writer.mjs`); `/close` is retired |
+| `hooks/session-end-check.sh` | — (not wired) | Legacy end-of-session check — present in the tree but NOT registered by the installer; superseded by the rolling capsule autosave (`daemons/stop-capsule-writer.mjs`); `/close` is retired |
 | `hooks/log-token-usage.sh` | Stop | Logs token cost to vault |
 
 ---

--- a/docs/cognitive-architecture-roadmap.md
+++ b/docs/cognitive-architecture-roadmap.md
@@ -14,7 +14,7 @@ created: 2026-05-08
 
 S39 shipped the infrastructure layer that S40 builds on top of:
 
-- **[[concepts/Skill Taxonomy]]** — 64 skills indexed with multi-word triggers, categories, and fallback chains
+- **[[concepts/Skill Taxonomy]]** — skills enrolled in the Caddy runtime index (`.claude/skill-index.json`) with multi-word triggers; not every on-disk skill is enrolled, and the category taxonomy and fallback chains live separately in `SKILL_LEDGER.md` and `SKILL_CHAINS.md` (which `caddy.sh` consults alongside the index), not as index fields
 - **[[concepts/Self-Learning Doctrine]]** — classify → artifact → prevent recurrence pipeline; /learn-from-failure skill
 - **[[concepts/Temporal Fact Ledger]]** — facts.jsonl with provenance + supersede chains; 10 seed facts
 - **Caddy upgrade** — trigger-phrase matching + taxonomy fallback, catches skills missed by either alone

--- a/docs/creating-agents.md
+++ b/docs/creating-agents.md
@@ -21,9 +21,18 @@ Every agent needs five things:
 
 A markdown file that defines who the agent is. Lives in `vault/agents/`.
 
+> [!important] The installer only registers an agent whose **first 20 lines** contain both a `name:` and a `tools:` YAML key (`install.sh` check). A file missing either is **silently skipped** — no error. Lead the frontmatter with both, as below.
+
 ```markdown
 ---
-title: Architect
+name: Architect
+description: Technical execution lead — code, infrastructure, deployments
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+model: sonnet
 tags:
   - agent
   - engineering

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -15,7 +15,7 @@ Skills are slash commands that trigger predefined workflows. Type the command an
 ## How Skills Work
 
 Each skill is a `SKILL.md` file in `skills/<name>/`. The file contains:
-- **Frontmatter** — name, description, trigger command
+- **Frontmatter** — `name`, `description`, a `triggers` list (plural), and `user-invocable`
 - **Protocol** — Step-by-step instructions for what the skill does
 - **Rules** — Constraints and guardrails
 
@@ -41,7 +41,10 @@ Then copy it to `.claude/skills/my-skill/SKILL.md` for runtime, or run `/caddy-e
 ---
 name: my-skill
 description: What this skill does in one sentence
-trigger: /my-skill
+triggers:
+  - /my-skill
+  - natural-language phrase that should fire it
+user-invocable: true
 ---
 
 # Skill Name

--- a/skills/pause/SKILL.md
+++ b/skills/pause/SKILL.md
@@ -23,9 +23,9 @@ Create a Capsule v2 with `status: paused` capturing full execution state for lat
 
 3. **Set resume_trigger**:
    - `will` → `manual` (the operator decides when to resume)
-   - `agent` → `open` (next /open checks agent status)
+   - `agent` → `open` (resumes at next session boot, which checks agent status)
    - `tool` → `manual` (check tool status on resume)
-   - `external` → `open` (next /open surfaces the wait)
+   - `external` → `open` (resumes at next session boot, surfacing the wait)
 
 4. **Write capsule** — use `/context-capsule` schema with `status: paused`
 
@@ -37,7 +37,7 @@ Create a Capsule v2 with `status: paused` capturing full execution state for lat
    Waiting on: {waiting_on}
    Resume trigger: {resume_trigger}
    Next action: {next_valid_action}
-   Resume with /resume or next /open will offer it.
+   Resume with /resume (offered automatically at next session boot).
    ```
 
 ## Related


### PR DESCRIPTION
Follow-up to #13 (merged @ 3bee302). Completes the docs-accuracy row: the 4 items that waited on the verify-features ground truth (#50 skill-index counts, #56 agent template, #57 triggers: plural, #58 fitness/heat on-demand, #59 best-effort persistence) plus both Rule-26 reviewer minors (unwired session-end-check hook row; stale /open prose in skills/pause). All claims code-verified; Titus own-hand spot-checks: vault/memory file-map move matches disk, caddy-reindex.sh:47 reads plural triggers, zero stale /open prose at tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D54qbh8m1kyptgEfkf2eSo