### PR TITLE
docs: two-verb lifecycle beta (v0.9.0) + known-issue caveat

### DIFF
--- a/daemons/session-engine.md
+++ b/daemons/session-engine.md
@@ -8,7 +8,7 @@ created: 2026-05-11
 # Session Engine
 
 > [!warning] SUPERSEDED — historical design artifact
-> This spec decomposes the **retired** `/open` and `/close` commands. The shipped lifecycle is the two-verb model — `/resume` + `/context-capsule`, auto-firing on `SessionStart`/`Stop`; see [[../docs/two-verb-lifecycle.md|Two-Verb Lifecycle]]. The decomposition below is kept as design history and does NOT describe current shipped behavior. The command files it references (`.claude/commands/open.md`, `.claude/commands/close.md`) do not exist in the current tree.
+> This spec decomposes the **retired** `/open` and `/close` commands. The shipped lifecycle is the two-verb model — `/resume` + `/context-capsule`, auto-firing on `SessionStart`/`Stop`; see [[../docs/two-verb-lifecycle.md|Two-Verb Lifecycle]] — current contract, beta (v0.9.0), see its known-issues note. The decomposition below is kept as design history and does NOT describe current shipped behavior. The command files it references (`.claude/commands/open.md`, `.claude/commands/close.md`) do not exist in the current tree.
 
 > Phase 3 of the [[concepts/aigent-OS Refactor Spec|aigent-OS Refactor]]. Broke `/open` and `/close` from monolithic prompt blobs into discrete, named steps.
 

--- a/docs/capsule-v2-doctrine.md
+++ b/docs/capsule-v2-doctrine.md
@@ -8,7 +8,7 @@ created: 2026-05-08
 # Capsule v2 Doctrine
 
 > [!info] Superseded by the two-verb lifecycle
-> `/open` and `/close` are retired — see [[../docs/two-verb-lifecycle.md|Two-Verb Lifecycle]]. `/resume` absorbs `/open`, `/context-capsule` absorbs `/close`. **The field contract narrowed:** the trusted writer (`daemons/capsule-verb.mjs`, `validateCapsuleText`) requires and validates only four fields — `id`, `objective`, `waiting_on`, `next_valid_action`. The extended v2 fields tabled below (`resume_trigger`, `success_criteria`, `open_questions`, `last_verified_state`, etc.) are optional, advisory prose the writer neither requires nor enforces. Treat [[../docs/two-verb-lifecycle.md|Two-Verb Lifecycle]] — not this historical note — as the current contract.
+> `/open` and `/close` are retired — see [[../docs/two-verb-lifecycle.md|Two-Verb Lifecycle]]. `/resume` absorbs `/open`, `/context-capsule` absorbs `/close`. **The field contract narrowed:** the trusted writer (`daemons/capsule-verb.mjs`, `validateCapsuleText`) requires and validates only four fields — `id`, `objective`, `waiting_on`, `next_valid_action`. The extended v2 fields tabled below (`resume_trigger`, `success_criteria`, `open_questions`, `last_verified_state`, etc.) are optional, advisory prose the writer neither requires nor enforces. Treat [[../docs/two-verb-lifecycle.md|Two-Verb Lifecycle]] — not this historical note — as the current contract, beta (v0.9.0) — see its known-issues note.
 
 > [!abstract] Key insight
 > Capsules are resumable execution state, not summaries. (12-Factor Agents: unify execution state and business state.)

--- a/docs/two-verb-lifecycle.md
+++ b/docs/two-verb-lifecycle.md
@@ -7,6 +7,9 @@ created: 2026-07-17
 
 # Two-Verb Lifecycle
 
+> [!warning] Beta (v0.9.0) — known issue, fix in progress
+> This lifecycle ships as **v0.9.0, BETA**. Known issue, currently being fixed: capsule/resume selection can, in some cases, resume a stale or already-consumed capsule — the "newest valid capsule" check does not yet reject a spent capsule. Separately, auto-commit of the vault to git is not yet wired safely. A fix is in progress and will be ported here once verified; this doc will be updated when it lands. Until then, treat capsule/resume selection as best-effort, not a hard guarantee.
+
 > [!abstract] Core idea
 > Session continuity collapses to exactly two verbs — `/context-capsule` (write state, then stop) and `/resume` (load state, re-ground, act). `/open` and `/close` are retired: resume absorbs open, the capsule verb absorbs close. Both verbs also fire automatically at the right SessionStart/Stop hook points, so the operator rarely needs to invoke them by name.
 


### PR DESCRIPTION
## Summary
Interim honesty caveat — docs-only, no code touched. The shipped two-verb lifecycle is v0.9.0/BETA; a known reliability gap is being fixed on the side and will be ported + reasserted here once verified:

- Capsule/resume selection can, in some cases, resume a stale or already-consumed capsule — the "newest valid capsule" check does not yet reject a spent capsule.
- Auto-commit of the vault to git is not yet wired safely.

## Changes
- `docs/two-verb-lifecycle.md` — new beta/known-issue callout near the top of the doc.
- `docs/capsule-v2-doctrine.md`, `daemons/session-engine.md` — the existing "current contract" pointer to the two-verb doc now notes beta (v0.9.0) status with a link to the known-issues note.

No behavior change. This doc will be updated when the fix lands.

## Test plan
- [x] Frontmatter intact on all 3 files (parsed cleanly)
- [x] `[...]`/`(...)` bracket counts balanced post-edit (no truncated links)
- [x] `git status` clean except the 3 intended files
- [x] Branch pushed, no push/merge to `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug26ki2kyboE32AvmLftQX