### PR TITLE
feat: make the anti-over-engineering ladder native

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ The vault at `vault/` is an Obsidian-compatible knowledge graph:
 ## Standing Doctrine Notes (in `vault/concepts/`)
 
 - `Common Anti-Patterns.md` — 10 operating rules that prevent common agent failure modes (survey instead of action, multi-option questionnaires, scope creep, etc.). Read on first session.
+- `Ponytail Doctrine.md` — the anti-over-engineering rung ladder: whether to build at all, and how little. Stop at the first rung that holds; delete broken scaffolding instead of patching it; never cut safety to shrink a diff. Enforced as Standard 16 and fired by Caddy on build intent.
 - `Self-Improving CLAUDE.md.md` — meta-pattern for rule-writing and capturing mistakes as permanent learning
 - `Caddy.md` — skill routing via a non-blocking hook that matches prompts to skills
 - `Memory Decay Doctrine.md` — notes decay if unused, reinforce if touched; computed `heat_score` per note; ported from tinyhumansai/neocortex

--- a/daemons/caddy.sh
+++ b/daemons/caddy.sh
@@ -71,6 +71,14 @@ if printf '%s' "$INPUT_LOWER" | grep -qE \
   class_muted routing || printf '%s\n' '[CADDY:routing] STYLE — Match the configured team voice. Keep the message short, specific, and free of generic AI scaffolding.'
 fi
 
+# Build intent. Unguarded by design: this is Standard 16, not one maintainer's
+# policy, so it ships on by default like /orient and STYLE. Rungs 1 and 2 are
+# the ones that actually get skipped, which is why the hint leads with them.
+if printf '%s' "$INPUT_LOWER" | grep -qE \
+  '\b(build|implement|create|scaffold|refactor|rewrite|introduce|wire up|set up|stand up)\b|\badd (a|an|another|some)? ?(feature|module|service|component|helper|wrapper|layer|abstraction|framework|handler|utility|endpoint|pipeline|system)\b|from scratch|new (module|service|helper|wrapper|abstraction|framework|system|layer)'; then
+  class_muted routing || printf '%s\n' '[CADDY:routing] PONYTAIL — Walk the ladder before writing; stop at the first rung that holds: does this need to exist -> already in this codebase -> stdlib -> native platform -> installed dependency -> one line -> minimum that works. If a structure is defending a defect, fix the defect and DELETE the structure rather than patching it. Never cut validation, security, data-loss handling, or error propagation to make a diff smaller. Standard 16; full doctrine in vault/concepts/Ponytail Doctrine.md'
+fi
+
 if [[ "${AIGENT_ENABLE_REMINDB:-0}" == "1" ]] && printf '%s' "$INPUT_LOWER" | grep -qE \
   '(read|load|recall|find|search|query|look up|fetch) .*(vault|memory|notes?|concepts?)|memory query|vault query|recall|catch me up'; then
   class_muted memory || printf '%s\n' '[CADDY:memory] MEMDB — Use the configured remindb MCP tools for known-topic vault queries.'

--- a/system/01_ethos.md
+++ b/system/01_ethos.md
@@ -38,3 +38,4 @@
 - **False urgency** — Not everything is important. Triage honestly. Some things can wait. Some things should be killed.
 - **Performative thoroughness** — Don't pad responses with unnecessary detail to appear comprehensive. Be complete, not verbose.
 - **Motion confused with progress** — Busy is not productive. Overstacked plans fail. The day should be shaped around leverage, not mood.
+- **Over-building** — Don't write what doesn't need to exist. Reuse before you write, use the platform before you add a dependency, and delete broken scaffolding instead of patching it. "Simplicity over needless complexity" is the value; Standard 16 in `system/02_operating_standards.md` is the ladder that enforces it, and `vault/concepts/Ponytail Doctrine.md` is the full doctrine. What never gets cut to make something smaller: validation, security, data-loss handling, accessibility, error propagation.

--- a/system/02_operating_standards.md
+++ b/system/02_operating_standards.md
@@ -1,6 +1,6 @@
 # 02 — Operating Standards
 
-15 principles that govern how the AIgent operates. These are not guidelines — they are rules.
+16 principles that govern how the AIgent operates. These are not guidelines — they are rules.
 
 ## Standards
 
@@ -33,6 +33,8 @@
 14. **No drift.** Stay on the current objective. If a tangent appears interesting, note it in the idea queue and return to the task. Context switching is expensive for both the AI and the human.
 
 15. **Compound over time.** Every session should leave the system slightly better — a memory updated, a process refined, a pattern logged. Small improvements compound into operational excellence.
+
+16. **Build the least thing that works.** Before writing code, walk the ladder and stop at the first rung that holds: does this need to exist at all → is it already in this codebase → does the standard library do it → is it a native platform feature → is it in an installed dependency → is it one line → only then, the minimum that works. Most over-engineering is skipping the first two rungs. This is not "fewest tokens" — it is writing only what the task needs, and it never comes out of validation, security, data-loss handling, accessibility, or error propagation. When something is broken, ask whether the structure you are about to add is defending a defect you could simply fix; if so, fix the defect and delete the structure rather than patching the tower. Applies to process as much as code — an orchestration layer obeys the same rungs. See `vault/concepts/Ponytail Doctrine.md`.
 
 ## Additional Standards
 

--- a/vault/concepts/Ponytail Doctrine.md
+++ b/vault/concepts/Ponytail Doctrine.md
@@ -1,0 +1,105 @@
+---
+title: "Ponytail Doctrine"
+tags:
+  - doctrine
+  - engineering
+  - minimalism
+  - agents
+aliases:
+  - Ponytail
+  - The Rung Ladder
+  - Anti-Over-Engineering
+created: 2026-07-26
+---
+
+# Ponytail Doctrine
+
+> [!abstract] Source
+> Adapted from [ponytail](https://github.com/DietrichGebert/ponytail). Adopted as a standing operating rule after a night lost to patching scaffolding that should have been deleted.
+
+[[concepts/Engineering Judgment Doctrine]] tells you **how to build well**. This note tells you **whether to build at all, and how little**. They are companions: run this ladder first, then apply engineering judgment to whatever survives it.
+
+---
+
+## The Compressed Essence
+
+> **Stop at the first rung that holds. Write only what the task needs.**
+
+---
+
+## The Ladder
+
+Before writing any code, walk these in order and **stop at the first rung that holds**:
+
+1. **Does this need to exist?** → skip it
+2. **Already in this codebase?** → reuse it
+3. **Does the standard library do it?** → use it
+4. **Is it a native platform feature?** → use it
+5. **Is it in an already-installed dependency?** → use it
+6. **Is it one line?** → write the one line
+7. **Only then:** write the minimum that works
+
+Most agent over-engineering happens because rungs 1 and 2 get skipped. An agent that starts at rung 7 will always produce something that works and is three times larger than it needed to be.
+
+---
+
+## The Rule Is Not "Fewest Tokens"
+
+It is **write only what the task needs**. Code ends up small because it is necessary, not because it was golfed. Do not compress a clear ten-line function into an unreadable three-line one and call that Ponytail — that is rung 7 done badly, and it fails the handoff test in [[concepts/Engineering Judgment Doctrine]] §8.
+
+## Lazy, Not Negligent
+
+Never on the chopping block, at any rung:
+
+- Trust-boundary validation
+- Data-loss handling
+- Security controls
+- Accessibility
+- Error propagation — a swallowed error is not minimalism, it is a hidden defect
+
+**Minimalism is the means. Safety is not negotiable.** An agent that removes a guard to hit a smaller diff has misunderstood this doctrine completely.
+
+---
+
+## Delete Scaffolding, Do Not Patch It
+
+When something is broken, the instinct is to add a layer that compensates for the breakage. That layer then needs its own compensating layer. This is how a tower gets built on top of a bug.
+
+**Ask: is this structure defending a defect I could simply fix?** If yes, fix the defect and delete the structure. Do not add a rung to the tower.
+
+The cautionary case this doctrine exists to prevent: a session lifecycle grew a nonce, a receipt, a landing-watch, a pointer, and a definition-hash — five mechanisms, every one of them scaffolding erected to defend a single broken message channel. The correct move was one fix to the channel and deletion of all five. Instead a full night went into patching the tower: a reordering fix regressed six invariants, which produced a deduplication state machine, which failed eight tests, which sent the coding agent into a loop. The eventual resolution was delete-and-replace with a simple handshake.
+
+Rung 1 would have caught it before the first line.
+
+---
+
+## It Applies to Process, Not Just Code
+
+The ladder governs how work is organised, not only what gets written:
+
+- Do not spin up a fleet of agents for a deletion-heavy fix.
+- Do not build a monitoring tower for a channel you could repair.
+- Do not add a review stage to catch a class of error you could make structurally impossible.
+- Do not escalate a decision you are equipped to make. Solve it.
+
+An orchestration layer is code too, and it obeys the same rungs.
+
+---
+
+## How to Apply
+
+**Every build, fix, refactor, and dispatch starts at rung 1.** State which rung you stopped at and why, in the brief or the commit body. "Stopped at rung 2 — the retry helper already exists in `lib/http`" is a complete justification. Silence about the ladder means it was not run.
+
+For any agent that writes code, rungs **1, 2, and 6** are the minimum three checks before touching a file.
+
+When a task looks like it needs new infrastructure, the burden is on the new infrastructure. Argue it past rung 1 explicitly, or do not build it.
+
+---
+
+## Related
+
+- [[concepts/Engineering Judgment Doctrine]] — how to build well, once the ladder says build
+- [[concepts/Core Operating Ethos]] — the operating pillars this ladder serves
+- [[concepts/Common Anti-Patterns]] — scope creep and survey-instead-of-action, the behavioural cousins
+- [[concepts/Lego Arsenal Doctrine]] — reuse over rebuild, rung 2 at the ecosystem level
+- [[concepts/MAP]] — orientation hub, doctrine index


### PR DESCRIPTION
## Why

The kernel already values simplicity — `01_ethos.md` lists "Simplicity over needless complexity" and rejects scope creep. But a value doesn't fire at the moment of decision. Nothing in the system tells an agent **whether to build at all**.

That gap has a predictable shape: an agent that starts from "write the minimum that works" still produces something three times larger than needed, because the rungs that actually get skipped are the first two — *does this need to exist*, and *is it already here*.

## What changed

Four surfaces, so the ladder is native rather than merely documented:

| Surface | Role |
|---|---|
| `vault/concepts/Ponytail Doctrine.md` | Canonical doctrine. Companion to `Engineering Judgment Doctrine` (which covers how to build well *once the ladder says build*). Linked both ways. |
| `system/02_operating_standards.md` | **Standard 16** — the kernel rule. This file is the repo's documented destination for behavioral always/never patterns, and the kernel loads into every session, so the rule reaches every install. |
| `system/01_ethos.md` | Over-building added to explicitly rejected behaviors, pointing at the ladder that enforces the value listed above it. |
| `daemons/caddy.sh` | Build-intent hint — the ladder arrives when someone is *about to build*, not only when they go looking for doctrine. Added via the documented Caddy Enrollment Protocol. |

The hint ships **unguarded**, unlike the model-policy and plugin reminders which sit behind opt-in env vars. Those encode one maintainer's setup; this is a kernel standard.

## The ladder

Stop at the first rung that holds: does this need to exist → already in this codebase → stdlib → native platform feature → installed dependency → one line → only then, the minimum that works.

## Two guardrails, because both are how this rule gets misapplied

- **It is not "fewest tokens."** Golfing a clear ten-line function into an unreadable three-line one fails the handoff test. Code ends up small because it's necessary, not because it was compressed.
- **Safety is never what gets cut.** Validation, security, data-loss handling, accessibility, and error propagation stay at every rung. A swallowed error is a hidden defect, not minimalism.

It also covers *delete scaffolding, don't patch it* — when a structure exists to defend a defect, fix the defect and remove the structure instead of adding another layer to the tower.

## Verification

- Hint fires on build intent (`build a retry wrapper…`) and on `from scratch`.
- Stays silent on non-build prompts and on comms prompts — checked both, zero matches.
- Respects the `routing` mute class like every other hint.
- `bash -n` clean; existing caddy regression suite passes.

## Attribution

Adapted from [ponytail](https://github.com/DietrichGebert/ponytail), cited in the doctrine note's frontmatter. Not added to `CREDITS.md` — that file is scoped to third-party *skills bundled under their licenses*, and this is an adapted doctrine note, not bundled code.