### PR TITLE
Make automatic capsules truthful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
           daemons/tests/capsule-verb.test.mjs
           daemons/tests/capsule-content-gate.test.mjs
           daemons/tests/state-home-dir.test.mjs
+          daemons/tests/stop-capsule-writer.test.mjs
 
       - name: Semantic-search confidential-class deny-list tests
         run: node daemons/tests/semantic-search-deny.test.mjs

--- a/daemons/capsule-verb.mjs
+++ b/daemons/capsule-verb.mjs
@@ -19,8 +19,16 @@ function frontmatterScalar(frontmatter, key) {
   const match = frontmatter.match(new RegExp(`^${key}:[ \\t]*(.*)$`, 'm'));
   if (!match) return null;
   let value = match[1].trim();
-  if ((value.startsWith('"') && value.endsWith('"'))
-    || (value.startsWith("'") && value.endsWith("'"))) {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    // Writer-owned frontmatter uses JSON.stringify(), so decode its escapes
+    // before returning the field. Fall back to quote stripping for valid YAML
+    // double-quoted scalars that are not also valid JSON strings.
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed === 'string') return parsed.trim();
+    } catch { /* YAML scalar fallback below */ }
+    value = value.slice(1, -1).trim();
+  } else if (value.startsWith("'") && value.endsWith("'")) {
     value = value.slice(1, -1).trim();
   } else {
     value = value.replace(/\s+#.*$/, '').trim();

--- a/daemons/resume-verb.mjs
+++ b/daemons/resume-verb.mjs
@@ -136,24 +136,27 @@ function capsuleAgeLines(loaded) {
   return lines;
 }
 
-// The Stop-hook autosave is a delta snapshot wearing a capsule's schema. Its
-// objective is a fixed placeholder, waiting_on is hardcoded null in the writer's
-// skeleton, and next_valid_action is a generic line padded with truncated prose
-// from the last turn. Every required field is non-empty, so the selector accepts
-// it — correctly, since there may be nothing else on disk. The gap is that the
-// session cannot tell it apart from a curated capsule once both arrive through
-// the same procedure, so a null waiting_on reads as "nothing pends" when it
-// means "unknown", and the padding reads as an instruction.
+// The Stop-hook autosave is a delta snapshot wearing a capsule's schema, not a
+// contract reconciled against live state. Current and legacy shapes coexist on
+// disk until each legacy autosave is healed by its next Stop write, so the
+// procedure must explain both without treating either one's fields as commands.
 function autosaveLines(loaded) {
   if (!loaded || !loaded.autosave) return [];
   return [
     '',
     '  *** AUTOSAVE, NOT A CURATED CAPSULE ***',
-    '  Written by the Stop hook from a session delta. `objective` is a fixed placeholder,',
-    '  `waiting_on` is hardcoded null and means UNKNOWN rather than "nothing pends", and',
-    '  `next_valid_action` is generic text padded with a truncated fragment of the last turn.',
-    '  None of that is a resume contract. Treat it as evidence a session ended, derive the',
-    '  next action from live memory, and do not read the padding as an instruction.',
+    '  Written by the Stop hook from a session delta. It records that a session ended;',
+    '  it is not a resume contract and was never reconciled against live state.',
+    '  Two shapes exist on disk, and the difference matters:',
+    '    CURRENT — an undetermined field carries an EXPLICIT unknown marker, while',
+    '    next_valid_action names claimed-row evidence or states plainly that none was',
+    '    captured. An unknown marker means UNKNOWN; it does not mean nothing is pending.',
+    '    LEGACY (written before this fix; healed on that session\'s next Stop) — a fixed',
+    '    placeholder objective, a bare null waiting_on, and a next_valid_action padded',
+    '    with truncated prose, often severed mid-sentence.',
+    '  In BOTH shapes, treat this only as evidence a session ended and derive the next',
+    '  action from live memory. Never read padding as an instruction, and never read an',
+    '  absent or unknown value as "nothing is pending".',
   ];
 }
 

--- a/daemons/stop-capsule-writer.mjs
+++ b/daemons/stop-capsule-writer.mjs
@@ -115,8 +115,41 @@ try {
   // injection-echo/ceremony, shared with capsule-verb's validateCapsuleText.
   // Import failure degrades to pre-gate behavior (logged, never blocks a turn).
   let gate = null;
-  try { gate = await import('./capsule-content-gate.mjs'); }
-  catch (e) { logErr(root, `content-gate import failed (gate skipped): ${e?.message || e}`); }
+  try {
+    gate = await import('./capsule-content-gate.mjs');
+    if (typeof gate.isInjectionEcho !== 'function') {
+      throw new TypeError('capsule-content-gate.mjs did not export isInjectionEcho()');
+    }
+  } catch (e) {
+    gate = null;
+    logErr(root, `content-gate import failed (gate skipped): ${e?.message || e}`);
+  }
+  const isInjectionEcho = (text) => {
+    if (!gate) return false;
+    try {
+      return Boolean(gate.isInjectionEcho(text));
+    } catch (e) {
+      // Treat a broken gate like an import failure for the rest of this worker.
+      // Falling back may capture noisier data, but the Stop snapshot still lands.
+      gate = null;
+      logErr(root, `content-gate check failed (gate skipped; write continues fail-open): ${e?.message || e}`);
+      return false;
+    }
+  };
+
+  // Keep validation inside the worker's fail-open boundary. A broken or missing
+  // validator is diagnostic: it must be visible, but must never prevent the best
+  // available Stop snapshot from landing.
+  let validateCapsuleText = null;
+  try {
+    ({ validateCapsuleText } = await import('./capsule-verb.mjs'));
+    if (typeof validateCapsuleText !== 'function') {
+      throw new TypeError('capsule-verb.mjs did not export validateCapsuleText()');
+    }
+  } catch (e) {
+    validateCapsuleText = null;
+    logErr(root, `capsule validator import failed (write continues fail-open): ${e?.message || e}`);
+  }
 
   const MEM = memRoot(root);
   const RUNTIME = path.join(MEM, 'runtime', 'stop-writer');
@@ -203,7 +236,7 @@ try {
     // otherwise fall through to [OPERATOR] — which makes injected instruction
     // text the capsule OBJECTIVE verbatim. Gate them out of human-hood; they stay
     // recoverable as tagged utterances under Done.
-    if (gate && gate.isInjectionEcho(t)) return { who: 'INJECT:harness', human: false, t };
+    if (isInjectionEcho(t)) return { who: 'INJECT:harness', human: false, t };
     return { who: 'OPERATOR', human: true, t };
   };
   const tagUtterance = (cl) => {
@@ -223,6 +256,9 @@ try {
     if (!t) continue;
     let ev;
     try { ev = JSON.parse(t); } catch { continue; } // partial trailing lines are normal
+    // JSON primitives and malformed content blocks are valid JSON but not
+    // transcript events. Skip them instead of abandoning the entire Stop delta.
+    if (!ev || typeof ev !== 'object' || Array.isArray(ev)) continue;
 
     if (ev.type === 'user' && !ev.isMeta) {
       const c = ev.message?.content;
@@ -231,21 +267,32 @@ try {
         if (clean && !clean.startsWith('<')) { const cl = classify(clean); if (cl.human) latestRequest = clean.slice(0, 300); tagUtterance(cl); }
       } else if (Array.isArray(c)) {
         for (const b of c) {
-          if (b.type === 'text' && b.text) {
+          if (!b || typeof b !== 'object' || Array.isArray(b)) continue;
+          if (b.type === 'text' && typeof b.text === 'string' && b.text) {
             const clean = stripMeta(b.text);
             if (clean && !clean.startsWith('<')) { const cl = classify(clean); if (cl.human) latestRequest = clean.slice(0, 300); tagUtterance(cl); }
           }
           if (b.type === 'tool_result' && b.is_error) {
             const txt = typeof b.content === 'string'
               ? b.content
-              : Array.isArray(b.content) ? b.content.filter((x) => x.type === 'text').map((x) => x.text).join(' ') : '';
+              : Array.isArray(b.content)
+                ? b.content
+                  .filter((x) => x && typeof x === 'object'
+                    && !Array.isArray(x) && x.type === 'text' && typeof x.text === 'string')
+                  .map((x) => x.text).join(' ')
+                : '';
             if (txt) errors.push(txt.replace(/\s+/g, ' ').slice(0, 200));
           }
         }
       }
     } else if (ev.type === 'assistant') {
-      for (const b of ev.message?.content ?? []) {
-        if (b.type === 'text' && b.text?.trim()) lastAssistantText = b.text.trim();
+      const content = ev.message?.content;
+      if (!Array.isArray(content)) continue;
+      for (const b of content) {
+        if (!b || typeof b !== 'object' || Array.isArray(b)) continue;
+        if (b.type === 'text' && typeof b.text === 'string' && b.text.trim()) {
+          lastAssistantText = b.text.trim();
+        }
         if (b.type !== 'tool_use') continue;
         const input = b.input ?? {};
         if (b.name === 'Read' || b.name === 'Grep' || b.name === 'Glob') {
@@ -253,10 +300,11 @@ try {
           if (p) filesRead.add(String(p));
         } else if (b.name === 'Edit' || b.name === 'Write' || b.name === 'NotebookEdit') {
           if (input.file_path) filesModified.add(String(input.file_path));
-        } else if (/(^|_)board_claim$/i.test(String(b.name || '')) && input.task_id) {
+        } else if (/(^|_)board_claim$/i.test(String(b.name || ''))
+          && typeof input.task_id === 'string' && input.task_id.trim()) {
           // Generic match on any *_board_claim tool (an optional task-board MCP,
           // whatever it is named) rather than one hardcoded server name.
-          claimedRows.add(String(input.task_id));
+          claimedRows.add(input.task_id.trim());
         }
       }
     }
@@ -290,23 +338,30 @@ try {
     capPath = path.join(capDir, `${dateStr}-auto-${sid.slice(0, 8)}.md`);
   }
 
-  // objective only ever carries a REAL human utterance — the classifier already
-  // gates injections; this re-check is defense in depth. When no human spoke this
-  // turn, nothing is synthesized: the ownership rule below keeps an existing
-  // capsule's objective untouched, and the skeleton default is only ever born at
-  // capsule creation.
-  const humanRequest = (latestRequest && !(gate && gate.isInjectionEcho(latestRequest)))
+  // Only a real operator utterance establishes the objective. A claim identifies
+  // a row, not what the operator intended to accomplish. When no objective was
+  // captured, say so explicitly.
+  const humanRequest = (latestRequest && !isInjectionEcho(latestRequest))
     ? latestRequest : null;
-  const objective = humanRequest || 'In-flight work (auto-captured; see latest session log)';
-  // next_valid_action must carry CONTENT (claimed rows, live assistant state) —
-  // templates like "Re-read the active turn state below..." are exactly what
-  // capsule-verb's content gate bans; this template must never match it.
-  const rowHint = claimedRows.size
-    ? `Re-verify claimed row(s) ${[...claimedRows].map((r) => r.slice(0, 8)).join(', ')} against the live memory, then continue that work`
-    : 'Re-derive the next action from the live memory (autosave carries deltas only)';
-  const nextValid = lastAssistantText
-    ? `${rowHint}; last assistant state: ${lastAssistantText.replace(/\s+/g, ' ').slice(0, 180)}`
-    : rowHint;
+  const rowIds = [...claimedRows].map((r) => r.slice(0, 8)).join(', ');
+  const unknownObjective = claimedRows.size
+    ? `Unknown: no operator objective was captured; claimed row id(s) ${rowIds} were observed.`
+    : 'Unknown: no operator objective was captured in this Stop delta.';
+  const objective = humanRequest || unknownObjective;
+
+  // The transcript has no trustworthy structured "waiting on" event. Tool
+  // errors are possible blockers, but even then their pending status is unknown.
+  // State that uncertainty instead of encoding YAML null ("nothing is pending").
+  const waitingOn = errors.length
+    ? `Unknown: ${errors.length} captured tool error(s) may be pending; inspect Historical-Errors.`
+    : 'Unknown: this Stop delta did not capture whether anything is pending.';
+
+  // A next action comes only from structured evidence. Assistant prose remains
+  // reference material in the body; truncating it into this field would turn a
+  // fragment into an instruction.
+  const nextValid = claimedRows.size
+    ? `Re-verify claimed row(s) ${rowIds} against the live memory, then continue that claimed work.`
+    : 'No concrete next action was captured in this Stop delta.';
 
   const ANCHORS = {
     done: '<!-- swe:done -->',
@@ -324,7 +379,7 @@ id: ${dateStr}-auto-${sid.slice(0, 8)}
 parent_capsule_id: null
 status: active
 objective: ${JSON.stringify(objective)}
-waiting_on: null
+waiting_on: ${JSON.stringify(waitingOn)}
 resume_trigger: compact
 expires: null
 trigger: stop-delta
@@ -405,18 +460,65 @@ ${ANCHORS.rows}
     mergeUnder(ANCHORS.done, [`- ${ts} ${lastAssistantText.replace(/\s+/g, ' ').slice(0, 240)}`]);
   }
 
-  // Refresh live frontmatter fields — the rolling writer only RAISES content,
-  // never downgrades it. objective moves only on a real human utterance, and the
-  // contract fields are touched at all ONLY on the writer's own autosave capsules
-  // (tags carry `autosave`) — deliberate/curated capsules own their frontmatter
-  // outright. Body bullets can never match (always `- `-prefixed) and .replace is
-  // leftmost-first so frontmatter wins.
-  const docTags = ((doc.match(/^tags:\s*(.+)\s*$/m) || [])[1] || '').toLowerCase();
-  if (/\bautosave\b/.test(docTags)) {
+  // Refresh live frontmatter fields. objective moves only on a real operator
+  // utterance (apart from healing the legacy placeholder), while next_valid_action
+  // is refreshed from structured evidence or an explicit no-action marker.
+  // Contract fields are touched ONLY on the writer's own autosave capsules (an
+  // exact `autosave` tag plus trigger `stop-delta`) — deliberate/curated capsules
+  // own their frontmatter outright. Body bullets can never confer ownership.
+  const frontmatterValue = (source, key) => {
+    const leadingFrontmatter = String(source)
+      .match(/^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/)?.[1] || '';
+    const raw = leadingFrontmatter.match(new RegExp(`^${key}:[ \\t]*(.*)$`, 'm'))?.[1]?.trim();
+    if (!raw) return '';
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed === 'string') return parsed;
+    } catch { /* plain YAML scalar */ }
+    return raw.replace(/\s+#.*$/, '').replace(/^['"]|['"]$/g, '').trim();
+  };
+  const autosaveTag = frontmatterValue(doc, 'tags')
+    .replace(/^\[|\]$/g, '')
+    .split(',')
+    .map((tag) => tag.trim().replace(/^['"]|['"]$/g, '').toLowerCase())
+    .includes('autosave');
+  const writerOwnedAutosave = autosaveTag
+    && frontmatterValue(doc, 'trigger').toLowerCase() === 'stop-delta';
+  if (writerOwnedAutosave) {
     if (humanRequest) {
       doc = doc.replace(/^objective: .*$/m, `objective: ${JSON.stringify(objective)}`);
+    } else {
+      // Heal writer-owned autosaves created by the old skeleton without
+      // overwriting a meaningful objective retained from an earlier turn.
+      doc = doc.replace(
+        `objective: ${JSON.stringify('In-flight work (auto-captured; see latest session log)')}`,
+        `objective: ${JSON.stringify(objective)}`,
+      );
     }
+    // In the capsule schema, unquoted null means "nothing is pending." The old
+    // autosave never knew that, so migrate it to an honest unknown marker.
+    doc = doc.replace(
+      /^waiting_on:[ \t]*(?:null|~)[ \t]*$/mi,
+      `waiting_on: ${JSON.stringify(waitingOn)}`,
+    );
     doc = doc.replace(/^next_valid_action: .*$/m, `next_valid_action: ${JSON.stringify(nextValid)}`);
+  }
+
+  // Validate the exact final document, after every merge and frontmatter
+  // refresh. Problems, malformed results, and thrown exceptions are logged, but
+  // the snapshot still writes: a Stop hook must always fail open.
+  if (validateCapsuleText) {
+    try {
+      const validation = validateCapsuleText(doc);
+      if (!validation || !Array.isArray(validation.problems)) {
+        throw new TypeError('validateCapsuleText() returned an unexpected result');
+      }
+      if (validation.problems.length) {
+        logErr(root, `capsule validation reported ${validation.problems.length} problem(s); write continues fail-open: ${validation.problems.join(' | ').slice(0, 1200)}`);
+      }
+    } catch (e) {
+      logErr(root, `capsule validation threw; write continues fail-open: ${e?.stack || e}`);
+    }
   }
 
   // Write the capsule. tmp+rename first; if rename can't land (AV lock etc.),
@@ -424,14 +526,27 @@ ${ANCHORS.rows}
   // lands, exit WITHOUT advancing state so next turn retries this same delta.
   const tmp = capPath + '.tmp';
   let committed = false;
-  writeFileSync(tmp, doc);
-  try { renameSync(tmp, capPath); committed = true; } catch {
-    try { rmSync(capPath, { force: true }); renameSync(tmp, capPath); committed = true; } catch {
-      try { writeFileSync(capPath, doc); committed = true; rmSync(tmp, { force: true }); } catch (e3) {
-        logErr(root, `capsule write failed (tmp+rename AND direct): ${e3?.message || e3} — state NOT advanced, will retry next turn`);
+  let staged = false;
+  try {
+    writeFileSync(tmp, doc);
+    staged = true;
+  } catch (e) {
+    logErr(root, `capsule tmp write failed; attempting direct write: ${e?.message || e}`);
+  }
+  if (staged) {
+    try { renameSync(tmp, capPath); committed = true; } catch {
+      try { rmSync(capPath, { force: true }); renameSync(tmp, capPath); committed = true; } catch {
+        // Direct fallback below also covers a rename failure after the target
+        // was removed.
       }
     }
   }
+  if (!committed) {
+    try { writeFileSync(capPath, doc); committed = true; } catch (e3) {
+      logErr(root, `capsule write failed (tmp+rename AND direct): ${e3?.message || e3} — state NOT advanced, will retry next turn`);
+    }
+  }
+  try { rmSync(tmp, { force: true }); } catch {}
   if (!committed) { outcome = 'error:write-failed'; process.exit(0); }
 
   // Pointer: aigent-OS is single-operator, so the pointer always lives at
@@ -442,7 +557,9 @@ ${ANCHORS.rows}
   const pointer = {
     id: path.basename(capPath, '.md'),
     path: path.relative(root, capPath).replace(/\\/g, '/'),
-    objective,
+    // Read from the exact final document so a retained objective on a rolling
+    // autosave cannot be replaced in the pointer by this delta's unknown marker.
+    objective: frontmatterValue(doc, 'objective') || objective,
     status: 'active',
     created_at: new Date().toISOString(),
     trigger: 'stop-delta',

--- a/daemons/tests/capsule-verb.test.mjs
+++ b/daemons/tests/capsule-verb.test.mjs
@@ -32,6 +32,17 @@ test('valid capsule text passes with no problems', () => {
   assert.equal(fields.next_valid_action, 'Run the daemon test suite');
 });
 
+test('JSON-quoted frontmatter scalars decode embedded quotes and backslashes', () => {
+  const objective = 'Fix the "quoted" C:\\capsule path';
+  const quoted = VALID.replace(
+    'objective: "Finish the daemon reconcile"',
+    `objective: ${JSON.stringify(objective)}`,
+  );
+  const { fields, problems } = validateCapsuleText(quoted);
+  assert.deepEqual(problems, []);
+  assert.equal(fields.objective, objective);
+});
+
 test('missing frontmatter block is refused', () => {
   const { fields, problems } = validateCapsuleText('no frontmatter here\n');
   assert.deepEqual(fields, {});

--- a/daemons/tests/resume-verb.test.mjs
+++ b/daemons/tests/resume-verb.test.mjs
@@ -575,7 +575,7 @@ test('reporting age never rejects: a stale capsule is still selected', () => {
   }
 });
 
-test('an autosave is named as one and its empty fields are given their real meaning', () => {
+test('an autosave is named and both current and legacy field shapes are explained', () => {
   const fixture = mkFixture();
   try {
     // The real autosave shape: placeholder objective, null waiting_on, and a next
@@ -590,8 +590,11 @@ test('an autosave is named as one and its empty fields are given their real mean
     const result = runResumeVerb({ projectRoot: fixture.root, source: 'clear', sessionId: 'sid-auto' });
     assert.equal(result.loaded.autosave, true);
     assert.match(result.prompt, /\*\*\* AUTOSAVE, NOT A CURATED CAPSULE \*\*\*/);
-    assert.match(result.prompt, /hardcoded null and means UNKNOWN rather than "nothing pends"/);
-    assert.match(result.prompt, /do not read the padding as an instruction/);
+    assert.match(result.prompt, /CURRENT — an undetermined field carries an EXPLICIT unknown marker/);
+    assert.match(result.prompt, /An unknown marker means UNKNOWN; it does not mean nothing is pending/);
+    assert.match(result.prompt, /LEGACY \(written before this fix; healed on that session's next Stop\)/);
+    assert.match(result.prompt, /Never read padding as an instruction/);
+    assert.match(result.prompt, /never read an\s+absent or unknown value as "nothing is pending"/);
   } finally {
     rmSync(fixture.base, { recursive: true, force: true });
   }

--- a/daemons/tests/stop-capsule-writer.test.mjs
+++ b/daemons/tests/stop-capsule-writer.test.mjs
@@ -1,0 +1,682 @@
+// stop-capsule-writer.test.mjs — autosave capsule truthfulness + fail-open guard.
+//
+// Black-box by design: every case spawns the shipped worker against an isolated
+// OS-temp memory root and inspects the capsule that actually landed. Validator
+// and content-gate failure cases copy the shipped daemon plus its static local
+// dependencies, then replace only the dependency whose failure is under test.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { validateCapsuleText } from '../capsule-verb.mjs';
+import { FRAMING_KEYS } from '../memory-hygiene/resume-framing.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DAEMONS = path.join(__dirname, '..');
+const DAEMON = process.env.SCW_DAEMON
+  || path.join(DAEMONS, 'stop-capsule-writer.mjs');
+const CAPSULE_VERB = path.join(DAEMONS, 'capsule-verb.mjs');
+const CONTENT_GATE = path.join(DAEMONS, 'capsule-content-gate.mjs');
+const LIFECYCLE_COMMON = path.join(DAEMONS, 'lifecycle-common.mjs');
+const RESUME_FRAMING = path.join(DAEMONS, 'memory-hygiene', 'resume-framing.mjs');
+const ATOMIC_STATE = path.join(DAEMONS, 'memory-hygiene', 'atomic-state.cjs');
+
+const LEGACY_OBJECTIVE = 'In-flight work (auto-captured; see latest session log)';
+const LEGACY_NEXT_ACTION = 'Re-derive the next action from live memory; last assistant state: severed mid-work';
+const NO_ACTION = 'No concrete next action was captured in this Stop delta.';
+const ASSISTANT_SENTINEL = 'RAW_ASSISTANT_SENTINEL should stay in the reference body only';
+const FRONTMATTER_FIELDS = [
+  'id', 'parent_capsule_id', 'status', 'objective', 'waiting_on',
+  'resume_trigger', 'expires', 'trigger', 'next_valid_action',
+  'success_criteria', 'tags', 'created_at', 'resolved_at',
+  ...FRAMING_KEYS,
+];
+const ANCHORS = [
+  '<!-- swe:done -->',
+  '<!-- swe:errors -->',
+  '<!-- swe:rejected -->',
+  '<!-- swe:files -->',
+  '<!-- swe:facts -->',
+  '<!-- swe:gates -->',
+  '<!-- swe:rows -->',
+];
+const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+function makeFixture() {
+  const base = mkdtempSync(path.join(tmpdir(), 'stop-capsule-writer-'));
+  const root = path.join(base, 'test-root');
+  const memory = path.join(root, 'memory');
+  const capsules = path.join(memory, 'capsules');
+  mkdirSync(capsules, { recursive: true });
+  writeFileSync(path.join(memory, 'BODY_STATE.json'), JSON.stringify({ state: {} }));
+  return { base, root, memory, capsules };
+}
+
+function runWorker(fixture, events, {
+  daemon = DAEMON,
+  sessionId = '01234567-test-session',
+  env = {},
+} = {}) {
+  const transcriptPath = path.join(fixture.root, `${sessionId}.jsonl`);
+  writeFileSync(transcriptPath, `${events.map((event) => JSON.stringify(event)).join('\n')}\n`);
+  const payload = {
+    __root: fixture.root,
+    session_id: sessionId,
+    transcript_path: transcriptPath,
+  };
+  const run = spawnSync(process.execPath, [daemon, '--worker', JSON.stringify(payload)], {
+    cwd: fixture.root,
+    encoding: 'utf8',
+    timeout: 15_000,
+    windowsHide: true,
+    env: {
+      ...process.env,
+      AIGENT_ROOT: fixture.root,
+      AIGENT_STATE_HOME_DIR: '',
+      AIGENT_SEAT_ID: '',
+      CLAUDE_PROJECT_DIR: '',
+      LIFECYCLE_KILL_STOP_WRITER: '0',
+      ...env,
+    },
+  });
+  const statePath = path.join(fixture.memory, 'runtime', 'stop-writer', `${sessionId}.json`);
+  const state = existsSync(statePath)
+    ? JSON.parse(readFileSync(statePath, 'utf8'))
+    : null;
+  const capsulePath = state?.capsule_path || null;
+  const doc = capsulePath && existsSync(capsulePath)
+    ? readFileSync(capsulePath, 'utf8')
+    : null;
+  return { run, state, capsulePath, doc };
+}
+
+function expectedCapsulePath(fixture, sessionId) {
+  const date = new Date().toISOString().slice(0, 10);
+  return path.join(fixture.capsules, `${date}-auto-${sessionId.slice(0, 8)}.md`);
+}
+
+function assistantEvent(text = ASSISTANT_SENTINEL) {
+  return {
+    type: 'assistant',
+    message: { content: [{ type: 'text', text }] },
+  };
+}
+
+function userEvent(text) {
+  return {
+    type: 'user',
+    isMeta: false,
+    message: { content: text },
+  };
+}
+
+function claimEvent(rowId, text = ASSISTANT_SENTINEL) {
+  return {
+    type: 'assistant',
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          name: 'mcp__tasks__board_claim',
+          input: { task_id: rowId },
+        },
+        { type: 'text', text },
+      ],
+    },
+  };
+}
+
+function fileWriteEvent(filePath, text = ASSISTANT_SENTINEL) {
+  return {
+    type: 'assistant',
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          name: 'Write',
+          input: { file_path: filePath },
+        },
+        { type: 'text', text },
+      ],
+    },
+  };
+}
+
+function toolErrorEvent(message) {
+  return {
+    type: 'user',
+    isMeta: false,
+    message: {
+      content: [{ type: 'tool_result', is_error: true, content: message }],
+    },
+  };
+}
+
+function frontmatterKeys(doc) {
+  const frontmatter = doc.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)?.[1];
+  assert.ok(frontmatter, 'capsule must have closed leading frontmatter');
+  return frontmatter.split(/\r?\n/)
+    .map((line) => line.match(/^([a-z_]+):/)?.[1])
+    .filter(Boolean);
+}
+
+function bodyPointer(fixture) {
+  return JSON.parse(
+    readFileSync(path.join(fixture.memory, 'BODY_STATE.json'), 'utf8'),
+  ).state.last_capsule;
+}
+
+function errorLog(fixture) {
+  const file = path.join(fixture.memory, '.daemon-errors.log');
+  return existsSync(file) ? readFileSync(file, 'utf8') : '';
+}
+
+function assertWorkerFlushed(result) {
+  assert.equal(result.run.status, 0, result.run.stderr);
+  assert.match(result.run.stdout || '', /SWE_OUTCOME:flushed/);
+  assert.ok(result.doc?.length, 'worker must land a non-empty capsule');
+}
+
+function withFixture(run) {
+  const fixture = makeFixture();
+  try {
+    return run(fixture);
+  } finally {
+    rmSync(fixture.base, { recursive: true, force: true });
+  }
+}
+
+function existingCapsule({
+  id,
+  objective = LEGACY_OBJECTIVE,
+  waitingOn = 'null',
+  nextAction = JSON.stringify(LEGACY_NEXT_ACTION),
+  tagsLine = 'tags: [capsule, autosave]',
+  bodyTail = '',
+}) {
+  return `---
+id: ${id}
+parent_capsule_id: null
+status: active
+objective: ${JSON.stringify(objective)}
+waiting_on: ${waitingOn}
+resume_trigger: compact
+expires: null
+trigger: stop-delta
+next_valid_action: ${nextAction}
+success_criteria: []
+${tagsLine ? `${tagsLine}\n` : ''}created_at: 2026-07-27T00:00:00.000Z
+resolved_at: null
+---
+
+## Done (don't redo)
+<!-- swe:done -->
+
+## Historical-Errors → Resolutions
+<!-- swe:errors -->
+
+## Historical-Rejected-Approaches
+<!-- swe:rejected -->
+
+## Files-Read / Files-Modified
+<!-- swe:files -->
+
+## Operating-Facts
+<!-- swe:facts -->
+
+## Pending-Gates
+<!-- swe:gates -->
+
+## Claimed-Rows
+<!-- swe:rows -->
+${bodyTail}`;
+}
+
+function installExistingCapsule(fixture, sessionId, doc, name = `${sessionId}.md`) {
+  const capsulePath = path.join(fixture.capsules, name);
+  writeFileSync(capsulePath, doc);
+  const runtime = path.join(fixture.memory, 'runtime', 'stop-writer');
+  mkdirSync(runtime, { recursive: true });
+  writeFileSync(path.join(runtime, `${sessionId}.json`), JSON.stringify({
+    offset: 0,
+    capsule_path: capsulePath,
+    last_delta_sha: null,
+  }));
+  return capsulePath;
+}
+
+function writeInstrumentedDaemon(fixture, {
+  validatorSource = null,
+  gateSource = null,
+} = {}) {
+  const daemonDir = path.join(fixture.base, 'instrumented-daemons');
+  const hygieneDir = path.join(daemonDir, 'memory-hygiene');
+  mkdirSync(hygieneDir, { recursive: true });
+
+  const daemon = path.join(daemonDir, 'stop-capsule-writer.mjs');
+  copyFileSync(DAEMON, daemon);
+  copyFileSync(LIFECYCLE_COMMON, path.join(daemonDir, 'lifecycle-common.mjs'));
+  copyFileSync(RESUME_FRAMING, path.join(hygieneDir, 'resume-framing.mjs'));
+  copyFileSync(ATOMIC_STATE, path.join(hygieneDir, 'atomic-state.cjs'));
+
+  if (gateSource === null) copyFileSync(CONTENT_GATE, path.join(daemonDir, 'capsule-content-gate.mjs'));
+  else writeFileSync(path.join(daemonDir, 'capsule-content-gate.mjs'), gateSource);
+
+  if (validatorSource === null) copyFileSync(CAPSULE_VERB, path.join(daemonDir, 'capsule-verb.mjs'));
+  else writeFileSync(path.join(daemonDir, 'capsule-verb.mjs'), validatorSource);
+  return daemon;
+}
+
+test('fresh assistant-only autosave names an unknown objective instead of the legacy placeholder', () => {
+  withFixture((fixture) => {
+    const result = runWorker(fixture, [assistantEvent()]);
+    assertWorkerFlushed(result);
+    const checked = validateCapsuleText(result.doc);
+    assert.match(checked.fields.objective, /^Unknown:/);
+    assert.notEqual(checked.fields.objective, LEGACY_OBJECTIVE);
+    assert.deepEqual(frontmatterKeys(result.doc), FRONTMATTER_FIELDS);
+    for (const anchor of ANCHORS) {
+      assert.equal(result.doc.split(anchor).length - 1, 1, `${anchor} must be preserved exactly once`);
+    }
+  });
+});
+
+test('fresh autosave writes an explicit unknown waiting state and passes the shared validator', () => {
+  withFixture((fixture) => {
+    const result = runWorker(fixture, [assistantEvent()]);
+    assertWorkerFlushed(result);
+    const checked = validateCapsuleText(result.doc);
+    assert.match(checked.fields.waiting_on, /^Unknown:.*pending/i);
+    assert.doesNotMatch(result.doc, /^waiting_on:[ \t]*(?:null|~)[ \t]*$/mi);
+    assert.deepEqual(checked.problems, []);
+  });
+});
+
+test('unstructured assistant prose never becomes next_valid_action', () => {
+  withFixture((fixture) => {
+    const result = runWorker(fixture, [assistantEvent()]);
+    assertWorkerFlushed(result);
+    const { next_valid_action: next } = validateCapsuleText(result.doc).fields;
+    assert.equal(next, NO_ACTION);
+    assert.doesNotMatch(next, /RAW_ASSISTANT_SENTINEL|last assistant state/i);
+  });
+});
+
+test('a structured board claim yields a row-specific action without a raw assistant tail', () => {
+  withFixture((fixture) => {
+    const rowId = 'abcdef12-3456-7890-abcd-ef1234567890';
+    const result = runWorker(fixture, [claimEvent(rowId)]);
+    assertWorkerFlushed(result);
+    const { objective, next_valid_action: next } = validateCapsuleText(result.doc).fields;
+    assert.match(objective, /^Unknown:.*claimed row id\(s\) abcdef12/i);
+    assert.match(next, /claimed row\(s\) abcdef12/i);
+    assert.doesNotMatch(next, /RAW_ASSISTANT_SENTINEL|last assistant state/i);
+  });
+});
+
+test('a real human request becomes the objective while unknown lifecycle fields stay honest', () => {
+  withFixture((fixture) => {
+    const request = 'Fix the Stop autosave lifecycle artifact';
+    const result = runWorker(fixture, [userEvent(request), assistantEvent()]);
+    assertWorkerFlushed(result);
+    const checked = validateCapsuleText(result.doc);
+    assert.equal(checked.fields.objective, request);
+    assert.match(checked.fields.waiting_on, /^Unknown:/);
+    assert.equal(checked.fields.next_valid_action, NO_ACTION);
+    assert.doesNotMatch(checked.fields.next_valid_action, /RAW_ASSISTANT_SENTINEL/);
+  });
+});
+
+test('captured tool errors mark uncertainty without inventing a next action', () => {
+  withFixture((fixture) => {
+    const error = 'TOOL_ERROR_SENTINEL connection reset';
+    const result = runWorker(fixture, [toolErrorEvent(error), assistantEvent()]);
+    assertWorkerFlushed(result);
+    const checked = validateCapsuleText(result.doc);
+    assert.match(checked.fields.waiting_on, /^Unknown: 1 captured tool error\(s\) may be pending/);
+    assert.equal(checked.fields.next_valid_action, NO_ACTION);
+    assert.doesNotMatch(checked.fields.next_valid_action, /RAW_ASSISTANT_SENTINEL|TOOL_ERROR_SENTINEL/);
+  });
+});
+
+test('a file write is historical evidence, not a fabricated next action', () => {
+  withFixture((fixture) => {
+    const result = runWorker(fixture, [fileWriteEvent('src/example.mjs')]);
+    assertWorkerFlushed(result);
+    const { next_valid_action: next } = validateCapsuleText(result.doc).fields;
+    assert.equal(next, NO_ACTION);
+    assert.doesNotMatch(next, /verify the changes|RAW_ASSISTANT_SENTINEL|last assistant state/i);
+  });
+});
+
+test('malformed-but-parseable transcript records are skipped and a capsule still lands', () => {
+  withFixture((fixture) => {
+    const result = runWorker(fixture, [
+      null,
+      {
+        type: 'user',
+        message: {
+          content: [
+            null,
+            42,
+            [],
+            { type: 'text', text: 42 },
+            {
+              type: 'tool_result',
+              is_error: true,
+              content: [null, 42, [], { type: 'text', text: 99 }],
+            },
+          ],
+        },
+      },
+      { type: 'assistant', message: { content: { type: 'text', text: 'not an array' } } },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 42 }] } },
+      assistantEvent('VALID_EVENT_AFTER_BAD_SHAPES'),
+    ]);
+    assertWorkerFlushed(result);
+    const checked = validateCapsuleText(result.doc);
+    assert.match(checked.fields.objective, /^Unknown:/);
+    assert.match(checked.fields.waiting_on, /^Unknown:/);
+    assert.equal(checked.fields.next_valid_action, NO_ACTION);
+    assert.deepEqual(checked.problems, []);
+  });
+});
+
+test('malformed claim task ids do not fabricate row-specific objectives or actions', () => {
+  withFixture((fixture) => {
+    const malformedClaims = [42, true, {}, [], '', '   '].map((taskId) => ({
+      type: 'tool_use',
+      name: 'mcp__tasks__board_claim',
+      input: { task_id: taskId },
+    }));
+    const result = runWorker(fixture, [{
+      type: 'assistant',
+      message: {
+        content: [...malformedClaims, { type: 'text', text: ASSISTANT_SENTINEL }],
+      },
+    }]);
+    assertWorkerFlushed(result);
+    const checked = validateCapsuleText(result.doc);
+    assert.equal(
+      checked.fields.objective,
+      'Unknown: no operator objective was captured in this Stop delta.',
+    );
+    assert.equal(checked.fields.next_valid_action, NO_ACTION);
+    const rows = result.doc.split('<!-- swe:rows -->')[1] || '';
+    assert.doesNotMatch(rows, /^- .*claimed:/m);
+  });
+});
+
+test('the shared validator receives the exact final document that lands on disk', () => {
+  withFixture((fixture) => {
+    const seenPath = path.join(fixture.base, 'validator-seen.txt');
+    const sessionId = 'validator-call-session';
+    const capsulePath = expectedCapsulePath(fixture, sessionId);
+    const daemon = writeInstrumentedDaemon(fixture, {
+      validatorSource: `
+        import { existsSync, writeFileSync } from 'node:fs';
+        export function validateCapsuleText(text) {
+          writeFileSync(process.env.STOP_WRITER_VALIDATOR_SEEN, JSON.stringify({
+            capsuleExisted: existsSync(process.env.STOP_WRITER_EXPECTED_CAPSULE),
+            text,
+          }));
+          return { fields: {}, problems: [] };
+        }
+      `,
+    });
+    const result = runWorker(fixture, [assistantEvent('FINAL_MERGE_SENTINEL')], {
+      daemon,
+      sessionId,
+      env: {
+        STOP_WRITER_VALIDATOR_SEEN: seenPath,
+        STOP_WRITER_EXPECTED_CAPSULE: capsulePath,
+      },
+    });
+    assertWorkerFlushed(result);
+    const seen = JSON.parse(readFileSync(seenPath, 'utf8'));
+    assert.equal(seen.capsuleExisted, false, 'validation must run before the capsule commit');
+    assert.equal(seen.text, result.doc);
+    assert.match(result.doc, /FINAL_MERGE_SENTINEL/);
+  });
+});
+
+test('a throwing validator is logged but still exits zero and writes the final capsule', () => {
+  withFixture((fixture) => {
+    const seenPath = path.join(fixture.base, 'validator-threw-seen.txt');
+    const daemon = writeInstrumentedDaemon(fixture, {
+      validatorSource: `
+        import { writeFileSync } from 'node:fs';
+        export function validateCapsuleText(text) {
+          writeFileSync(process.env.STOP_WRITER_VALIDATOR_SEEN, text);
+          throw new Error('FORCED_VALIDATOR_THROW');
+        }
+      `,
+    });
+    const result = runWorker(fixture, [assistantEvent('THROW_FINAL_MERGE_SENTINEL')], {
+      daemon,
+      env: { STOP_WRITER_VALIDATOR_SEEN: seenPath },
+    });
+    assertWorkerFlushed(result);
+    assert.equal(readFileSync(seenPath, 'utf8'), result.doc);
+    assert.match(result.doc, /THROW_FINAL_MERGE_SENTINEL/);
+    assert.match(errorLog(fixture), /capsule validation threw; write continues fail-open/);
+    assert.match(errorLog(fixture), /FORCED_VALIDATOR_THROW/);
+  });
+});
+
+test('reported validation problems are logged but the capsule still lands', () => {
+  withFixture((fixture) => {
+    const seenPath = path.join(fixture.base, 'validator-problem-seen.txt');
+    const sessionId = 'problem1-final-doc-fallback';
+    const finalObjective = 'Preserve "final" objective at C:\\work\\reported-problem.md';
+    installExistingCapsule(
+      fixture,
+      sessionId,
+      existingCapsule({
+        id: 'problem1-final-doc-fallback',
+        objective: finalObjective,
+      }),
+      'problem1-final-doc-fallback.md',
+    );
+    const daemon = writeInstrumentedDaemon(fixture, {
+      validatorSource: `
+        import { writeFileSync } from 'node:fs';
+        export function validateCapsuleText(text) {
+          writeFileSync(process.env.STOP_WRITER_VALIDATOR_SEEN, text);
+          return { fields: null, problems: ['FORCED_UNRESOLVABLE_FIELD'] };
+        }
+      `,
+    });
+    const result = runWorker(fixture, [assistantEvent('PROBLEM_FINAL_MERGE_SENTINEL')], {
+      daemon,
+      sessionId,
+      env: { STOP_WRITER_VALIDATOR_SEEN: seenPath },
+    });
+    assertWorkerFlushed(result);
+    assert.equal(readFileSync(seenPath, 'utf8'), result.doc);
+    assert.match(result.doc, /PROBLEM_FINAL_MERGE_SENTINEL/);
+    assert.equal(validateCapsuleText(result.doc).fields.objective, finalObjective);
+    assert.equal(bodyPointer(fixture).objective, finalObjective);
+    assert.match(errorLog(fixture), /capsule validation reported 1 problem\(s\); write continues fail-open/);
+    assert.match(errorLog(fixture), /FORCED_UNRESOLVABLE_FIELD/);
+  });
+});
+
+test('an unexpected validator result is logged but the capsule still lands', () => {
+  withFixture((fixture) => {
+    const seenPath = path.join(fixture.base, 'validator-shape-seen.txt');
+    const daemon = writeInstrumentedDaemon(fixture, {
+      validatorSource: `
+        import { writeFileSync } from 'node:fs';
+        export function validateCapsuleText(text) {
+          writeFileSync(process.env.STOP_WRITER_VALIDATOR_SEEN, text);
+          return { fields: {}, problems: 'not-an-array' };
+        }
+      `,
+    });
+    const result = runWorker(fixture, [assistantEvent('SHAPE_FINAL_MERGE_SENTINEL')], {
+      daemon,
+      env: { STOP_WRITER_VALIDATOR_SEEN: seenPath },
+    });
+    assertWorkerFlushed(result);
+    assert.equal(readFileSync(seenPath, 'utf8'), result.doc);
+    assert.match(errorLog(fixture), /validateCapsuleText\(\) returned an unexpected result/);
+  });
+});
+
+test('a validator import failure is logged but the capsule still lands', () => {
+  withFixture((fixture) => {
+    const seenPath = path.join(fixture.base, 'validator-import-seen.txt');
+    const daemon = writeInstrumentedDaemon(fixture, {
+      validatorSource: `
+        import { writeFileSync } from 'node:fs';
+        writeFileSync(process.env.STOP_WRITER_VALIDATOR_SEEN, 'import attempted');
+        throw new Error('FORCED_VALIDATOR_IMPORT_FAILURE');
+      `,
+    });
+    const result = runWorker(fixture, [assistantEvent('IMPORT_FINAL_MERGE_SENTINEL')], {
+      daemon,
+      env: { STOP_WRITER_VALIDATOR_SEEN: seenPath },
+    });
+    assertWorkerFlushed(result);
+    assert.equal(readFileSync(seenPath, 'utf8'), 'import attempted');
+    assert.match(result.doc, /IMPORT_FINAL_MERGE_SENTINEL/);
+    assert.match(errorLog(fixture), /capsule validator import failed \(write continues fail-open\)/);
+    assert.match(errorLog(fixture), /FORCED_VALIDATOR_IMPORT_FAILURE/);
+  });
+});
+
+test('a throwing content gate is logged but the capsule still lands', () => {
+  withFixture((fixture) => {
+    const daemon = writeInstrumentedDaemon(fixture, {
+      gateSource: `
+        export function isInjectionEcho() {
+          throw new Error('FORCED_CONTENT_GATE_THROW');
+        }
+        export function isCeremonyAction() { return false; }
+        export function contentProblems() { return []; }
+      `,
+    });
+    const result = runWorker(
+      fixture,
+      [userEvent('A real request still needs a Stop snapshot'), assistantEvent('GATE_THROW_SENTINEL')],
+      { daemon },
+    );
+    assertWorkerFlushed(result);
+    assert.match(result.doc, /GATE_THROW_SENTINEL/);
+    assert.match(errorLog(fixture), /FORCED_CONTENT_GATE_THROW/);
+    assert.match(errorLog(fixture), /content-gate/i);
+  });
+});
+
+test('a failed temporary write falls back to a direct capsule write', () => {
+  withFixture((fixture) => {
+    const sessionId = 'tmpfail1-direct-fallback';
+    const capsulePath = expectedCapsulePath(fixture, sessionId);
+    mkdirSync(`${capsulePath}.tmp`);
+    const result = runWorker(fixture, [assistantEvent('DIRECT_WRITE_SENTINEL')], {
+      sessionId,
+    });
+    assertWorkerFlushed(result);
+    assert.equal(result.capsulePath, capsulePath);
+    assert.match(result.doc, /DIRECT_WRITE_SENTINEL/);
+    assert.match(errorLog(fixture), /capsule tmp write failed; attempting direct write/);
+  });
+});
+
+test('the next Stop heals all three defective fields in an existing legacy autosave', () => {
+  withFixture((fixture) => {
+    const sessionId = '89abcdef-legacy-session';
+    installExistingCapsule(
+      fixture,
+      sessionId,
+      existingCapsule({ id: '2026-07-27-auto-89abcdef' }),
+      '2026-07-27-auto-89abcdef.md',
+    );
+
+    const result = runWorker(fixture, [assistantEvent()], { sessionId });
+    assertWorkerFlushed(result);
+    const checked = validateCapsuleText(result.doc);
+    assert.match(checked.fields.objective, /^Unknown:/);
+    assert.notEqual(checked.fields.objective, LEGACY_OBJECTIVE);
+    assert.match(checked.fields.waiting_on, /^Unknown:/);
+    assert.equal(checked.fields.next_valid_action, NO_ACTION);
+    assert.doesNotMatch(checked.fields.next_valid_action, /last assistant state|severed|RAW_ASSISTANT_SENTINEL/i);
+    assert.deepEqual(checked.problems, []);
+    assert.equal(bodyPointer(fixture).objective, checked.fields.objective);
+  });
+});
+
+test('a meaningful autosave objective survives healing and the pointer uses its exact parsed value', () => {
+  withFixture((fixture) => {
+    const sessionId = 'meaning1-preserved-objective';
+    const objective = 'Keep "quoted" work at C:\\work\\capsules\\draft.md';
+    const encodedObjective = JSON.stringify(objective);
+    const parsedObjective = objective;
+    installExistingCapsule(
+      fixture,
+      sessionId,
+      existingCapsule({
+        id: 'meaningful-existing-autosave',
+        objective,
+      }),
+      'meaningful-existing-autosave.md',
+    );
+
+    const result = runWorker(fixture, [assistantEvent()], { sessionId });
+    assertWorkerFlushed(result);
+    assert.match(result.doc, new RegExp(`^objective: ${escapeRegExp(encodedObjective)}$`, 'm'));
+    const checked = validateCapsuleText(result.doc);
+    assert.equal(checked.fields.objective, parsedObjective);
+    assert.match(checked.fields.waiting_on, /^Unknown:/);
+    assert.equal(checked.fields.next_valid_action, NO_ACTION);
+    assert.equal(bodyPointer(fixture).objective, parsedObjective);
+  });
+});
+
+test('an autosave near-match tag cannot authorize contract-field healing', () => {
+  withFixture((fixture) => {
+    const sessionId = 'near-tag-no-ownership';
+    installExistingCapsule(
+      fixture,
+      sessionId,
+      existingCapsule({
+        id: 'near-tag-no-ownership',
+        tagsLine: 'tags: [capsule, not-autosave]',
+      }),
+    );
+
+    const result = runWorker(fixture, [assistantEvent()], { sessionId });
+    assertWorkerFlushed(result);
+    assert.match(result.doc, new RegExp(`^objective: ${escapeRegExp(JSON.stringify(LEGACY_OBJECTIVE))}$`, 'm'));
+    assert.match(result.doc, /^waiting_on: null$/m);
+    assert.match(result.doc, new RegExp(`^next_valid_action: ${escapeRegExp(JSON.stringify(LEGACY_NEXT_ACTION))}$`, 'm'));
+  });
+});
+
+test('an autosave-looking body line cannot authorize contract-field healing', () => {
+  withFixture((fixture) => {
+    const sessionId = 'body-tag-no-ownership';
+    installExistingCapsule(
+      fixture,
+      sessionId,
+      existingCapsule({
+        id: 'body-tag-no-ownership',
+        tagsLine: '',
+        bodyTail: '\ntags: [capsule, autosave]\n',
+      }),
+    );
+
+    const result = runWorker(fixture, [assistantEvent()], { sessionId });
+    assertWorkerFlushed(result);
+    assert.match(result.doc, new RegExp(`^objective: ${escapeRegExp(JSON.stringify(LEGACY_OBJECTIVE))}$`, 'm'));
+    assert.match(result.doc, /^waiting_on: null$/m);
+    assert.match(result.doc, new RegExp(`^next_valid_action: ${escapeRegExp(JSON.stringify(LEGACY_NEXT_ACTION))}$`, 'm'));
+  });
+});

--- a/docs/two-verb-lifecycle.md
+++ b/docs/two-verb-lifecycle.md
@@ -52,7 +52,7 @@ Both patterns are START-ANCHORED: a capsule that legitimately *references* the c
 
 ## Validation
 
-`daemons/capsule-verb.mjs` exports `validateCapsuleText()`: the one place required-field presence and the content gate (above) are checked together. It returns `{ fields, problems }`; an empty `problems` array means the four required fields are present and neither `objective` nor `next_valid_action` is injection-echo or ceremony-action. There is no separate trusted-writer process that stamps a pointer or a digest (the operator, or the model acting on the operator's behalf, writes the capsule file directly), and `validateCapsuleText()` is available as a utility for a skill or a test to self-check.
+`daemons/capsule-verb.mjs` exports `validateCapsuleText()`: the one place required-field presence and the content gate (above) are checked together. It returns `{ fields, problems }`; an empty `problems` array means the four required fields are present and neither `objective` nor `next_valid_action` is injection-echo or ceremony-action. The Stop-hook writer calls it on the final merged autosave before committing the file. That check is diagnostic and fail-open because a Stop hook must still preserve the best available snapshot if validation cannot run. There is no separate trusted-writer process that stamps a pointer or a digest, and `validateCapsuleText()` remains available for a skill or test to self-check.
 
 ## Selection is loud about what it discards
 
@@ -74,7 +74,7 @@ So `CAPSULE DATA` carries an `age` line every time, and past seven days adds an 
 
 The under-threshold path still says that freshness is not correctness: verify each value against live state, and expect part of the next action to be done already. A capsule minutes old can describe work that has since been finished by someone else.
 
-The same block names the **writer**. The Stop-hook autosave satisfies every selector requirement while carrying no resume contract — its objective is a fixed placeholder, the writer hardcodes `waiting_on` to `null` in its skeleton, and `next_valid_action` is a generic line padded with a truncated fragment of the last turn. Both required fields are non-empty, so selection accepts it, correctly, since there may be nothing else on disk. The gap was that a session could not tell it apart from a curated capsule once both arrived through the same procedure. A null `waiting_on` then reads as "nothing pends" when it means "unknown", and the truncated padding reads as an instruction. The procedure now labels it and gives those empty fields their real meaning.
+The same block names the **writer**. A Stop-hook autosave satisfies every selector requirement, but it is still a session-delta snapshot rather than a contract reconciled against live state. Current autosaves use explicit unknown markers for fields the writer cannot determine, and `next_valid_action` either names real claimed-row evidence or says plainly that none was captured. Legacy autosaves remain on disk until that session's next Stop heals them; those carry the old fixed objective, bare null `waiting_on`, and truncated-prose action. The procedure describes both shapes because a resuming session must never read unknown or absent state as "nothing is pending", or treat legacy prose padding as an instruction.
 
 Detection reads a structured field — the `trigger` scalar or the `tags` array — never the placeholder wording. The wording is free to change, and a marker that lives in prose is the first thing a reader collapses. `created_at` is capsule-controlled like every other value here, so it renders through `inert()` too.
 
@@ -104,9 +104,9 @@ If a fork wires multiple agents/sessions that need to pause for a conducted, mul
 
 - **The capsule is best-effort autosave, never a gate.** An operator `/clear` passes through whether or not a capsule landed. Nothing in this system should ever tell the operator to wait on capsule machinery.
 
-## Known issue: resolved by removal
+## Former refresh-cycle issue
 
-The v0.9.0 beta's known issue (an automated refresh cycle could try to stamp a fresh, still-`waiting_on: null` autosave capsule and be refused) no longer applies: v0.9.1 removes the automated stamping path entirely (see "Context-pressure self-refresh" above). `validateCapsuleText()` still treats a bare `waiting_on: null` as not-yet-resumable (that check is correct and unchanged), but nothing calls it against an in-flight autosave capsule anymore. It only matters when a skill or test explicitly validates a capsule that's meant to be a resume source.
+The v0.9.0 beta's known issue (an automated refresh cycle could try to stamp a fresh, still-`waiting_on: null` autosave capsule and be refused) no longer applies: v0.9.1 removes that stamping path entirely (see "Context-pressure self-refresh" above). `validateCapsuleText()` still treats a bare `waiting_on: null` as not resumable, and the Stop writer now calls it diagnostically on every final autosave. Validation problems are logged but never block the snapshot. Current autosaves emit an explicit unknown marker instead of null, while legacy autosaves heal on their next write.
 
 ## File map
 


### PR DESCRIPTION
The Stop-hook writer produces the capsule a session resumes from when nobody typed anything. It could emit a document that satisfied every selector requirement while carrying no real information: a fixed placeholder objective, a hardcoded `null` waiting state, and a truncated fragment of the last assistant turn as the next action.

Each of those is worse than an empty field. A `null` waiting state reads as "nothing is pending" when it means "we did not determine this", and prose padding reads as an instruction to whoever resumes. Because every required field was non-empty, selection accepted the document and a resuming session could not distinguish it from a deliberately written capsule.

`validateCapsuleText()` already existed one file away and was never called — the writer even carried a comment referring to it.

## What changed

- The writer calls the shared validator on the exact document that lands on disk.
- Fields it cannot determine carry an explicit unknown marker, distinguishable from both a real value and `null`.
- `next_valid_action` is derived only from structured claim evidence, or plainly states that none was captured. Assistant prose stays in the body as reference material.
- Legacy autosaves heal on their next ordinary write. No history is rewritten.
- The lifecycle doc describes both shapes, since both exist on disk during the transition.

Every path is fail-open. This runs on every Stop, so a failed validator import, a throwing validator, an unexpected validator result, and a failed temporary write are each logged and still produce a capsule.

## Tests

A new suite (20 cases) covers the contract fields, prose exclusion, malformed transcript records, legacy healing, and each fail-open branch. Two cases verify that a capsule cannot authorize healing of its own contract fields via a near-match tag or a body line that resembles one.

Verified by mutation rather than assertion: restoring the original bare `null` waiting state turns 6 of the 20 red; reverting the mutation returns all 20 green and the file to its original checksum.