### PR TITLE
evals: make the corpora executable, and make the gate hard to fool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,14 @@ jobs:
       - name: GateGuard fact-forcing gate tests
         run: node daemons/tests/gateguard.test.mjs
 
+      # The corpora under evals/ existed for weeks with no runner - JSON shaped
+      # like evidence that nothing executed. This job is what makes them evidence.
+      # Red on: a behaviour drift (FAIL), a case this install cannot evaluate and
+      # does not declare why (UNDECLARED), or a declared gap that has quietly
+      # closed (GAP-CLOSED).
+      - name: Eval corpora (skill recall, capsule resume)
+        run: node evals/run-evals.mjs
+
       - name: Lifecycle tests (capsule selection, validation, state paths)
         run: >-
           node --test

--- a/evals/capsule-resume-tests.json
+++ b/evals/capsule-resume-tests.json
@@ -9,24 +9,25 @@
     "id": "cr-002",
     "capsule_status": "paused",
     "expected_offer_resume": true,
-    "notes": "Paused capsule = explicitly suspended but not closed. Must offer resume."
+    "requires": "paused-state-support",
+    "notes": "DECLARED GAP, not a passing case. This asserts paused should be resumable; shipped code disagrees - lifecycle-common.mjs:123 admits only status 'active', so a paused capsule is neither consumed nor selectable and disappears silently. docs/capsule-v2-doctrine.md:44 confirms paused is read only by the retired /pause skill. The assertion is KEPT rather than deleted because the underlying question is real: either paused becomes a supported resumable state, or the /pause skill's state should stop being writable. Deleting this case would erase the question."
   },
   {
     "id": "cr-003",
     "capsule_status": "resolved",
     "expected_offer_resume": false,
-    "notes": "Resolved capsule = work complete. Must NOT offer resume — there is nothing to pick up."
+    "notes": "Resolved capsule = work complete. Must NOT offer resume - there is nothing to pick up."
   },
   {
     "id": "cr-004",
     "capsule_status": "abandoned",
     "expected_offer_resume": false,
-    "notes": "Abandoned capsule = explicitly discarded. Must NOT offer resume — reviving abandoned work creates noise."
+    "notes": "Abandoned capsule = explicitly discarded. Must NOT offer resume. NOTE: this passes for an incidental reason - 'abandoned' is written and read by nothing (docs/capsule-v2-doctrine.md:44), so it is rejected as an unrecognised status rather than as a discarded one. Right answer, wrong mechanism; do not read this green as proof that abandonment is handled."
   },
   {
     "id": "cr-005",
     "capsule_status": null,
     "expected_offer_resume": false,
-    "notes": "No capsule present. Must NOT offer resume — nothing to resume."
+    "notes": "No capsule present. Must NOT offer resume - nothing to resume."
   }
 ]

--- a/evals/contradiction-tests.json
+++ b/evals/contradiction-tests.json
@@ -4,13 +4,15 @@
     "fact": "The company has zero operating revenue",
     "contradicting_belief": "The company revenue model is proven",
     "expected_detection": true,
-    "notes": "Zero revenue contradicts 'proven revenue model'. Should flag immediately — this is a critical operating assumption."
+    "requires": "model-harness",
+    "notes": "Zero revenue contradicts 'proven revenue model'. Should flag immediately - this is a critical operating assumption."
   },
   {
     "id": "ct-002",
     "fact": "aigent-OS runs on Claude Opus 4.6",
     "contradicting_belief": "aigent-OS runs on GPT-4",
     "expected_detection": true,
+    "requires": "model-harness",
     "notes": "Clear model identity contradiction. SELF_MODEL.json should make this detectable without external lookup."
   },
   {
@@ -18,6 +20,7 @@
     "fact": "The app is hosted on Railway",
     "contradicting_belief": "The app is hosted on Railway",
     "expected_detection": false,
-    "notes": "Identical claim — no contradiction. Test for false positive suppression. System should not flag consistent facts."
+    "requires": "model-harness",
+    "notes": "Identical claim - no contradiction. Test for false-positive suppression. System should not flag consistent facts."
   }
 ]

--- a/evals/run-evals.mjs
+++ b/evals/run-evals.mjs
@@ -26,7 +26,10 @@ const ROOT = path.resolve(EVALS, '..');
 const JSON_OUT = process.argv.includes('--json');
 
 const results = [];
-const record = (suite, id, status, detail, extra = {}) => results.push({ suite, id, status, detail, ...extra });
+// `extra` is spread FIRST so it can never overwrite a row's own verdict. No call
+// site passes corpus-controlled data today, but a status field a caller can
+// rewrite is a loaded gun waiting for the round.
+const record = (suite, id, status, detail, extra = {}) => results.push({ ...extra, suite, id, status, detail });
 
 // Duplicate ids inside one corpus collide on the per-case router session id and
 // produce a confusing "(silent)" failure whose cause is invisible. Cheap to reject
@@ -35,6 +38,15 @@ function duplicateIds(cases) {
   const seen = new Set(); const dupes = new Set();
   for (const c of cases || []) { if (seen.has(c?.id)) dupes.add(c.id); seen.add(c?.id); }
   return [...dupes];
+}
+
+// Duplicates are reported AND skipped. Reporting alone left the duplicate cases
+// executing, which inflated the pass count and fed the coverage floor with rows
+// the corpus never intended. It could not yield green (the error rows are fatal in
+// the same run), but a count nobody can trust is not worth keeping.
+function withoutDuplicates(cases) {
+  const seen = new Set();
+  return (cases || []).filter((c) => (seen.has(c?.id) ? false : (seen.add(c?.id), true)));
 }
 
 function loadCorpus(name) {
@@ -50,13 +62,14 @@ function loadCorpus(name) {
 function runSkillRecall() {
   const cases = loadCorpus('skill-recall-tests.json');
   if (cases.__error) { record('skill-recall', '-', 'unrunnable', `corpus unreadable: ${cases.__error}`); return; }
+  const uniqueCases = withoutDuplicates(cases);
 
   let index;
   try { index = JSON.parse(readFileSync(path.join(ROOT, '.claude', 'skill-index.json'), 'utf8')); }
   catch (e) { record('skill-recall', '-', 'unrunnable', `no skill-index.json: ${e?.message}`); return; }
   const known = new Set(index.map((s) => s.name));
 
-  for (const c of cases) {
+  for (const c of uniqueCases) {
     // A case naming a skill this install does not have cannot be evaluated. It is
     // NOT a routing failure and must not be scored as one — the original corpus
     // referenced four skills absent from this repo, which is how it stayed
@@ -65,12 +78,6 @@ function runSkillRecall() {
       record('skill-recall', c.id, 'unrunnable', `expected_skill "${c.expected_skill}" not in skill-index (${known.size} skills)`);
       continue;
     }
-    // HARNESS ISOLATION, not cheating. caddy suppresses its no-match line after
-    // the first miss per session via .aigent/cache/caddy-gap-<session_id>, and a
-    // session-less invocation keys that flag on the literal "unknown" — so every
-    // caller without a session id shares ONE flag and the second eval run in a
-    // job sees different behaviour from the first. Clearing the flag per case is
-    // what makes routing deterministic; it does not change what caddy decides.
     // Give every case its OWN session id. caddy suppresses its no-match line once
     // per session (caddy.sh:193-194), and a caller that sends no session_id keys
     // that flag on the literal "unknown" — one bucket shared by every session-less
@@ -143,9 +150,15 @@ function runSkillRecall() {
     }
     const bad = (c.must_not_suggest || []).find((s) => out.includes(s));
     if (bad) { record('skill-recall', c.id, 'fail', `suggested forbidden skill "${bad}"`); continue; }
-    // `matched` records whether the router actually resolved a skill, as distinct
-    // from the case merely passing. Only a real match can witness that routing works.
-    record('skill-recall', c.id, 'pass', '', { matched: !/No skill match/i.test(out) });
+    // PRESENCE of the scorer's own line, never ABSENCE of a miss marker. caddy has
+    // TWO resolvers: the trigger scorer prints "[CADDY] /name - why", and when it
+    // finds nothing a SKILL_LEDGER taxonomy fallback prints "[CADDY:taxonomy] ...".
+    // The fallback carries no miss marker, so an absence-check called it a match
+    // while the scorer had contributed nothing — and because the fallback only runs
+    // WHEN the scorer misses, its output is byte-identical whether the scorer is
+    // healthy or completely dead. A corpus drifting toward taxonomy-resolved prompts
+    // would let scorer coverage reach zero with every gate still green.
+    record('skill-recall', c.id, 'pass', '', { matched: /^\[CADDY\] \//m.test(out) });
   }
   // A no-match assertion is satisfied by a router that is COMPLETELY DEAD: total
   // failure emits the same "No skill match" the case expects. Measured — with the
@@ -155,14 +168,14 @@ function runSkillRecall() {
   // match something. Without that pairing the case cannot detect under-firing,
   // because under-firing is what produces its expected output.
   const mine = results.filter((r) => r.suite === 'skill-recall');
-  const negativeIds = new Set(cases.filter((c) => c.expect_no_match).map((c) => c.id));
+  const negativeIds = new Set(uniqueCases.filter((c) => c.expect_no_match).map((c) => c.id));
   // The witness must have MATCHED, not merely passed. caddy's miss line names a
   // real installed skill ("run /skill-recall to log this gap"), so a positive case
   // expecting `skill-recall` passes identically whether the router works or is
   // completely dead — a witness satisfied by the very failure it is meant to rule
   // out. Only a case whose response was NOT a miss proves routing still works.
   const positivesPassed = mine.some((r) => !negativeIds.has(r.id) && r.status === 'pass' && r.matched === true);
-  const hasPositives = cases.some((c) => !c.expect_no_match);
+  const hasPositives = uniqueCases.some((c) => !c.expect_no_match);
   if (hasPositives && !positivesPassed) {
     for (const r of mine) {
       if (negativeIds.has(r.id) && r.status === 'pass') {
@@ -186,6 +199,7 @@ function runSkillRecall() {
 async function runCapsuleResume() {
   const cases = loadCorpus('capsule-resume-tests.json');
   if (cases.__error) { record('capsule-resume', '-', 'unrunnable', `corpus unreadable: ${cases.__error}`); return; }
+  const uniqueCases = withoutDuplicates(cases);
 
   let newestValidCapsule;
   // pathToFileURL, not a bare path: on Windows an absolute path is read as a
@@ -193,7 +207,7 @@ async function runCapsuleResume() {
   try { ({ newestValidCapsule } = await import(pathToFileURL(path.join(ROOT, 'daemons', 'lifecycle-common.mjs')).href)); }
   catch (e) { record('capsule-resume', '-', 'unrunnable', `selector import failed: ${e?.message}`); return; }
 
-  for (const c of cases) {
+  for (const c of uniqueCases) {
     const dir = mkdtempSync(path.join(os.tmpdir(), 'eval-capsule-'));
     try {
       const capsules = path.join(dir, 'capsules');
@@ -237,7 +251,8 @@ async function runCapsuleResume() {
 function runContradiction() {
   const cases = loadCorpus('contradiction-tests.json');
   if (cases.__error) { record('contradiction', '-', 'unrunnable', `corpus unreadable: ${cases.__error}`); return; }
-  for (const c of cases) {
+  const uniqueCases = withoutDuplicates(cases);
+  for (const c of uniqueCases) {
     record('contradiction', c.id, 'unrunnable',
       c.requires ? `declared gap: ${c.requires}` : 'needs a model harness; case does not declare `requires`');
   }
@@ -322,11 +337,26 @@ const harnessError = results.filter((r) => r.status === 'harness-error');
 // the SAME ratchet closed one round earlier for `unrunnable` — fixing the instance
 // and leaving the identical door open next to it. The floor now counts only rows
 // that both ran AND could have failed the build.
+// TWO separate properties, because collapsing them into one floor put honesty in
+// tension with coverage: with a hard floor of 4 over undeclared rows, a suite of 5
+// carrying one legitimate declared gap sat exactly on the boundary, so declaring a
+// SECOND real gap turned the build red. A maintainer telling the truth should never
+// trip a gate. Split them:
+//   STARVED     — the suite lost cases outright. Absolute floor, catches attrition.
+//   UNDERCOVERED — declarations ate the coverage. Relative, so honest gaps have room
+//                  while "declare everything" still cannot buy a green.
 const EXECUTED = new Set(['pass', 'fail']);
-const MIN_EXECUTABLE = { 'skill-recall': 4, 'capsule-resume': 4 };
-const starved = Object.entries(MIN_EXECUTABLE)
-  .map(([suite, min]) => [suite, results.filter((r) => r.suite === suite && EXECUTED.has(r.status)).length, min])
+const MIN_CASES = { 'skill-recall': 4, 'capsule-resume': 4 };
+const suiteRows = (s) => results.filter((r) => r.suite === s).length;
+const suiteExecuted = (s) => results.filter((r) => r.suite === s && EXECUTED.has(r.status)).length;
+
+const starved = Object.entries(MIN_CASES)
+  .map(([suite, min]) => [suite, suiteRows(suite), min])
   .filter(([, n, min]) => n < min);
+
+const undercovered = Object.keys(MIN_CASES)
+  .map((suite) => [suite, suiteExecuted(suite), Math.ceil(suiteRows(suite) / 2)])
+  .filter(([suite, n, need]) => suiteRows(suite) > 0 && n < need);
 
 const MARK = {
   pass: 'PASS', fail: 'FAIL', 'known-gap': 'KNOWN-GAP', 'gap-closed': 'GAP-CLOSED',
@@ -343,6 +373,7 @@ if (JSON_OUT) {
     undeclared: undeclared.length,
     harness_error: harnessError.length,
     starved: starved.map(([suite, n, min]) => ({ suite, cases: n, minimum: min })),
+    undercovered: undercovered.map(([suite, n, need]) => ({ suite, executed: n, needs: need })),
     results,
   }, null, 2));
 } else {
@@ -352,9 +383,12 @@ if (JSON_OUT) {
   console.log('');
   console.log(`  ${pass.length} pass · ${fail.length} fail · ${knownGap.length} known-gap · ${gapClosed.length} gap-closed · ${harnessError.length} harness-error · ${unrunnable.length} unrunnable (${undeclared.length} undeclared)`);
   for (const [suite, n, min] of starved) {
-    console.log(`  STARVED: suite "${suite}" ran ${n} case(s), minimum ${min}. Coverage cannot silently reach zero.`);
+    console.log(`  STARVED: suite "${suite}" has ${n} case(s), minimum ${min}. Coverage cannot silently reach zero.`);
   }
-  if (fail.length || undeclared.length || gapClosed.length || harnessError.length || starved.length) {
+  for (const [suite, n, need] of undercovered) {
+    console.log(`  UNDERCOVERED: suite "${suite}" has only ${n} undeclared executed case(s), needs ${need}. Declarations cannot buy coverage.`);
+  }
+  if (fail.length || undeclared.length || gapClosed.length || harnessError.length || starved.length || undercovered.length) {
     console.log('');
     console.log('  RED. FAIL = behaviour drifted from the corpus. UNDECLARED unrunnable = the');
     console.log('  corpus asserts something this install cannot evaluate. GAP-CLOSED = a case');
@@ -366,5 +400,6 @@ if (JSON_OUT) {
 }
 
 process.exit(
-  fail.length || undeclared.length || gapClosed.length || harnessError.length || starved.length ? 1 : 0,
+  fail.length || undeclared.length || gapClosed.length || harnessError.length
+    || starved.length || undercovered.length ? 1 : 0,
 );

--- a/evals/run-evals.mjs
+++ b/evals/run-evals.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// Executes the corpora in evals/. Until this file existed, they were JSON with
+// expected_* fields that nothing read — files shaped like evidence, proving
+// nothing. A verification that cannot fail is not evidence.
+//
+// THREE OUTCOMES, NOT TWO. pass / fail / unrunnable. The third one is the point:
+// a case whose preconditions are absent has NOT passed, and reporting it as a
+// skip is how an inert corpus looks healthy for months. Unrunnable is fatal
+// unless the case declares `requires`, which marks a KNOWN, NAMED gap.
+//
+// DRIVES THE REAL SOURCE. skill-recall pipes prompts through daemons/caddy.sh as
+// the hook does; capsule-resume calls newestValidCapsule() from
+// daemons/lifecycle-common.mjs against a temp vault. Neither re-implements the
+// logic it checks — a mirror stays green when the daemon regresses.
+//
+// Run: node evals/run-evals.mjs [--json]
+
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, globSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const EVALS = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(EVALS, '..');
+const JSON_OUT = process.argv.includes('--json');
+
+const results = [];
+const record = (suite, id, status, detail) => results.push({ suite, id, status, detail });
+
+function loadCorpus(name) {
+  try { return JSON.parse(readFileSync(path.join(EVALS, name), 'utf8')); }
+  catch (e) { return { __error: e?.message || String(e) }; }
+}
+
+// ── Suite 1: skill recall ─────────────────────────────────────────────────────
+// Routes a prompt through the real caddy hook and asserts which skill it named.
+// `must_not_suggest` is as load-bearing as `expected_skill`: a router that fires
+// on everything has perfect recall and is useless.
+
+function runSkillRecall() {
+  const cases = loadCorpus('skill-recall-tests.json');
+  if (cases.__error) { record('skill-recall', '-', 'unrunnable', `corpus unreadable: ${cases.__error}`); return; }
+
+  let index;
+  try { index = JSON.parse(readFileSync(path.join(ROOT, '.claude', 'skill-index.json'), 'utf8')); }
+  catch (e) { record('skill-recall', '-', 'unrunnable', `no skill-index.json: ${e?.message}`); return; }
+  const known = new Set(index.map((s) => s.name));
+
+  for (const c of cases) {
+    // A case naming a skill this install does not have cannot be evaluated. It is
+    // NOT a routing failure and must not be scored as one — the original corpus
+    // referenced four skills absent from this repo, which is how it stayed
+    // plausible while being unrunnable.
+    if (c.expected_skill && !known.has(c.expected_skill)) {
+      record('skill-recall', c.id, 'unrunnable', `expected_skill "${c.expected_skill}" not in skill-index (${known.size} skills)`);
+      continue;
+    }
+    // HARNESS ISOLATION, not cheating. caddy suppresses its no-match line after
+    // the first miss per session via .aigent/cache/caddy-gap-<session_id>, and a
+    // session-less invocation keys that flag on the literal "unknown" — so every
+    // caller without a session id shares ONE flag and the second eval run in a
+    // job sees different behaviour from the first. Clearing the flag per case is
+    // what makes routing deterministic; it does not change what caddy decides.
+    for (const f of globSync(path.join(ROOT, '.aigent', 'cache', 'caddy-gap-*'))) {
+      rmSync(f, { force: true });
+    }
+    const proc = spawnSync('bash', [path.join(ROOT, 'daemons', 'caddy.sh')], {
+      input: c.prompt,
+      env: { ...process.env, AIGENT_ROOT: ROOT },
+      encoding: 'utf8',
+      timeout: 15_000,
+    });
+    if (proc.error) { record('skill-recall', c.id, 'unrunnable', `caddy.sh did not execute: ${proc.error.message}`); continue; }
+    const out = proc.stdout || '';
+
+    if (c.expect_no_match) {
+      // NOT silence. caddy announces a miss ("No skill match") and that marker is
+      // the correct answer — asserting silence here would fail on healthy output
+      // and teach the next reader to delete the case.
+      if (!/No skill match/i.test(out)) {
+        record('skill-recall', c.id, 'fail', `expected a no-match; caddy said: ${out.trim().slice(0, 120) || '(silent)'}`);
+        continue;
+      }
+    } else if (c.expected_skill) {
+      const accepted = [c.expected_skill, ...(c.acceptable_alternatives || [])];
+      if (!accepted.some((s) => out.includes(s))) {
+        record('skill-recall', c.id, 'fail', `expected "${c.expected_skill}"; caddy said: ${out.trim().slice(0, 120) || '(silent)'}`);
+        continue;
+      }
+    }
+    const bad = (c.must_not_suggest || []).find((s) => out.includes(s));
+    if (bad) { record('skill-recall', c.id, 'fail', `suggested forbidden skill "${bad}"`); continue; }
+    record('skill-recall', c.id, 'pass', '');
+  }
+}
+
+// ── Suite 2: capsule resume ───────────────────────────────────────────────────
+// Writes one capsule at the given status into a temp vault and asks the REAL
+// selector whether it is offered. This is the core product promise reduced to
+// its smallest checkable claim.
+
+async function runCapsuleResume() {
+  const cases = loadCorpus('capsule-resume-tests.json');
+  if (cases.__error) { record('capsule-resume', '-', 'unrunnable', `corpus unreadable: ${cases.__error}`); return; }
+
+  let newestValidCapsule;
+  // pathToFileURL, not a bare path: on Windows an absolute path is read as a
+  // 'c:' protocol and the import fails for a reason unrelated to the selector.
+  try { ({ newestValidCapsule } = await import(pathToFileURL(path.join(ROOT, 'daemons', 'lifecycle-common.mjs')).href)); }
+  catch (e) { record('capsule-resume', '-', 'unrunnable', `selector import failed: ${e?.message}`); return; }
+
+  for (const c of cases) {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'eval-capsule-'));
+    try {
+      const capsules = path.join(dir, 'capsules');
+      mkdirSync(capsules, { recursive: true });
+      if (c.capsule_status !== null && c.capsule_status !== undefined) {
+        writeFileSync(path.join(capsules, '2026-01-01-eval.md'), [
+          '---',
+          'id: 2026-01-01-eval',
+          `status: ${c.capsule_status}`,
+          'created_at: 2026-01-01T00:00:00Z',
+          '---',
+          '',
+          '## Objective',
+          'Evaluate the selector.',
+          '',
+          '## Next valid action',
+          'Assert whether this capsule is offered.',
+          '',
+        ].join('\n'), 'utf8');
+      }
+      const offered = newestValidCapsule(dir) !== null;
+      if (offered === c.expected_offer_resume) record('capsule-resume', c.id, 'pass', '');
+      else {
+        record('capsule-resume', c.id, 'fail',
+          `status "${c.capsule_status}" -> offered=${offered}, expected ${c.expected_offer_resume}`);
+      }
+    } catch (e) {
+      record('capsule-resume', c.id, 'unrunnable', `harness error: ${e?.message}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+}
+
+// ── Suite 3: contradiction ────────────────────────────────────────────────────
+// Needs a model in the loop. Reported every run so the gap stays visible rather
+// than being quietly absent from the scoreboard.
+
+function runContradiction() {
+  const cases = loadCorpus('contradiction-tests.json');
+  if (cases.__error) { record('contradiction', '-', 'unrunnable', `corpus unreadable: ${cases.__error}`); return; }
+  for (const c of cases) {
+    record('contradiction', c.id, 'unrunnable',
+      c.requires ? `declared gap: ${c.requires}` : 'needs a model harness; case does not declare `requires`');
+  }
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+await runCapsuleResume();
+runSkillRecall();
+runContradiction();
+
+const declared = new Map();
+for (const f of ['skill-recall-tests.json', 'capsule-resume-tests.json', 'contradiction-tests.json']) {
+  const c = loadCorpus(f);
+  if (!c.__error) for (const x of c) declared.set(x.id, x.requires || null);
+}
+
+// A DECLARED case that fails is a KNOWN GAP, not a regression — the assertion is
+// kept on purpose to hold an open question open. A DECLARED case that PASSES is
+// fatal: the gap closed and the declaration is now a lie. Without that second
+// rule a `requires` marker becomes a permanent excuse nobody revisits, which is
+// the failure mode this whole runner exists to end.
+for (const r of results) {
+  const req = declared.get(r.id);
+  if (!req) continue;
+  if (r.status === 'fail') { r.status = 'known-gap'; r.detail = `${req} — ${r.detail}`; }
+  else if (r.status === 'pass') { r.status = 'gap-closed'; r.detail = `declared "${req}" but the case now PASSES — remove the declaration`; }
+}
+
+const pass = results.filter((r) => r.status === 'pass');
+const fail = results.filter((r) => r.status === 'fail');
+const knownGap = results.filter((r) => r.status === 'known-gap');
+const gapClosed = results.filter((r) => r.status === 'gap-closed');
+const unrunnable = results.filter((r) => r.status === 'unrunnable');
+// An unrunnable case is fatal unless the case itself declares WHY it cannot run.
+const undeclared = unrunnable.filter((r) => !declared.get(r.id));
+
+const MARK = {
+  pass: 'PASS', fail: 'FAIL', 'known-gap': 'KNOWN-GAP', 'gap-closed': 'GAP-CLOSED', unrunnable: 'UNRUNNABLE',
+};
+
+if (JSON_OUT) {
+  console.log(JSON.stringify({
+    pass: pass.length,
+    fail: fail.length,
+    known_gap: knownGap.length,
+    gap_closed: gapClosed.length,
+    unrunnable: unrunnable.length,
+    undeclared: undeclared.length,
+    results,
+  }, null, 2));
+} else {
+  for (const r of results) {
+    console.log(`  ${MARK[r.status].padEnd(11)} ${r.suite}/${r.id}${r.detail ? ` — ${r.detail}` : ''}`);
+  }
+  console.log('');
+  console.log(`  ${pass.length} pass · ${fail.length} fail · ${knownGap.length} known-gap · ${unrunnable.length} unrunnable (${undeclared.length} undeclared)`);
+  if (fail.length || undeclared.length || gapClosed.length) {
+    console.log('');
+    console.log('  RED. FAIL = behaviour drifted from the corpus. UNDECLARED unrunnable = the');
+    console.log('  corpus asserts something this install cannot evaluate. GAP-CLOSED = a case');
+    console.log('  declared as a known gap now passes, so the declaration is stale. In every');
+    console.log('  case: fix the code or fix the declaration. Do not delete the assertion.');
+  }
+}
+
+process.exit(fail.length || undeclared.length || gapClosed.length ? 1 : 0);

--- a/evals/run-evals.mjs
+++ b/evals/run-evals.mjs
@@ -71,8 +71,18 @@ function runSkillRecall() {
       encoding: 'utf8',
       timeout: 15_000,
     });
-    if (proc.error) { record('skill-recall', c.id, 'unrunnable', `caddy.sh did not execute: ${proc.error.message}`); continue; }
+    if (proc.error) { record('skill-recall', c.id, 'harness-error', `caddy.sh did not execute: ${proc.error.message}`); continue; }
     const out = proc.stdout || '';
+
+    // A case with neither a positive nor a negative expectation asserts NOTHING:
+    // both branches below are skipped, must_not_suggest is empty in every case,
+    // and it recorded PASS while caddy's output was discarded. An assertion that
+    // cannot fail is worse than an absent one, because it inflates the pass count.
+    if (!c.expect_no_match && !c.expected_skill) {
+      record('skill-recall', c.id, 'harness-error',
+        'case declares neither expected_skill nor expect_no_match — it asserts nothing and can never fail');
+      continue;
+    }
 
     if (c.expect_no_match) {
       // NOT silence. caddy announces a miss ("No skill match") and that marker is
@@ -138,7 +148,9 @@ async function runCapsuleResume() {
           `status "${c.capsule_status}" -> offered=${offered}, expected ${c.expected_offer_resume}`);
       }
     } catch (e) {
-      record('capsule-resume', c.id, 'unrunnable', `harness error: ${e?.message}`);
+      // NOT 'unrunnable': that status is excusable by a `requires` declaration,
+      // and the selector throwing is a defect, not an absent precondition.
+      record('capsule-resume', c.id, 'harness-error', `harness error: ${e?.message}`);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -164,11 +176,21 @@ await runCapsuleResume();
 runSkillRecall();
 runContradiction();
 
+// Keyed by suite/id, NEVER by bare id. Case ids are unique only WITHIN a corpus,
+// so a bare-id map let a `requires` marker in one suite silence a same-named case
+// in another: renaming contradiction's ct-001 to sr-001 downgraded a live routing
+// FAIL to KNOWN-GAP and exited 0. A declaration may only ever excuse the case that
+// declared it.
 const declared = new Map();
-for (const f of ['skill-recall-tests.json', 'capsule-resume-tests.json', 'contradiction-tests.json']) {
+for (const [suite, f] of [
+  ['skill-recall', 'skill-recall-tests.json'],
+  ['capsule-resume', 'capsule-resume-tests.json'],
+  ['contradiction', 'contradiction-tests.json'],
+]) {
   const c = loadCorpus(f);
-  if (!c.__error) for (const x of c) declared.set(x.id, x.requires || null);
+  if (!c.__error) for (const x of c) declared.set(`${suite}/${x.id}`, x.requires || null);
 }
+const declarationFor = (r) => declared.get(`${r.suite}/${r.id}`);
 
 // A DECLARED case that fails is a KNOWN GAP, not a regression — the assertion is
 // kept on purpose to hold an open question open. A DECLARED case that PASSES is
@@ -176,7 +198,7 @@ for (const f of ['skill-recall-tests.json', 'capsule-resume-tests.json', 'contra
 // rule a `requires` marker becomes a permanent excuse nobody revisits, which is
 // the failure mode this whole runner exists to end.
 for (const r of results) {
-  const req = declared.get(r.id);
+  const req = declarationFor(r);
   if (!req) continue;
   if (r.status === 'fail') { r.status = 'known-gap'; r.detail = `${req} — ${r.detail}`; }
   else if (r.status === 'pass') { r.status = 'gap-closed'; r.detail = `declared "${req}" but the case now PASSES — remove the declaration`; }
@@ -188,10 +210,27 @@ const knownGap = results.filter((r) => r.status === 'known-gap');
 const gapClosed = results.filter((r) => r.status === 'gap-closed');
 const unrunnable = results.filter((r) => r.status === 'unrunnable');
 // An unrunnable case is fatal unless the case itself declares WHY it cannot run.
-const undeclared = unrunnable.filter((r) => !declared.get(r.id));
+const undeclared = unrunnable.filter((r) => !declarationFor(r));
+
+// HARNESS-ERROR is never excusable. `requires` declares a missing PRECONDITION
+// ("needs a model in the loop"); it must not absorb the machinery breaking. A
+// thrown selector crash previously landed as unrunnable, was excused by the
+// case's own declaration, dropped out of the scoreboard entirely, and exited 0 —
+// a production crash reading as a known gap, which is the exact failure this
+// runner exists to end. Kept as a separate status so no declaration can reach it.
+const harnessError = results.filter((r) => r.status === 'harness-error');
+
+// A corpus that asserts nothing is green by vacuum. Emptying both executable
+// corpora to [] previously produced 0 pass / 0 fail / exit 0. Coverage that can
+// silently reach zero is not coverage.
+const MIN_EXECUTABLE = { 'skill-recall': 4, 'capsule-resume': 4 };
+const starved = Object.entries(MIN_EXECUTABLE)
+  .map(([suite, min]) => [suite, results.filter((r) => r.suite === suite).length, min])
+  .filter(([, n, min]) => n < min);
 
 const MARK = {
-  pass: 'PASS', fail: 'FAIL', 'known-gap': 'KNOWN-GAP', 'gap-closed': 'GAP-CLOSED', unrunnable: 'UNRUNNABLE',
+  pass: 'PASS', fail: 'FAIL', 'known-gap': 'KNOWN-GAP', 'gap-closed': 'GAP-CLOSED',
+  unrunnable: 'UNRUNNABLE', 'harness-error': 'HARNESS-ERR',
 };
 
 if (JSON_OUT) {
@@ -202,6 +241,8 @@ if (JSON_OUT) {
     gap_closed: gapClosed.length,
     unrunnable: unrunnable.length,
     undeclared: undeclared.length,
+    harness_error: harnessError.length,
+    starved: starved.map(([suite, n, min]) => ({ suite, cases: n, minimum: min })),
     results,
   }, null, 2));
 } else {
@@ -209,14 +250,21 @@ if (JSON_OUT) {
     console.log(`  ${MARK[r.status].padEnd(11)} ${r.suite}/${r.id}${r.detail ? ` — ${r.detail}` : ''}`);
   }
   console.log('');
-  console.log(`  ${pass.length} pass · ${fail.length} fail · ${knownGap.length} known-gap · ${unrunnable.length} unrunnable (${undeclared.length} undeclared)`);
-  if (fail.length || undeclared.length || gapClosed.length) {
+  console.log(`  ${pass.length} pass · ${fail.length} fail · ${knownGap.length} known-gap · ${gapClosed.length} gap-closed · ${harnessError.length} harness-error · ${unrunnable.length} unrunnable (${undeclared.length} undeclared)`);
+  for (const [suite, n, min] of starved) {
+    console.log(`  STARVED: suite "${suite}" ran ${n} case(s), minimum ${min}. Coverage cannot silently reach zero.`);
+  }
+  if (fail.length || undeclared.length || gapClosed.length || harnessError.length || starved.length) {
     console.log('');
     console.log('  RED. FAIL = behaviour drifted from the corpus. UNDECLARED unrunnable = the');
     console.log('  corpus asserts something this install cannot evaluate. GAP-CLOSED = a case');
-    console.log('  declared as a known gap now passes, so the declaration is stale. In every');
-    console.log('  case: fix the code or fix the declaration. Do not delete the assertion.');
+    console.log('  declared as a known gap now passes, so the declaration is stale. HARNESS-ERR');
+    console.log('  = the machinery itself broke, and no `requires` declaration can excuse it.');
+    console.log('  STARVED = a suite lost cases. In every case: fix the code or fix the');
+    console.log('  declaration. Do not delete the assertion.');
   }
 }
 
-process.exit(fail.length || undeclared.length || gapClosed.length ? 1 : 0);
+process.exit(
+  fail.length || undeclared.length || gapClosed.length || harnessError.length || starved.length ? 1 : 0,
+);

--- a/evals/run-evals.mjs
+++ b/evals/run-evals.mjs
@@ -62,11 +62,18 @@ function runSkillRecall() {
     // caller without a session id shares ONE flag and the second eval run in a
     // job sees different behaviour from the first. Clearing the flag per case is
     // what makes routing deterministic; it does not change what caddy decides.
-    for (const f of globSync(path.join(ROOT, '.aigent', 'cache', 'caddy-gap-*'))) {
-      rmSync(f, { force: true });
-    }
+    // Give every case its OWN session id. caddy suppresses its no-match line once
+    // per session (caddy.sh:193-194), and a caller that sends no session_id keys
+    // that flag on the literal "unknown" — one bucket shared by every session-less
+    // caller on the install, including any live agent session firing the same hook.
+    // Clearing the shared flag instead of avoiding it was both flaky and rude: it
+    // deleted other sessions' state, and a live session could recreate the flag
+    // between the clear and the spawn. Measured at 1 failure in 5 runs, always the
+    // negative case, always "caddy said: (silent)" — a green suite that goes red
+    // depending on what else is running is not a gate.
+    const evalSession = `eval-${process.pid}-${c.id}`;
     const proc = spawnSync('bash', [path.join(ROOT, 'daemons', 'caddy.sh')], {
-      input: c.prompt,
+      input: JSON.stringify({ prompt: c.prompt, session_id: evalSession }),
       env: { ...process.env, AIGENT_ROOT: ROOT },
       encoding: 'utf8',
       timeout: 15_000,
@@ -81,6 +88,21 @@ function runSkillRecall() {
     if (!c.expect_no_match && !c.expected_skill) {
       record('skill-recall', c.id, 'harness-error',
         'case declares neither expected_skill nor expect_no_match — it asserts nothing and can never fail');
+      continue;
+    }
+
+    // An empty or falsy needle matches EVERY string, because out.includes('') is
+    // always true. One '' in acceptable_alternatives rescues any wrong answer:
+    // a case pointed at the wrong skill with alternatives [''] passed against a
+    // FULLY DEAD router while three siblings went red in the same run. This is the
+    // same defect as an assertion-free case, one level down — the case declares an
+    // expectation, but the expectation cannot fail. A trailing-comma edit produces
+    // it by accident.
+    const emptyNeedle = [...(c.acceptable_alternatives || []), ...(c.must_not_suggest || [])]
+      .some((s) => typeof s !== 'string' || s === '');
+    if (emptyNeedle) {
+      record('skill-recall', c.id, 'harness-error',
+        'acceptable_alternatives/must_not_suggest contains an empty or non-string entry — it matches every response and cannot fail');
       continue;
     }
 
@@ -102,6 +124,30 @@ function runSkillRecall() {
     const bad = (c.must_not_suggest || []).find((s) => out.includes(s));
     if (bad) { record('skill-recall', c.id, 'fail', `suggested forbidden skill "${bad}"`); continue; }
     record('skill-recall', c.id, 'pass', '');
+  }
+  // A no-match assertion is satisfied by a router that is COMPLETELY DEAD: total
+  // failure emits the same "No skill match" the case expects. Measured — with the
+  // scorer stubbed to return nothing, the negative case PASSED while three
+  // positive siblings went red in the same run. So a negative result only carries
+  // information when the router has proven, in this same run, that it can still
+  // match something. Without that pairing the case cannot detect under-firing,
+  // because under-firing is what produces its expected output.
+  const mine = results.filter((r) => r.suite === 'skill-recall');
+  const negativeIds = new Set(cases.filter((c) => c.expect_no_match).map((c) => c.id));
+  const positivesPassed = mine.some((r) => !negativeIds.has(r.id) && r.status === 'pass');
+  const hasPositives = cases.some((c) => !c.expect_no_match);
+  if (hasPositives && !positivesPassed) {
+    for (const r of mine) {
+      if (negativeIds.has(r.id) && r.status === 'pass') {
+        r.status = 'harness-error';
+        r.detail = 'no-match assertion is unverifiable: zero positive cases passed this run, so a dead router would satisfy it identically';
+      }
+    }
+  }
+
+  // Clean up only the flags this run created. Never touch another session's.
+  for (const f of globSync(path.join(ROOT, '.aigent', 'cache', `caddy-gap-eval-${process.pid}-*`))) {
+    rmSync(f, { force: true });
   }
 }
 
@@ -223,9 +269,17 @@ const harnessError = results.filter((r) => r.status === 'harness-error');
 // A corpus that asserts nothing is green by vacuum. Emptying both executable
 // corpora to [] previously produced 0 pass / 0 fail / exit 0. Coverage that can
 // silently reach zero is not coverage.
+// Counted over EXECUTED rows only. Counting every row let declared-unrunnable
+// satisfy the floor: pointing all five skill-recall cases at an absent skill with
+// a `requires` marker produced 5 rows >= the floor, 0 undeclared, exit 0, and
+// caddy was never invoked once. Reachable one case at a time by a reasonable
+// person — rename a skill, the case goes undeclared-unrunnable and turns CI red,
+// and the cheapest green is adding `requires` rather than fixing the corpus. Each
+// step defensible, the suite inert. A row is not an assertion.
+const EXECUTED = new Set(['pass', 'fail', 'known-gap']);
 const MIN_EXECUTABLE = { 'skill-recall': 4, 'capsule-resume': 4 };
 const starved = Object.entries(MIN_EXECUTABLE)
-  .map(([suite, min]) => [suite, results.filter((r) => r.suite === suite).length, min])
+  .map(([suite, min]) => [suite, results.filter((r) => r.suite === suite && EXECUTED.has(r.status)).length, min])
   .filter(([, n, min]) => n < min);
 
 const MARK = {

--- a/evals/run-evals.mjs
+++ b/evals/run-evals.mjs
@@ -26,7 +26,16 @@ const ROOT = path.resolve(EVALS, '..');
 const JSON_OUT = process.argv.includes('--json');
 
 const results = [];
-const record = (suite, id, status, detail) => results.push({ suite, id, status, detail });
+const record = (suite, id, status, detail, extra = {}) => results.push({ suite, id, status, detail, ...extra });
+
+// Duplicate ids inside one corpus collide on the per-case router session id and
+// produce a confusing "(silent)" failure whose cause is invisible. Cheap to reject
+// at load; expensive to diagnose at 2am.
+function duplicateIds(cases) {
+  const seen = new Set(); const dupes = new Set();
+  for (const c of cases || []) { if (seen.has(c?.id)) dupes.add(c.id); seen.add(c?.id); }
+  return [...dupes];
+}
 
 function loadCorpus(name) {
   try { return JSON.parse(readFileSync(path.join(EVALS, name), 'utf8')); }
@@ -98,6 +107,17 @@ function runSkillRecall() {
     // same defect as an assertion-free case, one level down — the case declares an
     // expectation, but the expectation cannot fail. A trailing-comma edit produces
     // it by accident.
+    // Type-check the FIELD before its entries. A JSON string instead of an array
+    // spreads into single characters, each a non-empty string, so an entry-level
+    // check passes and `out.includes('s')` then matches essentially any response.
+    // "acceptable_alternatives": "scout-vault" is one missing bracket pair.
+    const badShape = ['acceptable_alternatives', 'must_not_suggest']
+      .find((k) => c[k] !== undefined && !Array.isArray(c[k]));
+    if (badShape) {
+      record('skill-recall', c.id, 'harness-error',
+        `${badShape} must be an array; a bare string spreads into single characters that match anything`);
+      continue;
+    }
     const emptyNeedle = [...(c.acceptable_alternatives || []), ...(c.must_not_suggest || [])]
       .some((s) => typeof s !== 'string' || s === '');
     if (emptyNeedle) {
@@ -123,7 +143,9 @@ function runSkillRecall() {
     }
     const bad = (c.must_not_suggest || []).find((s) => out.includes(s));
     if (bad) { record('skill-recall', c.id, 'fail', `suggested forbidden skill "${bad}"`); continue; }
-    record('skill-recall', c.id, 'pass', '');
+    // `matched` records whether the router actually resolved a skill, as distinct
+    // from the case merely passing. Only a real match can witness that routing works.
+    record('skill-recall', c.id, 'pass', '', { matched: !/No skill match/i.test(out) });
   }
   // A no-match assertion is satisfied by a router that is COMPLETELY DEAD: total
   // failure emits the same "No skill match" the case expects. Measured — with the
@@ -134,7 +156,12 @@ function runSkillRecall() {
   // because under-firing is what produces its expected output.
   const mine = results.filter((r) => r.suite === 'skill-recall');
   const negativeIds = new Set(cases.filter((c) => c.expect_no_match).map((c) => c.id));
-  const positivesPassed = mine.some((r) => !negativeIds.has(r.id) && r.status === 'pass');
+  // The witness must have MATCHED, not merely passed. caddy's miss line names a
+  // real installed skill ("run /skill-recall to log this gap"), so a positive case
+  // expecting `skill-recall` passes identically whether the router works or is
+  // completely dead — a witness satisfied by the very failure it is meant to rule
+  // out. Only a case whose response was NOT a miss proves routing still works.
+  const positivesPassed = mine.some((r) => !negativeIds.has(r.id) && r.status === 'pass' && r.matched === true);
   const hasPositives = cases.some((c) => !c.expect_no_match);
   if (hasPositives && !positivesPassed) {
     for (const r of mine) {
@@ -238,6 +265,18 @@ for (const [suite, f] of [
 }
 const declarationFor = (r) => declared.get(`${r.suite}/${r.id}`);
 
+for (const [suite, f] of [
+  ['skill-recall', 'skill-recall-tests.json'],
+  ['capsule-resume', 'capsule-resume-tests.json'],
+  ['contradiction', 'contradiction-tests.json'],
+]) {
+  const c = loadCorpus(f);
+  if (c.__error) continue;
+  for (const id of duplicateIds(c)) {
+    record(suite, id, 'harness-error', 'duplicate case id in corpus — cases collide on the per-case router session and fail with a misleading symptom');
+  }
+}
+
 // A DECLARED case that fails is a KNOWN GAP, not a regression — the assertion is
 // kept on purpose to hold an open question open. A DECLARED case that PASSES is
 // fatal: the gap closed and the declaration is now a lie. Without that second
@@ -276,7 +315,14 @@ const harnessError = results.filter((r) => r.status === 'harness-error');
 // person — rename a skill, the case goes undeclared-unrunnable and turns CI red,
 // and the cheapest green is adding `requires` rather than fixing the corpus. Each
 // step defensible, the suite inert. A row is not an assertion.
-const EXECUTED = new Set(['pass', 'fail', 'known-gap']);
+// `known-gap` is deliberately EXCLUDED. It executes, but it is also non-fatal, so
+// counting it let a declaration buy coverage it never pays for: with every
+// positive case declared and the router fully dead, four known-gaps satisfied a
+// floor of four and the suite exited 0 over a router that matched nothing. That is
+// the SAME ratchet closed one round earlier for `unrunnable` — fixing the instance
+// and leaving the identical door open next to it. The floor now counts only rows
+// that both ran AND could have failed the build.
+const EXECUTED = new Set(['pass', 'fail']);
 const MIN_EXECUTABLE = { 'skill-recall': 4, 'capsule-resume': 4 };
 const starved = Object.entries(MIN_EXECUTABLE)
   .map(([suite, min]) => [suite, results.filter((r) => r.suite === suite && EXECUTED.has(r.status)).length, min])

--- a/evals/run-evals.mjs
+++ b/evals/run-evals.mjs
@@ -358,6 +358,26 @@ const undercovered = Object.keys(MIN_CASES)
   .map((suite) => [suite, suiteExecuted(suite), Math.ceil(suiteRows(suite) / 2)])
   .filter(([suite, n, need]) => suiteRows(suite) > 0 && n < need);
 
+// UNWITNESSED — a suite with positive cases must contain at least one pass the
+// TRIGGER SCORER resolved. Without this, `matched` was consulted in exactly one
+// place (the negative-case witness rule) and therefore only mattered when the
+// corpus happened to contain an expect_no_match row. Nothing required such a row
+// to exist. Delete the negative case — the likeliest one to be deleted, since it
+// was the flaky one before session isolation — and four taxonomy-resolved passes
+// satisfied both STARVED and UNDERCOVERED with scorer coverage at exactly zero.
+// This makes scorer liveness a property of the suite rather than a courtesy
+// extended to negative cases.
+// KNOWN LATENT FALSE NEGATIVE, recorded so it is not a surprise: daemons/skill-router.sh
+// is a THIRD resolver emitting "[CADDY:skill] MATCH". It cannot spoof `matched`
+// (colon-prefixed), but a corpus whose positives ALL resolve through it would have
+// no witness and go red while healthy. Red-when-healthy is the safe direction and
+// it is loud, so it is left; no current corpus prompt reaches that path.
+const witnessedSuites = new Set(
+  results.filter((r) => r.status === 'pass' && r.matched === true).map((r) => r.suite),
+);
+const unwitnessed = ['skill-recall']
+  .filter((s) => results.some((r) => r.suite === s && EXECUTED.has(r.status)) && !witnessedSuites.has(s));
+
 const MARK = {
   pass: 'PASS', fail: 'FAIL', 'known-gap': 'KNOWN-GAP', 'gap-closed': 'GAP-CLOSED',
   unrunnable: 'UNRUNNABLE', 'harness-error': 'HARNESS-ERR',
@@ -374,6 +394,7 @@ if (JSON_OUT) {
     harness_error: harnessError.length,
     starved: starved.map(([suite, n, min]) => ({ suite, cases: n, minimum: min })),
     undercovered: undercovered.map(([suite, n, need]) => ({ suite, executed: n, needs: need })),
+    unwitnessed,
     results,
   }, null, 2));
 } else {
@@ -386,9 +407,12 @@ if (JSON_OUT) {
     console.log(`  STARVED: suite "${suite}" has ${n} case(s), minimum ${min}. Coverage cannot silently reach zero.`);
   }
   for (const [suite, n, need] of undercovered) {
-    console.log(`  UNDERCOVERED: suite "${suite}" has only ${n} undeclared executed case(s), needs ${need}. Declarations cannot buy coverage.`);
+    console.log(`  UNDERCOVERED: suite "${suite}" has only ${n} undeclared executed case(s) of ${suiteRows(suite)} rows, needs ${need}. Either declarations ate the coverage or unrunnable rows inflated the denominator.`);
   }
-  if (fail.length || undeclared.length || gapClosed.length || harnessError.length || starved.length || undercovered.length) {
+  for (const suite of unwitnessed) {
+    console.log(`  UNWITNESSED: suite "${suite}" has no scorer-resolved pass. Every passing case was answered by a fallback resolver, so the trigger scorer could be entirely dead.`);
+  }
+  if (fail.length || undeclared.length || gapClosed.length || harnessError.length || starved.length || undercovered.length || unwitnessed.length) {
     console.log('');
     console.log('  RED. FAIL = behaviour drifted from the corpus. UNDECLARED unrunnable = the');
     console.log('  corpus asserts something this install cannot evaluate. GAP-CLOSED = a case');
@@ -401,5 +425,5 @@ if (JSON_OUT) {
 
 process.exit(
   fail.length || undeclared.length || gapClosed.length || harnessError.length
-    || starved.length || undercovered.length ? 1 : 0,
+    || starved.length || undercovered.length || unwitnessed.length ? 1 : 0,
 );

--- a/evals/skill-recall-tests.json
+++ b/evals/skill-recall-tests.json
@@ -1,30 +1,37 @@
 [
   {
     "id": "sr-001",
-    "prompt": "transcribe this audio recording",
-    "expected_skill": "audio-transcriber",
-    "expected_taxonomy": "research.audio.transcriber",
-    "notes": "Direct audio domain match. Should not route to video-analyzer or generic research."
+    "prompt": "audit my install",
+    "expected_skill": "system-check",
+    "must_not_suggest": [],
+    "notes": "Direct install-health match. Rewritten 2026-07-27: the previous case expected 'audio-transcriber', which is not in this repo's skill-index, so it could never be evaluated here."
   },
   {
     "id": "sr-002",
-    "prompt": "check this PR for security issues",
-    "expected_skill": "security-audit",
-    "expected_taxonomy": "security.audit.owasp",
-    "notes": "Security + PR review combined. security-audit is the correct primary skill over code-review."
+    "prompt": "critique this plan",
+    "expected_skill": "critique-plan",
+    "must_not_suggest": [],
+    "notes": "Adversarial review request. Single unambiguous match."
   },
   {
     "id": "sr-003",
-    "prompt": "optimize this slow database query",
-    "expected_skill": "query-optimizer",
-    "expected_taxonomy": "research.deep.investigate",
-    "notes": "Database performance domain. query-optimizer is the installed skill; investigate is the fallback taxonomy path."
+    "prompt": "find notes about pricing",
+    "expected_skill": "semantic-search",
+    "acceptable_alternatives": ["scout-vault"],
+    "must_not_suggest": [],
+    "notes": "Vault retrieval. Caddy returns BOTH scout-vault and semantic-search today, so this case documents that ambiguity rather than pretending to a top-1 answer. Tighten to top-1 only when the router is asked to rank."
+  },
+  {
+    "id": "sr-004",
+    "prompt": "I am blocked and not sure how to proceed",
+    "expected_skill": "stuck",
+    "must_not_suggest": [],
+    "notes": "Restores the id gap in the original corpus, which jumped sr-003 to sr-005."
   },
   {
     "id": "sr-005",
-    "prompt": "generate an OpenAPI spec for this codebase",
-    "expected_skill": "api-docs",
-    "expected_taxonomy": "content.seo.audit",
-    "notes": "API documentation generation. api-docs is the correct skill. taxonomy path is approximate — update if SKILL_LEDGER gets a dedicated api-docs path."
+    "prompt": "what is the weather today",
+    "expect_no_match": true,
+    "notes": "NEGATIVE CASE - no skill should be served. A router that fires on everything has perfect recall and is useless. Caddy announces a miss rather than going silent, so the assertion is on the no-match marker, not on empty output."
   }
 ]

--- a/evals/skill-recall-tests.json
+++ b/evals/skill-recall-tests.json
@@ -2,7 +2,7 @@
   {
     "id": "sr-001",
     "prompt": "audit my install",
-    "expected_skill": "digest",
+    "expected_skill": "system-check",
     "must_not_suggest": [],
     "notes": "Direct install-health match. Rewritten 2026-07-27: the previous case expected 'audio-transcriber', which is not in this repo's skill-index, so it could never be evaluated here."
   },
@@ -17,9 +17,7 @@
     "id": "sr-003",
     "prompt": "find notes about pricing",
     "expected_skill": "semantic-search",
-    "acceptable_alternatives": [
-      "scout-vault"
-    ],
+    "acceptable_alternatives": ["scout-vault"],
     "must_not_suggest": [],
     "notes": "Vault retrieval. Caddy returns BOTH scout-vault and semantic-search today, so this case documents that ambiguity rather than pretending to a top-1 answer. Tighten to top-1 only when the router is asked to rank."
   },

--- a/evals/skill-recall-tests.json
+++ b/evals/skill-recall-tests.json
@@ -2,7 +2,7 @@
   {
     "id": "sr-001",
     "prompt": "audit my install",
-    "expected_skill": "system-check",
+    "expected_skill": "digest",
     "must_not_suggest": [],
     "notes": "Direct install-health match. Rewritten 2026-07-27: the previous case expected 'audio-transcriber', which is not in this repo's skill-index, so it could never be evaluated here."
   },
@@ -17,7 +17,9 @@
     "id": "sr-003",
     "prompt": "find notes about pricing",
     "expected_skill": "semantic-search",
-    "acceptable_alternatives": ["scout-vault"],
+    "acceptable_alternatives": [
+      "scout-vault"
+    ],
     "must_not_suggest": [],
     "notes": "Vault retrieval. Caddy returns BOTH scout-vault and semantic-search today, so this case documents that ambiguity rather than pretending to a top-1 answer. Tighten to top-1 only when the router is asked to rank."
   },


### PR DESCRIPTION
The three corpora under `evals/` carried `expected_*` fields that nothing read. Files shaped like evidence, proving nothing, for weeks. This adds the runner that executes them and wires it into CI.

## What it does

Drives the real subsystems rather than mirroring them. Skill-recall pipes prompts through `daemons/caddy.sh` exactly as the hook does; capsule-resume calls the real selector against a temp vault. A mirror of the logic would stay green while the daemon regressed.

Three outcomes, not two: pass / fail / unrunnable. The third is the point — a case whose preconditions are absent has not passed, and reporting it as a skip is how an inert corpus looks healthy for months. Unrunnable is fatal unless the case declares `requires`, which names a known gap. A declared gap that starts passing is also fatal, so a declaration cannot become a permanent excuse.

## Hardening

The runner went through five rounds of adversarial review whose only question was "can this report green while something real is broken." Thirteen such paths were found and closed. The recurring shape: a guard that measured its own subject correctly while defending something narrower than the property it existed to protect.

- A declaration in one suite could silence a same-named case in another, downgrading a live routing failure to a known gap.
- A thrown exception from the real selector was swallowed into a non-fatal status and excused by the case's own declaration.
- Cases that asserted nothing reported pass; an empty string in `acceptable_alternatives` matched every response; a bare string in place of an array spread into single characters that matched anything.
- Declared and non-executing rows could satisfy the coverage floor with the router never invoked once.
- The negative case was satisfied by total router failure, since a dead router emits exactly the "no match" it asserts.
- `caddy` resolves in two stages, and a fallback-resolved pass could certify a run in which the trigger scorer was entirely dead.

Coverage is now guarded by three separate properties: cases must exist, enough of them must be undeclared and executed, and at least one pass must have been resolved by the scorer itself.

## Verification

Every fix carries a mutation proof with a hash-verified restore. The failing path was observed in CI directly, not inferred: a deliberate one-line break turned the eval step red while every prior step stayed green, and was reverted.

Current state on this branch: 9 pass, 0 fail, 1 known gap, 3 unrunnable, exit 0.

## Known limitations, declared rather than hidden

- The contradiction suite needs a model in the loop. Its three cases are reported unrunnable every run. They are not merely unexercised: the runner reads only `id` and `requires`, so the suite emits identical rows for any corpus content. The gap is in the runner, not the corpus.
- `must_not_suggest` is empty in every case, so that half of the router claim is currently inert.
- A corpus whose positive cases all resolve through `skill-router.sh` would have no witness and go red while healthy. Red-when-healthy is the safe direction, so it stands.
- One capsule-resume case is a declared known gap: a paused capsule is unreachable, neither consumed nor selectable.