### PR TITLE
doctor: attest an install against a pinned fleet baseline manifest

### DIFF
--- a/daemons/tests/fleet-baseline-attest.test.mjs
+++ b/daemons/tests/fleet-baseline-attest.test.mjs
@@ -26,6 +26,7 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -50,8 +51,8 @@ function readManifest() {
 // Simulates an exact install: every path the manifest requires, the manifest
 // itself (the installer's COPY_DIRS already carries scripts/), a rendered
 // settings.json, and the directories a real install creates.
-function buildInstall() {
-  const root = mkdtempSync(path.join(tmpdir(), 'fleet-baseline-attest-'));
+function buildInstall({ settingsRootFor = (root) => root } = {}) {
+  const root = realpathSync(mkdtempSync(path.join(tmpdir(), 'fleet-baseline-attest-')));
   const manifest = readManifest();
 
   for (const relative of Object.keys(manifest.required_files)) {
@@ -70,6 +71,7 @@ function buildInstall() {
   // moment the install root contains a backslash, which every Windows install
   // root does -- so the fixture has to render the way the installer renders.
   const token = manifest.required_settings.unresolved_placeholder;
+  const settingsRoot = settingsRootFor(root);
   const shellDoubleQuoted = (value) => value
     .replace(/\\/g, '\\\\')
     .replace(/"/g, '\\"')
@@ -78,7 +80,9 @@ function buildInstall() {
   const render = (value) => {
     if (typeof value === 'string') {
       if (!value.includes(token)) return value;
-      return value === token ? root : value.split(token).join(shellDoubleQuoted(root));
+      return value === token
+        ? settingsRoot
+        : value.split(token).join(shellDoubleQuoted(settingsRoot));
     }
     if (Array.isArray(value)) return value.map(render);
     if (value && typeof value === 'object') {
@@ -150,13 +154,20 @@ function digest(root) {
   return accumulator.digest('hex');
 }
 
-function withInstall(run) {
-  const root = buildInstall();
+function withInstall(run, options) {
+  const root = buildInstall(options);
   try {
     run(root);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+}
+
+function lowercaseMsysRoot(root) {
+  const forward = root.replace(/\\/g, '/');
+  const match = forward.match(/^([A-Za-z]):(\/.*)$/);
+  assert.ok(match, `expected a Windows drive path, got: ${root}`);
+  return `/${match[1].toLowerCase()}${match[2].toLowerCase()}`;
 }
 
 test('an exact install attests COMPLIANT against the shipped manifest', () => {
@@ -165,6 +176,17 @@ test('an exact install attests COMPLIANT against the shipped manifest', () => {
     assert.equal(verdict, 'COMPLIANT', output);
     assert.equal(status, 0, 'COMPLIANT exits 0');
   });
+});
+
+test('a settings fixture rendered with a lowercase Windows root attests COMPLIANT', {
+  skip: process.platform !== 'win32',
+}, () => {
+  withInstall((root) => {
+    const lowerRoot = lowercaseMsysRoot(root);
+    const { verdict, status, output } = attest(lowerRoot);
+    assert.equal(verdict, 'COMPLIANT', output);
+    assert.equal(status, 0, 'COMPLIANT exits 0');
+  }, { settingsRootFor: lowercaseMsysRoot });
 });
 
 // THE MUTATION WITNESS. One expected hash in the manifest is flipped; the file
@@ -211,6 +233,32 @@ test('settings stale against the manifest attest NONCOMPLIANT', () => {
 
     const { verdict, output } = attest(root);
     assert.equal(verdict, 'NONCOMPLIANT', output);
+    assert.match(output, /settings hook daemons\/gateguard\.mjs not wired under event/);
+    assert.equal(
+      output.match(/gateguard\.mjs/g)?.length,
+      1,
+      `a parsed missing hook should produce one structural finding:\n${output}`,
+    );
+  });
+});
+
+test('an unparsed settings document keeps the raw missing-hook finding', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    const settings = path.join(root, ...manifest.required_settings.path.split('/'));
+    const parsed = JSON.parse(readFileSync(settings, 'utf8'));
+    parsed.hooks.PreToolUse = parsed.hooks.PreToolUse.filter(
+      (entry) => !JSON.stringify(entry).includes('gateguard.mjs'),
+    );
+    writeFileSync(settings, `${JSON.stringify(parsed, null, 2)},\n`);
+
+    const { verdict, status, output } = attest(root);
+    assert.deepEqual(
+      { verdict, status },
+      { verdict: 'NONCOMPLIANT', status: 1 },
+      output,
+    );
+    assert.match(output, /settings JSON malformed: \.claude\/settings\.json/);
     assert.match(output, /settings hook not wired: daemons\/gateguard\.mjs/);
   });
 });
@@ -256,6 +304,73 @@ test('a required hook under the wrong matcher attests NONCOMPLIANT', () => {
       output,
     );
     assert.match(output, /settings hook .*daemons\/gateguard\.mjs.*matcher/);
+  });
+});
+
+test('omitting an empty match-all matcher remains COMPLIANT', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    const settings = path.join(root, ...manifest.required_settings.path.split('/'));
+    const parsed = JSON.parse(readFileSync(settings, 'utf8'));
+    const matchAll = parsed.hooks.SessionStart.find(({ matcher, hooks }) => (
+      matcher === ''
+      && hooks.some(({ command }) => command.includes('sessionstart-reinject.mjs'))
+    ));
+    assert.ok(matchAll, 'fixture includes a SessionStart match-all hook');
+    delete matchAll.matcher;
+    writeFileSync(settings, `${JSON.stringify(parsed, null, 2)}\n`);
+
+    const { verdict, status, output } = attest(root);
+    assert.equal(verdict, 'COMPLIANT', output);
+    assert.equal(status, 0, 'COMPLIANT exits 0');
+  });
+});
+
+test('raising a required hook timeout remains COMPLIANT', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    const settings = path.join(root, ...manifest.required_settings.path.split('/'));
+    const parsed = JSON.parse(readFileSync(settings, 'utf8'));
+    const matchAll = parsed.hooks.SessionStart.find(({ matcher, hooks }) => (
+      matcher === ''
+      && hooks.some(({ command }) => command.includes('sessionstart-reinject.mjs'))
+    ));
+    const hook = matchAll?.hooks.find(({ command }) => (
+      command.includes('sessionstart-reinject.mjs')
+    ));
+    assert.ok(hook, 'fixture includes the required SessionStart hook');
+    hook.timeout += 1000;
+    writeFileSync(settings, `${JSON.stringify(parsed, null, 2)}\n`);
+
+    const { verdict, status, output } = attest(root);
+    assert.equal(verdict, 'COMPLIANT', output);
+    assert.equal(status, 0, 'COMPLIANT exits 0');
+  });
+});
+
+test('lowering a required hook timeout attests NONCOMPLIANT', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    const settings = path.join(root, ...manifest.required_settings.path.split('/'));
+    const parsed = JSON.parse(readFileSync(settings, 'utf8'));
+    const matchAll = parsed.hooks.SessionStart.find(({ matcher, hooks }) => (
+      matcher === ''
+      && hooks.some(({ command }) => command.includes('sessionstart-reinject.mjs'))
+    ));
+    const hook = matchAll?.hooks.find(({ command }) => (
+      command.includes('sessionstart-reinject.mjs')
+    ));
+    assert.ok(hook, 'fixture includes the required SessionStart hook');
+    hook.timeout -= 1000;
+    writeFileSync(settings, `${JSON.stringify(parsed, null, 2)}\n`);
+
+    const { verdict, status, output } = attest(root);
+    assert.deepEqual(
+      { verdict, status },
+      { verdict: 'NONCOMPLIANT', status: 1 },
+      output,
+    );
+    assert.match(output, /settings hook .*sessionstart-reinject\.mjs.*timeout/);
   });
 });
 

--- a/daemons/tests/fleet-baseline-attest.test.mjs
+++ b/daemons/tests/fleet-baseline-attest.test.mjs
@@ -179,7 +179,7 @@ test('an exact install attests COMPLIANT against the shipped manifest', () => {
 });
 
 test('a settings fixture rendered with a lowercase Windows root attests COMPLIANT', {
-  skip: process.platform !== 'win32',
+  skip: process.platform !== 'win32' && 'Windows drive-letter canonicalization only',
 }, () => {
   withInstall((root) => {
     const lowerRoot = lowercaseMsysRoot(root);

--- a/daemons/tests/fleet-baseline-attest.test.mjs
+++ b/daemons/tests/fleet-baseline-attest.test.mjs
@@ -215,6 +215,72 @@ test('settings stale against the manifest attest NONCOMPLIANT', () => {
   });
 });
 
+test('malformed settings JSON attests NONCOMPLIANT', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    const settings = path.join(root, ...manifest.required_settings.path.split('/'));
+    const valid = readFileSync(settings, 'utf8').trimEnd();
+    // Keep every required command path present while making the document
+    // invalid, so a raw substring scan cannot distinguish it from a contract.
+    writeFileSync(settings, `${valid},\n`);
+
+    const { verdict, status, output } = attest(root);
+    assert.deepEqual(
+      { verdict, status },
+      { verdict: 'NONCOMPLIANT', status: 1 },
+      output,
+    );
+    assert.match(output, /settings JSON malformed: \.claude\/settings\.json/);
+  });
+});
+
+test('a required hook under the wrong matcher attests NONCOMPLIANT', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    const settings = path.join(root, ...manifest.required_settings.path.split('/'));
+    const parsed = JSON.parse(readFileSync(settings, 'utf8'));
+    const preToolUse = parsed.hooks.PreToolUse;
+    const expectedTuple = preToolUse.find(({ matcher }) => matcher === 'Edit|Write|Bash');
+    const hookIndex = expectedTuple.hooks.findIndex(({ command }) => (
+      command.includes('gateguard.mjs')
+    ));
+    assert.notEqual(hookIndex, -1, 'fixture includes the required gateguard hook');
+    const [movedHook] = expectedTuple.hooks.splice(hookIndex, 1);
+    preToolUse.find(({ matcher }) => matcher === 'Agent').hooks.push(movedHook);
+    writeFileSync(settings, `${JSON.stringify(parsed, null, 2)}\n`);
+
+    const { verdict, status, output } = attest(root);
+    assert.deepEqual(
+      { verdict, status },
+      { verdict: 'NONCOMPLIANT', status: 1 },
+      output,
+    );
+    assert.match(output, /settings hook .*daemons\/gateguard\.mjs.*matcher/);
+  });
+});
+
+test('unrelated operator settings do not affect a COMPLIANT verdict', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    const settings = path.join(root, ...manifest.required_settings.path.split('/'));
+    const parsed = JSON.parse(readFileSync(settings, 'utf8'));
+    parsed.env.OPERATOR_THEME = 'midnight';
+    parsed.permissions = { allow: ['Read'], deny: ['Bash(rm:*)'] };
+    parsed.operator = { notifications: true };
+    parsed.hooks.OperatorEvent = [
+      {
+        matcher: 'operator-only',
+        hooks: [{ type: 'command', command: 'echo operator hook', timeout: 500 }],
+      },
+    ];
+    writeFileSync(settings, `${JSON.stringify(parsed, null, 2)}\n`);
+
+    const { verdict, status, output } = attest(root);
+    assert.equal(verdict, 'COMPLIANT', output);
+    assert.equal(status, 0, 'COMPLIANT exits 0');
+  });
+});
+
 test('an unsubstituted settings placeholder attests NONCOMPLIANT', () => {
   withInstall((root) => {
     const manifest = readManifest();

--- a/daemons/tests/fleet-baseline-attest.test.mjs
+++ b/daemons/tests/fleet-baseline-attest.test.mjs
@@ -1,0 +1,326 @@
+// fleet-baseline-attest.test.mjs -- scripts/doctor.sh --attest against the
+// shipped fleet baseline manifest.
+//
+// Every case materializes a throwaway install from the COMMITTED manifest
+// (scripts/fleet-baseline-manifest.json) and points --attest at it, so this
+// file validates the manifest that ships, not a synthetic one built to agree
+// with itself. That is what makes the mutation witness real: change one
+// expected hash in the committed manifest and the exact-install case below
+// goes red, because the file copied out of the repo no longer matches what
+// the manifest claims it should be.
+//
+// Nothing here touches a real install. Each case builds its own temp
+// directory and removes it again, and --attest never writes at all -- the
+// read-only case proves that by digesting the tree before and after.
+//
+// node-pty is stubbed rather than installed. The attestation's runner check is
+// install.sh's own probe, createRequire(transport-deps/package.json)('node-pty'),
+// which asks one question: does the module resolve and load. A resolvable stub
+// answers it deterministically on every machine with no network and no native
+// build, and the "unavailable" case removes the stub to prove the other side.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, '..', '..');
+const DOCTOR = path.join(REPO, 'scripts', 'doctor.sh');
+const MANIFEST = path.join(REPO, 'scripts', 'fleet-baseline-manifest.json');
+
+const TERMINALS = ['COMPLIANT', 'DEGRADED', 'NONCOMPLIANT', 'UNKNOWN'];
+
+function readManifest() {
+  return JSON.parse(readFileSync(MANIFEST, 'utf8'));
+}
+
+// Simulates an exact install: every path the manifest requires, the manifest
+// itself (the installer's COPY_DIRS already carries scripts/), a rendered
+// settings.json, and the directories a real install creates.
+function buildInstall() {
+  const root = mkdtempSync(path.join(tmpdir(), 'fleet-baseline-attest-'));
+  const manifest = readManifest();
+
+  for (const relative of Object.keys(manifest.required_files)) {
+    const destination = path.join(root, ...relative.split('/'));
+    mkdirSync(path.dirname(destination), { recursive: true });
+    cpSync(path.join(REPO, ...relative.split('/')), destination);
+  }
+
+  mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  cpSync(MANIFEST, path.join(root, 'scripts', 'fleet-baseline-manifest.json'));
+
+  // What install.sh's render step produces. It is deliberately not a text
+  // substitution: the template is parsed as JSON, the placeholder is replaced
+  // inside string values with a shell-escaped root, and the result is
+  // re-serialized. A plain search-and-replace here would emit invalid JSON the
+  // moment the install root contains a backslash, which every Windows install
+  // root does -- so the fixture has to render the way the installer renders.
+  const token = manifest.required_settings.unresolved_placeholder;
+  const shellDoubleQuoted = (value) => value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, '\\$')
+    .replace(/`/g, '\\`');
+  const render = (value) => {
+    if (typeof value === 'string') {
+      if (!value.includes(token)) return value;
+      return value === token ? root : value.split(token).join(shellDoubleQuoted(root));
+    }
+    if (Array.isArray(value)) return value.map(render);
+    if (value && typeof value === 'object') {
+      return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, render(item)]));
+    }
+    return value;
+  };
+  const template = JSON.parse(readFileSync(
+    path.join(root, ...manifest.required_settings.template.split('/')),
+    'utf8',
+  ));
+  writeFileSync(
+    path.join(root, ...manifest.required_settings.path.split('/')),
+    `${JSON.stringify(render(template), null, 2)}\n`,
+  );
+
+  mkdirSync(path.join(root, 'vault', 'memory', 'runtime'), { recursive: true });
+  mkdirSync(
+    path.join(root, ...manifest.optional_components.semantic_search.path.split('/')),
+    { recursive: true },
+  );
+
+  const ptyDir = path.join(
+    root,
+    ...manifest.managed_runner.dependency_root.split('/'),
+    'node_modules',
+    'node-pty',
+  );
+  mkdirSync(ptyDir, { recursive: true });
+  writeFileSync(
+    path.join(ptyDir, 'package.json'),
+    `{"name":"node-pty","version":"${manifest.managed_runner.version}","main":"index.js"}\n`,
+  );
+  writeFileSync(path.join(ptyDir, 'index.js'), 'module.exports = {};\n');
+
+  return root;
+}
+
+function attest(root) {
+  const result = spawnSync('bash', [DOCTOR, root, '--attest'], { encoding: 'utf8' });
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+  const verdicts = output
+    .split('\n')
+    .map((line) => line.trim().match(/^ATTEST: (\w+)$/))
+    .filter(Boolean)
+    .map((match) => match[1]);
+  // The contract is one terminal class, not "a terminal class somewhere in the
+  // output". A second verdict line would make every assertion below ambiguous.
+  assert.equal(verdicts.length, 1, `expected exactly one ATTEST line, got:\n${output}`);
+  assert.ok(TERMINALS.includes(verdicts[0]), `unknown terminal class: ${verdicts[0]}`);
+  return { verdict: verdicts[0], status: result.status, output };
+}
+
+function digest(root) {
+  const accumulator = createHash('sha256');
+  const walk = (dir, prefix) => {
+    for (const entry of readdirSync(dir).sort()) {
+      const full = path.join(dir, entry);
+      const relative = prefix ? `${prefix}/${entry}` : entry;
+      if (statSync(full).isDirectory()) {
+        walk(full, relative);
+      } else {
+        accumulator.update(relative);
+        accumulator.update(readFileSync(full));
+      }
+    }
+  };
+  walk(root, '');
+  return accumulator.digest('hex');
+}
+
+function withInstall(run) {
+  const root = buildInstall();
+  try {
+    run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('an exact install attests COMPLIANT against the shipped manifest', () => {
+  withInstall((root) => {
+    const { verdict, status, output } = attest(root);
+    assert.equal(verdict, 'COMPLIANT', output);
+    assert.equal(status, 0, 'COMPLIANT exits 0');
+  });
+});
+
+// THE MUTATION WITNESS. One expected hash in the manifest is flipped; the file
+// on disk is untouched. If the exact-install comparison were not actually
+// comparing bytes against these hashes, this would still read COMPLIANT.
+test('mutating one expected hash turns the exact-install check red', () => {
+  withInstall((root) => {
+    const installed = path.join(root, 'scripts', 'fleet-baseline-manifest.json');
+    const manifest = JSON.parse(readFileSync(installed, 'utf8'));
+    const [target] = Object.keys(manifest.required_files);
+    manifest.required_files[target] = 'f'.repeat(64);
+    writeFileSync(installed, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const { verdict, status, output } = attest(root);
+    assert.equal(verdict, 'NONCOMPLIANT', output);
+    assert.equal(status, 1, 'NONCOMPLIANT exits 1');
+    assert.match(output, new RegExp(`required file changed: ${target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+  });
+});
+
+test('a byte changed in a required file attests NONCOMPLIANT', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    const [target] = Object.keys(manifest.required_files);
+    const file = path.join(root, ...target.split('/'));
+    writeFileSync(file, `${readFileSync(file, 'utf8')}\n`);
+
+    const { verdict, output } = attest(root);
+    assert.equal(verdict, 'NONCOMPLIANT', output);
+  });
+});
+
+test('settings stale against the manifest attest NONCOMPLIANT', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    const settings = path.join(root, ...manifest.required_settings.path.split('/'));
+    const parsed = JSON.parse(readFileSync(settings, 'utf8'));
+    // What an install rendered from an older template looks like: valid JSON,
+    // every path resolved, one newer hook simply never wired.
+    parsed.hooks.PreToolUse = parsed.hooks.PreToolUse.filter(
+      (entry) => !JSON.stringify(entry).includes('gateguard.mjs'),
+    );
+    writeFileSync(settings, `${JSON.stringify(parsed, null, 2)}\n`);
+
+    const { verdict, output } = attest(root);
+    assert.equal(verdict, 'NONCOMPLIANT', output);
+    assert.match(output, /settings hook not wired: daemons\/gateguard\.mjs/);
+  });
+});
+
+test('an unsubstituted settings placeholder attests NONCOMPLIANT', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    cpSync(
+      path.join(root, ...manifest.required_settings.template.split('/')),
+      path.join(root, ...manifest.required_settings.path.split('/')),
+    );
+
+    const { verdict, output } = attest(root);
+    assert.equal(verdict, 'NONCOMPLIANT', output);
+    assert.match(output, /placeholder not substituted/);
+  });
+});
+
+test('an unloadable node-pty attests NONCOMPLIANT while Auto-Refresh is expected enabled', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    assert.equal(manifest.auto_refresh.expected, 'enabled', 'v1 baseline expects managed Auto-Refresh');
+    rmSync(
+      path.join(root, ...manifest.managed_runner.dependency_root.split('/'), 'node_modules'),
+      { recursive: true, force: true },
+    );
+
+    const { verdict, output } = attest(root);
+    assert.equal(verdict, 'NONCOMPLIANT', output);
+    assert.match(output, /managed runner unavailable/);
+  });
+});
+
+test('an Auto-Refresh kill switch attests NONCOMPLIANT against an enabled baseline', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    const [primaryRoot] = manifest.auto_refresh.kill_switch_roots;
+    writeFileSync(
+      path.join(
+        root,
+        ...primaryRoot.split('/'),
+        ...manifest.auto_refresh.kill_switch_file.split('/'),
+      ),
+      '',
+    );
+
+    const { verdict, output } = attest(root);
+    assert.equal(verdict, 'NONCOMPLIANT', output);
+    assert.match(output, /kill switch is set/);
+  });
+});
+
+test('a missing manifest attests UNKNOWN, not NONCOMPLIANT', () => {
+  withInstall((root) => {
+    rmSync(path.join(root, 'scripts', 'fleet-baseline-manifest.json'), { force: true });
+
+    const { verdict, status, output } = attest(root);
+    // "cannot measure" and "measured, and it is broken" are different facts.
+    // Collapsing them would let a fleet gate read an unreadable manifest as a
+    // failing install, or worse, the reverse.
+    assert.equal(verdict, 'UNKNOWN', output);
+    assert.equal(status, 2, 'UNKNOWN exits 2, distinct from NONCOMPLIANT exit 1');
+  });
+});
+
+test('an unreadable manifest attests UNKNOWN', () => {
+  withInstall((root) => {
+    writeFileSync(path.join(root, 'scripts', 'fleet-baseline-manifest.json'), '{ not json');
+
+    const { verdict, status, output } = attest(root);
+    assert.equal(verdict, 'UNKNOWN', output);
+    assert.equal(status, 2);
+  });
+});
+
+test('an absent optional component attests DEGRADED, everything else exact', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    rmSync(
+      path.join(root, ...manifest.optional_components.semantic_search.path.split('/')),
+      { recursive: true, force: true },
+    );
+
+    const { verdict, status, output } = attest(root);
+    assert.equal(verdict, 'DEGRADED', output);
+    assert.equal(status, 0, 'DEGRADED is not a failure exit');
+  });
+});
+
+// An optional absence must never pull a broken install back up to DEGRADED.
+test('an optional absence alongside a required failure stays NONCOMPLIANT', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    rmSync(
+      path.join(root, ...manifest.optional_components.semantic_search.path.split('/')),
+      { recursive: true, force: true },
+    );
+    const [target] = Object.keys(manifest.required_files);
+    const file = path.join(root, ...target.split('/'));
+    writeFileSync(file, `${readFileSync(file, 'utf8')}\n`);
+
+    const { verdict, output } = attest(root);
+    assert.equal(verdict, 'NONCOMPLIANT', output);
+  });
+});
+
+test('--attest writes nothing into the tree it attests', () => {
+  withInstall((root) => {
+    const before = digest(root);
+    attest(root);
+    assert.equal(digest(root), before, '--attest must not modify the attested tree');
+  });
+});

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -133,11 +133,22 @@ for relative, expected in manifest["required_files"].items():
 # stays valid JSON with every path resolved and is simply missing the newer
 # hook wiring. Checking the placeholder alone would read that as healthy.
 settings = manifest["required_settings"]
+MISSING = object()
+settings_document = MISSING
+
+
+def reject_json_constant(value):
+    raise ValueError("invalid JSON constant: %s" % value)
+
+
 try:
     with open(under_root(settings["path"]), encoding="utf-8") as fh:
         settings_text = fh.read()
 except OSError:
     findings.append("settings missing: %s" % settings["path"])
+    settings_text = None
+except UnicodeError:
+    findings.append("settings JSON malformed: %s" % settings["path"])
     settings_text = None
 
 if settings_text is not None:
@@ -152,6 +163,215 @@ if settings_text is not None:
         # substring of a correctly rendered settings.json.
         if command not in settings_text:
             findings.append("settings hook not wired: %s" % command)
+    try:
+        settings_document = json.loads(
+            settings_text, parse_constant=reject_json_constant
+        )
+    except (ValueError, UnicodeError, RecursionError):
+        findings.append("settings JSON malformed: %s" % settings["path"])
+
+# The pinned template is the structural contract. Only its managed statusLine
+# and selected hook entries are required; unrelated operator settings remain
+# deliberately outside attestation.
+template_document = MISSING
+try:
+    with open(under_root(settings["template"]), encoding="utf-8") as fh:
+        template_document = json.load(fh, parse_constant=reject_json_constant)
+except OSError:
+    findings.append("settings template missing: %s" % settings["template"])
+except (ValueError, UnicodeError, RecursionError):
+    findings.append("settings template JSON malformed: %s" % settings["template"])
+
+
+root_to_resolve = root
+if (
+    os.name == "nt"
+    and len(root) >= 2
+    and root[0] == "/"
+    and root[1].isalpha()
+    and (len(root) == 2 or root[2] == "/")
+):
+    root_to_resolve = root[1] + ":" + root[2:]
+canonical_root = os.path.realpath(os.path.abspath(root_to_resolve))
+root_spellings = []
+
+
+def add_root_spelling(value):
+    if value not in root_spellings:
+        root_spellings.append(value)
+
+
+add_root_spelling(canonical_root)
+forward_root = canonical_root.replace("\\", "/")
+add_root_spelling(forward_root)
+drive, tail = os.path.splitdrive(forward_root)
+if len(drive) == 2 and drive[1] == ":":
+    add_root_spelling("/%s%s" % (drive[0].lower(), tail))
+
+
+def render_commands(command):
+    token = settings["unresolved_placeholder"]
+    if not isinstance(command, str) or token not in command:
+        return (command,)
+    if command == token:
+        return tuple(root_spellings)
+    rendered = []
+    for root_spelling in root_spellings:
+        escaped_root = (
+            root_spelling.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("$", "\\$")
+            .replace("`", "\\`")
+        )
+        rendered.append(command.replace(token, escaped_root))
+    return tuple(dict.fromkeys(rendered))
+
+
+def hook_records(document):
+    records = []
+    hooks = document.get("hooks") if isinstance(document, dict) else None
+    if not isinstance(hooks, dict):
+        return records
+    for event, groups in hooks.items():
+        if not isinstance(groups, list):
+            continue
+        for group in groups:
+            if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+                continue
+            for entry in group["hooks"]:
+                if isinstance(entry, dict):
+                    records.append(
+                        (
+                            event,
+                            group.get("matcher", MISSING),
+                            entry.get("type", MISSING),
+                            entry.get("command", MISSING),
+                            entry.get("timeout", MISSING),
+                        )
+                    )
+    return records
+
+
+def same(left, right):
+    return type(left) is type(right) and left == right
+
+
+def shown(value):
+    return "missing" if value is MISSING else repr(value)
+
+
+def command_matches(actual, expected_commands):
+    return any(same(actual, expected) for expected in expected_commands)
+
+
+def shown_commands(commands):
+    return " or ".join(shown(command) for command in commands)
+
+
+if template_document is not MISSING:
+    required_commands = settings["hook_commands"]
+    represented = set()
+    expected_status = MISSING
+    status_line = (
+        template_document.get("statusLine")
+        if isinstance(template_document, dict)
+        else None
+    )
+    if isinstance(status_line, dict) and "command" in status_line:
+        template_status = status_line["command"]
+        expected_status = render_commands(template_status)
+        if isinstance(template_status, str):
+            represented.update(
+                command for command in required_commands if command in template_status
+            )
+    else:
+        findings.append(
+            "settings template contract missing statusLine command: %s"
+            % settings["template"]
+        )
+
+    expected_hooks = []
+    for event, matcher, hook_type, command, timeout in hook_records(template_document):
+        if not isinstance(command, str):
+            continue
+        for relative in required_commands:
+            if relative in command:
+                expected_hooks.append(
+                    (
+                        relative,
+                        event,
+                        matcher,
+                        hook_type,
+                        render_commands(command),
+                        timeout,
+                    )
+                )
+                represented.add(relative)
+    for command in required_commands:
+        if command not in represented:
+            findings.append(
+                "settings template contract missing required command: %s" % command
+            )
+
+    if settings_document is not MISSING:
+        installed_status = MISSING
+        if isinstance(settings_document, dict):
+            status_line = settings_document.get("statusLine")
+            if isinstance(status_line, dict):
+                installed_status = status_line.get("command", MISSING)
+        if (
+            expected_status is not MISSING
+            and not command_matches(installed_status, expected_status)
+        ):
+            findings.append(
+                "settings statusLine command differs: expected %s, got %s"
+                % (shown_commands(expected_status), shown(installed_status))
+            )
+
+        installed_hooks = hook_records(settings_document)
+        for relative, event, matcher, hook_type, commands, timeout in expected_hooks:
+            candidates = [
+                actual
+                for actual in installed_hooks
+                if isinstance(actual[3], str) and relative in actual[3]
+            ]
+            if not candidates:
+                findings.append(
+                    "settings hook %s not wired under event %s matcher %s"
+                    % (relative, shown(event), shown(matcher))
+                )
+                continue
+
+            compared = []
+            for candidate in candidates:
+                differences = []
+                for name, actual, required in (
+                    ("event", candidate[0], event),
+                    ("matcher", candidate[1], matcher),
+                    ("type", candidate[2], hook_type),
+                    ("timeout", candidate[4], timeout),
+                ):
+                    if not same(actual, required):
+                        differences.append(
+                            "%s expected %s, got %s"
+                            % (name, shown(required), shown(actual))
+                        )
+                if not command_matches(candidate[3], commands):
+                    differences.append(
+                        "command expected %s, got %s"
+                        % (shown_commands(commands), shown(candidate[3]))
+                    )
+                if not differences:
+                    break
+                compared.append(differences)
+            if not differences:
+                continue
+
+            differences = min(compared, key=len)
+            findings.append(
+                "settings hook %s differs: %s"
+                % (relative, "; ".join(differences))
+            )
 
 # The managed launcher expectation is enforced through required_files. This
 # check guards the manifest itself: a declared launcher path that nothing

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -157,18 +157,18 @@ if settings_text is not None:
             "settings placeholder not substituted: %s"
             % settings["unresolved_placeholder"]
         )
-    for command in settings["hook_commands"]:
-        # The template embeds every hook as "<root>/<relative>" with forward
-        # slashes on every platform, so the relative tail is a literal
-        # substring of a correctly rendered settings.json.
-        if command not in settings_text:
-            findings.append("settings hook not wired: %s" % command)
     try:
         settings_document = json.loads(
             settings_text, parse_constant=reject_json_constant
         )
     except (ValueError, UnicodeError, RecursionError):
         findings.append("settings JSON malformed: %s" % settings["path"])
+    if settings_document is MISSING:
+        for command in settings["hook_commands"]:
+            # When parsing fails, retain the legacy text witness and message:
+            # the relative tail is a literal substring of a rendered command.
+            if command not in settings_text:
+                findings.append("settings hook not wired: %s" % command)
 
 # The pinned template is the structural contract. Only its managed statusLine
 # and selected hook entries are required; unrelated operator settings remain
@@ -192,7 +192,8 @@ if (
     and (len(root) == 2 or root[2] == "/")
 ):
     root_to_resolve = root[1] + ":" + root[2:]
-canonical_root = os.path.realpath(os.path.abspath(root_to_resolve))
+absolute_root = os.path.abspath(root_to_resolve)
+canonical_root = os.path.realpath(absolute_root)
 root_spellings = []
 
 
@@ -201,12 +202,18 @@ def add_root_spelling(value):
         root_spellings.append(value)
 
 
-add_root_spelling(canonical_root)
-forward_root = canonical_root.replace("\\", "/")
-add_root_spelling(forward_root)
-drive, tail = os.path.splitdrive(forward_root)
-if len(drive) == 2 and drive[1] == ":":
-    add_root_spelling("/%s%s" % (drive[0].lower(), tail))
+def add_root_variants(value):
+    add_root_spelling(value)
+    forward = value.replace("\\", "/")
+    add_root_spelling(forward)
+    drive, tail = os.path.splitdrive(forward)
+    if len(drive) == 2 and drive[1] == ":":
+        add_root_spelling("/%s%s" % (drive[0].lower(), tail))
+        add_root_spelling("/%s%s" % (drive[0].upper(), tail))
+
+
+for root_spelling in (canonical_root, absolute_root, root):
+    add_root_variants(root_spelling)
 
 
 def render_commands(command):
@@ -227,6 +234,10 @@ def render_commands(command):
     return tuple(dict.fromkeys(rendered))
 
 
+def normalized_matcher(value):
+    return "" if value is MISSING or value in ("", "*") else value
+
+
 def hook_records(document):
     records = []
     hooks = document.get("hooks") if isinstance(document, dict) else None
@@ -243,7 +254,7 @@ def hook_records(document):
                     records.append(
                         (
                             event,
-                            group.get("matcher", MISSING),
+                            normalized_matcher(group.get("matcher", MISSING)),
                             entry.get("type", MISSING),
                             entry.get("command", MISSING),
                             entry.get("timeout", MISSING),
@@ -260,8 +271,29 @@ def shown(value):
     return "missing" if value is MISSING else repr(value)
 
 
+def normalized_command(command):
+    if os.name == "nt" and isinstance(command, str):
+        return os.path.normcase(command)
+    return command
+
+
 def command_matches(actual, expected_commands):
-    return any(same(actual, expected) for expected in expected_commands)
+    actual = normalized_command(actual)
+    return any(
+        same(actual, normalized_command(expected)) for expected in expected_commands
+    )
+
+
+def timeout_is_insufficient(actual, required):
+    if required is MISSING:
+        return False
+    if actual is MISSING:
+        return True
+    if isinstance(required, bool) or not isinstance(required, (int, float)):
+        return not same(actual, required)
+    if isinstance(actual, bool) or not isinstance(actual, (int, float)):
+        return True
+    return actual < required
 
 
 def shown_commands(commands):
@@ -333,7 +365,8 @@ if template_document is not MISSING:
             candidates = [
                 actual
                 for actual in installed_hooks
-                if isinstance(actual[3], str) and relative in actual[3]
+                if isinstance(actual[3], str)
+                and normalized_command(relative) in normalized_command(actual[3])
             ]
             if not candidates:
                 findings.append(
@@ -349,13 +382,17 @@ if template_document is not MISSING:
                     ("event", candidate[0], event),
                     ("matcher", candidate[1], matcher),
                     ("type", candidate[2], hook_type),
-                    ("timeout", candidate[4], timeout),
                 ):
                     if not same(actual, required):
                         differences.append(
                             "%s expected %s, got %s"
                             % (name, shown(required), shown(actual))
                         )
+                if timeout_is_insufficient(candidate[4], timeout):
+                    differences.append(
+                        "timeout expected %s, got %s"
+                        % (shown(timeout), shown(candidate[4]))
+                    )
                 if not command_matches(candidate[3], commands):
                     differences.append(
                         "command expected %s, got %s"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -2,9 +2,18 @@
 # aigent-OS Doctor
 # Diagnoses install health. Exit 0 = no FAILs. Exit 1 = at least one FAIL.
 # Usage: bash scripts/doctor.sh [aigent-root-path] [--fix]
+#        bash scripts/doctor.sh [aigent-root-path] --attest
 #
 # By default this script is READ-ONLY -- it reports missing dirs/files as WARN but does not create them.
 # Pass --fix to enable mutation (mkdir for missing vault dirs, etc.).
+#
+# --attest compares this tree against scripts/fleet-baseline-manifest.json and
+# prints exactly one terminal class: COMPLIANT, DEGRADED, NONCOMPLIANT, or
+# UNKNOWN. It is strictly read-only -- no writes anywhere (not even a temp
+# file), no repairs, no network -- and returns before the diagnostic pass
+# below, so --fix can never run alongside it. Exit 0 = COMPLIANT or DEGRADED,
+# 1 = NONCOMPLIANT, 2 = UNKNOWN (the tree could not be measured, which is not
+# the same as measuring it and finding it broken).
 #
 # Checks:
 #   - aigent-OS root detected
@@ -24,9 +33,11 @@ set -euo pipefail
 # -- Parse args ----------------------------------------------------------------
 ROOT=""
 FIX=0
+ATTEST=0
 for arg in "$@"; do
   case "$arg" in
     --fix) FIX=1 ;;
+    --attest) ATTEST=1 ;;
     -*) ;;  # ignore unknown flags
     *) [ -z "$ROOT" ] && ROOT="$arg" ;;
   esac
@@ -40,6 +51,196 @@ if [ -z "$ROOT" ]; then
   elif [ -f "$(pwd)/../system/00_identity.md" ]; then
     ROOT="$(cd "$(pwd)/.." && pwd)"
   fi
+fi
+
+# -- Baseline attestation (--attest) -------------------------------------------
+# Returns before the diagnostic pass below. Everything here reads; nothing
+# writes, so this mode is safe to point at a live seat.
+#
+# The manifest is read with python3 (the same runtime checks 7b and 11 below
+# already depend on) via a stdin heredoc rather than a mktemp scratch file --
+# the read-only claim has to hold for /tmp too. python3 being absent is
+# "cannot measure", which is UNKNOWN, not a failure of the tree.
+if [ "$ATTEST" -eq 1 ]; then
+  attest_verdict() {
+    echo ""
+    echo "  ----------------------------------------"
+    echo "  ATTEST: $1"
+    echo ""
+    case "$1" in
+      COMPLIANT|DEGRADED) exit 0 ;;
+      NONCOMPLIANT)       exit 1 ;;
+      *)                  exit 2 ;;
+    esac
+  }
+
+  echo ""
+  echo "  aigent-OS Baseline Attestation"
+  echo "  ----------------------------------------"
+
+  if [ -z "$ROOT" ]; then
+    echo "  [detail] aigent-OS root not found -- pass the path as an argument or set AIGENT_ROOT"
+    attest_verdict UNKNOWN
+  fi
+  echo "  root:     $ROOT"
+
+  MANIFEST="$ROOT/scripts/fleet-baseline-manifest.json"
+  if [ ! -f "$MANIFEST" ]; then
+    echo "  [detail] baseline manifest not found: $MANIFEST"
+    attest_verdict UNKNOWN
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "  [detail] python3 not available -- the baseline manifest cannot be read"
+    attest_verdict UNKNOWN
+  fi
+
+  ATTEST_RC=0
+  ATTEST_OUT="$(python3 - "$MANIFEST" "$ROOT" <<'ATTESTPY'
+import hashlib
+import json
+import os
+import sys
+
+manifest_path, root = sys.argv[1:3]
+
+with open(manifest_path, encoding="utf-8") as fh:
+    manifest = json.load(fh)
+
+
+def under_root(relative):
+    return os.path.join(root, *relative.split("/"))
+
+
+findings = []
+
+print("info:baseline %s" % manifest["baseline_id"])
+print("info:commit %s" % manifest["public_product_commit"])
+
+# Required files, byte for byte. A missing file and a changed file are the
+# same terminal but not the same fact, so they stay separate lines.
+for relative, expected in manifest["required_files"].items():
+    try:
+        with open(under_root(relative), "rb") as fh:
+            actual = hashlib.sha256(fh.read()).hexdigest()
+    except OSError:
+        findings.append("required file missing: %s" % relative)
+        continue
+    if actual != expected:
+        findings.append("required file changed: %s" % relative)
+
+# Settings staleness. The installer MERGES into an existing settings.json
+# rather than replacing it, so a settings file rendered from an older template
+# stays valid JSON with every path resolved and is simply missing the newer
+# hook wiring. Checking the placeholder alone would read that as healthy.
+settings = manifest["required_settings"]
+try:
+    with open(under_root(settings["path"]), encoding="utf-8") as fh:
+        settings_text = fh.read()
+except OSError:
+    findings.append("settings missing: %s" % settings["path"])
+    settings_text = None
+
+if settings_text is not None:
+    if settings["unresolved_placeholder"] in settings_text:
+        findings.append(
+            "settings placeholder not substituted: %s"
+            % settings["unresolved_placeholder"]
+        )
+    for command in settings["hook_commands"]:
+        # The template embeds every hook as "<root>/<relative>" with forward
+        # slashes on every platform, so the relative tail is a literal
+        # substring of a correctly rendered settings.json.
+        if command not in settings_text:
+            findings.append("settings hook not wired: %s" % command)
+
+# The managed launcher expectation is enforced through required_files. This
+# check guards the manifest itself: a declared launcher path that nothing
+# hashes is an expectation with no instrument behind it.
+for relative in manifest["managed_launcher"]["paths"]:
+    if relative not in manifest["required_files"]:
+        findings.append("manifest declares an unhashed launcher path: %s" % relative)
+
+auto_refresh = manifest["auto_refresh"]
+if auto_refresh["expected"] == "enabled":
+    if os.environ.get(auto_refresh["kill_switch_env"]) == "1":
+        findings.append(
+            "Auto-Refresh expected enabled but %s=1"
+            % auto_refresh["kill_switch_env"]
+        )
+    # Mirrors memRoot() in daemons/lifecycle-common.mjs: the FIRST existing
+    # root wins. Checking both would fail an install that merely still has a
+    # stale marker under the root the runtime never reads.
+    for candidate in auto_refresh["kill_switch_roots"]:
+        if os.path.isdir(under_root(candidate)):
+            marker = "%s/%s" % (candidate, auto_refresh["kill_switch_file"])
+            if os.path.exists(under_root(marker)):
+                findings.append(
+                    "Auto-Refresh expected enabled but the kill switch is set: %s"
+                    % marker
+                )
+            break
+    print("runner-required:%s" % under_root(manifest["managed_runner"]["dependency_root"]))
+
+for name, spec in manifest["optional_components"].items():
+    if not os.path.exists(under_root(spec["path"])):
+        findings.append("optional %s absent: %s" % (name, spec["path"]))
+
+for finding in findings:
+    print("finding:%s" % finding)
+ATTESTPY
+  )" || ATTEST_RC=$?
+
+  if [ "$ATTEST_RC" -ne 0 ]; then
+    echo "  [detail] baseline manifest could not be read or is malformed: $MANIFEST"
+    attest_verdict UNKNOWN
+  fi
+
+  ATTEST_FINDINGS=()
+  RUNNER_ROOT=""
+  while IFS= read -r line; do
+    # python3 on Windows writes CRLF, and `read -r` keeps the CR. Without this
+    # strip the runner root parsed below ends in a bare CR, the node-pty probe
+    # is handed a path that cannot exist, and a healthy managed runner reports
+    # as unavailable on every Windows install.
+    line="${line%$'\r'}"
+    case "$line" in
+      info:*)            echo "  ${line#info:}" ;;
+      runner-required:*) RUNNER_ROOT="${line#runner-required:}" ;;
+      finding:*)         ATTEST_FINDINGS+=("${line#finding:}") ;;
+    esac
+  done <<< "$ATTEST_OUT"
+
+  # Managed runner. Same load probe install.sh runs after npm rebuild, so
+  # "installed but unloadable" is caught here exactly as it is at install time.
+  if [ -n "$RUNNER_ROOT" ]; then
+    if ! command -v node >/dev/null 2>&1; then
+      ATTEST_FINDINGS+=("managed runner unavailable: node not found, so node-pty cannot load")
+    elif ! node -e '
+const { createRequire } = require("node:module");
+createRequire(process.argv[1])("node-pty");
+' "$RUNNER_ROOT/package.json" >/dev/null 2>&1; then
+      ATTEST_FINDINGS+=("managed runner unavailable: node-pty could not be loaded from $RUNNER_ROOT")
+    fi
+  fi
+
+  # An optional-component finding must never pull the verdict back UP from
+  # NONCOMPLIANT, so DEGRADED is only ever reached from COMPLIANT.
+  TERMINAL="COMPLIANT"
+  if [ "${#ATTEST_FINDINGS[@]}" -gt 0 ]; then
+    for finding in "${ATTEST_FINDINGS[@]}"; do
+      echo "  [detail] $finding"
+      case "$finding" in
+        optional*)
+          if [ "$TERMINAL" = "COMPLIANT" ]; then TERMINAL="DEGRADED"; fi
+          ;;
+        *)
+          TERMINAL="NONCOMPLIANT"
+          ;;
+      esac
+    done
+  fi
+
+  attest_verdict "$TERMINAL"
 fi
 
 # -- Counters ------------------------------------------------------------------

--- a/scripts/fleet-baseline-manifest.json
+++ b/scripts/fleet-baseline-manifest.json
@@ -1,0 +1,109 @@
+{
+  "schema": "FleetBaselineManifest/v1",
+  "baseline_id": "aigent-os-2026-08-19-41051d9e",
+  "public_product_commit": "41051d9e544063309d3b69462aecb7aa4edbe149",
+  "notes": [
+    "Every sha256 below is the blob at public_product_commit. .gitattributes forces eol=lf, so an installed tree's bytes match on every platform.",
+    "Population rule: every executable .claude/settings.json.template wires as a hook or statusLine, plus the entry points install.sh names by path (managed runner, its dependency root, managed launcher), the settings template, the post-compact rule, and the system kernel root.",
+    "scripts/doctor.sh is excluded: it is the measuring instrument, and this baseline was cut before the --attest change landed, so its post-merge bytes are not the pinned ones.",
+    "CLAUDE.md, .claude/settings.json and .gitignore are excluded: the installer rewrites them (marker block, placeholder render, managed ignore block), so their installed bytes are never the repo bytes.",
+    ".claude/skill-index.json and skills/*/SKILL.md are excluded: caddy-enroll and operator-authored skills legitimately change them, so hashing them would report every customized install as NONCOMPLIANT."
+  ],
+  "required_files": {
+    "daemons/statusline-ctx.sh": "49c1aa9d2336ce3515314e4c7a0bbdaf0c2576082413e53d3b09901d648bdb2e",
+    "daemons/sessionstart-reinject.mjs": "f088db2faba158af4008dc56321d80cb52a7544d37a952d51472d69fa9e39496",
+    "daemons/resume-verb.mjs": "abc505d1581e28c5640eb018e41cfbd1f637da85d36312320abe9c7444052dc5",
+    "daemons/caddy.sh": "3985a94194fb5914b77c0f6089188045a08dd863f8143e02ffad85728f5c3b0e",
+    "daemons/userpromptsubmit-journal.mjs": "9ae9f9953e3a132b0671b8c017324366463b8efd5bdb687901522573fdc13462",
+    "daemons/precompact-flush.mjs": "eb93bc6bed70e24400229d4930c7ec9b3f806476562f20ea83f6da4cc3b8b07a",
+    "daemons/ctx-refresh-sensor.mjs": "0978848f6fac08f66fa7c6842e666c19eed6d05b82836a316b9c3c2be49e6cfb",
+    "daemons/model-tier-guard.mjs": "11a68c2afcfbd8531d37ada2e9cd0b5fc08d30030862ff1bce078cf0c182b659",
+    "daemons/gateguard.mjs": "5135ec0d86c96867c86cf318cdbee84ea0e0ef97e91a1ea4d1b2d46d0fba8e4d",
+    "daemons/memory-budget-guard.mjs": "78098d5281c28e61380bf09956f609a6721eff47f5e63a9fe80589250f0b10a2",
+    "hooks/suggest-compact.sh": "a7aaf8d9eee7f2c7d5269167566a51677f22319f8343cb904ea82ba2390197f4",
+    "hooks/auto-capture.sh": "47f3d26989b74ec9c3f32fc4f108e88f89bbbfb26b0a0231be7ec7d2f9eb8fff",
+    "hooks/security-scan.sh": "64046ceec1afaae7f278ad47be7795c6574c3d5d22576087b1881d80259521f1",
+    "daemons/caddy-detect-new-skill.sh": "d2cde2f1585636be41107f8ec9992d9ee2b36a644cd129397401baa799ebfd1b",
+    "daemons/stop-capsule-writer.mjs": "a9c37843f0b8d9e2bec10c1cd798afae80add202f795bcd0d0326410fca30f55",
+    "daemons/discipline-check.mjs": "8c0c43beea08d9349407fcd58697bb2127a0b5eafae0f9981fbefa0fb72e2181",
+    "hooks/session-capture-summary.sh": "42c6ce5a62258f65526137aa820f370452f26cd3e2fea129edb6f7aa51fccb4d",
+    "hooks/log-token-usage.sh": "5a009edd29267d54c34827a483b7309370d58f7a9483defe000061ec3804965c",
+    "daemons/sessionend-flush.mjs": "d78b4c848f3be48e6eeaedaeb4fc1126803428fb1c9ab0f82b50363ee9e59974",
+    ".claude/settings.json.template": "2a56f0b438f8c3280653854d75f6efee3c6f90492f788b821ccaf2f0c46782d0",
+    ".claude/rules/post-compact-critical.md": "5859c7d30e6f59188942930586f23e6669306d9d877e9219bbc57898dc9d883a",
+    "system/00_identity.md": "593db8cc6acff24e6fb46e2afaf37b2d47d7b571d70b745a8dc6ac322a15d5b9",
+    "daemons/pty-runner.mjs": "384f7a6b6be1e6be7882cd58e3d5b454390c39de31d64fc20e88c0749da79389",
+    "daemons/auto-clear-transport.mjs": "c552f4270158e5b1efe248ffa2580a4b5baa3fe7b00ecf715c3e0b6a69dabe3f",
+    "daemons/lifecycle-common.mjs": "e4f36b6c41d3e6c4725c9ccf678fe192ba1bed513e158f824176fd24684e9d8b",
+    "daemons/transport-deps/package.json": "a1d03430f519bf4ee1ea7ebbc26d80a2213c928451cc253de726ab6aeaf01bca",
+    "daemons/transport-deps/package-lock.json": "59cab0396f5d3758816f45f5f6903a1bde5a0649a180321b3ef10de0d9f7b5f5",
+    "launcher/aigent.sh": "5aebacaf419b421f87260ff5aa31c0b7b68a795435031475b92e9c65d8419335",
+    "launcher/aigent.ps1": "44e21c52268c77fb64e190b698beeeffc27ab188e315c5f5d3b173af950508b0",
+    "launcher/install.sh": "cdb11fd4a4f0d0f5a39ba044ac2e3a509482ee35d1964b677a32f52f78dd2285",
+    "launcher/install.ps1": "472cb70b6bfba4c1d3ff38cf72855eadde2953ac5063bcdfc89c3fa05ae93574"
+  },
+  "required_settings": {
+    "path": ".claude/settings.json",
+    "template": ".claude/settings.json.template",
+    "unresolved_placeholder": "__AIGENT_ROOT__",
+    "hook_commands": [
+      "daemons/statusline-ctx.sh",
+      "daemons/sessionstart-reinject.mjs",
+      "daemons/resume-verb.mjs",
+      "daemons/caddy.sh",
+      "daemons/userpromptsubmit-journal.mjs",
+      "daemons/precompact-flush.mjs",
+      "daemons/ctx-refresh-sensor.mjs",
+      "daemons/model-tier-guard.mjs",
+      "daemons/gateguard.mjs",
+      "daemons/memory-budget-guard.mjs",
+      "hooks/suggest-compact.sh",
+      "hooks/auto-capture.sh",
+      "hooks/security-scan.sh",
+      "daemons/caddy-detect-new-skill.sh",
+      "daemons/stop-capsule-writer.mjs",
+      "daemons/discipline-check.mjs",
+      "hooks/session-capture-summary.sh",
+      "hooks/log-token-usage.sh",
+      "daemons/sessionend-flush.mjs"
+    ]
+  },
+  "managed_runner": {
+    "dependency_root": "daemons/transport-deps",
+    "module": "node-pty",
+    "version": "1.1.0",
+    "entry_point": "daemons/pty-runner.mjs"
+  },
+  "managed_launcher": {
+    "expected": "present",
+    "paths": [
+      "launcher/aigent.sh",
+      "launcher/aigent.ps1",
+      "launcher/install.sh",
+      "launcher/install.ps1"
+    ],
+    "scope_note": "v1 attests the launcher files in the tree only. The PATH shim and desktop/Start-menu shortcuts that launcher/install.* create land outside the install root and are out of scope for a read-only in-tree attestation."
+  },
+  "auto_refresh": {
+    "expected": "enabled",
+    "kill_switch_env": "AUTO_CLEAR_OFF",
+    "kill_switch_file": "runtime/auto-clear-off",
+    "kill_switch_roots": [
+      "vault/memory",
+      "memory"
+    ],
+    "note": "kill_switch_file is resolved under the first existing kill_switch_roots entry, mirroring memRoot() in daemons/lifecycle-common.mjs. When expected is enabled, an active kill switch or an unloadable node-pty is NONCOMPLIANT."
+  },
+  "optional_components": {
+    "semantic_search": {
+      "path": "daemons/semantic-search/node_modules",
+      "absent_verdict": "DEGRADED"
+    }
+  },
+  "terminals": [
+    "COMPLIANT",
+    "DEGRADED",
+    "NONCOMPLIANT",
+    "UNKNOWN"
+  ]
+}


### PR DESCRIPTION
Implements the bounded attestation slice of #21: a read-only `doctor.sh --attest` that checks an installed tree against a pinned baseline manifest and returns exactly one terminal.

**Scope (3 files, +636/-0):**
- `scripts/fleet-baseline-manifest.json` — `FleetBaselineManifest/v1`, baseline `aigent-os-2026-08-19-41051d9e`: sha256 pins for 31 load-bearing files (every executable the settings template wires as a hook or statusLine — 19 of them — plus the managed runner, its dependency root, the managed launcher, the settings template, the post-compact rule, and the system kernel root), the required hook set for a rendered settings.json, the node-pty expectation, and the optional semantic-search component.
- `scripts/doctor.sh` — `--attest` mode (+201 lines).
- `daemons/tests/fleet-baseline-attest.test.mjs` — direct regression check in the existing style (+326 lines).

No installer changes were needed: `install.sh` copies `scripts/` wholesale, so the manifest lands in every installed tree (verified end-to-end against a real `install.sh --target` run).

**Terminals (exactly one per run):**
| condition | verdict | exit |
|---|---|---|
| exact install | COMPLIANT | 0 |
| required file byte changed | NONCOMPLIANT | 1 |
| stale rendered settings (hook set mismatch) | NONCOMPLIANT | 1 |
| required node-pty unavailable | NONCOMPLIANT | 1 |
| manifest absent or unreadable | UNKNOWN | 2 |
| optional semantic search absent | DEGRADED | 0 |

**Test:** `node --test daemons/tests/fleet-baseline-attest.test.mjs` — 12/12 pass. Red mutation witness: flipping one expected hash in the manifest turns the exact-install case NONCOMPLIANT (10/12 with exactly the two intended failures), restored byte-identical.

**Read-only, proven by measurement:** recursive path+size+mtime listing of the attested tree identical before/after (941-entry stubbed tree and 1292-entry tree with a real native node-pty build); the code path contains no mkdir/mktemp/network — only /dev/null redirects.

**No side effects:** no daemon, database, service, controller, or rollout code is touched; the attestation only reads an installed tree and prints a verdict. The full daemon test sweep (38 files) passes unchanged.

An independent non-author review of this exact head ran all six terminal falsifiers on real installer-produced trees, reproduced the red mutation witness, verified the read-only property twice by measurement, and confirmed the hashed population is complete in both directions (every template-wired executable hashed, nothing hashed that isn't load-bearing). Verdict: PASS, 0 blocking findings.