### PR TITLE
install: keep an existing operator rules file; unpin it from the baseline manifest

### DIFF
--- a/daemons/tests/render-boundary-guard.test.mjs
+++ b/daemons/tests/render-boundary-guard.test.mjs
@@ -1672,7 +1672,7 @@ const SHELL_RAW_ALLOWLIST = [
   {
     file: 'install.sh',
     accessor: 'unsafeRawPromoteProcedureFile',
-    reason: "the post-compact rule is reviewed multiline procedure text promoted into Claude's runtime",
+    reason: 'the post-compact rule starter is reviewed multiline procedure text seeded only into a fresh install',
   },
   {
     file: 'install.sh',

--- a/install.sh
+++ b/install.sh
@@ -496,10 +496,11 @@ fi
 safe_mkdir_p "$TARGET/.claude/rules" || fail "cannot create $TARGET/.claude/rules (see symlink warning above)"
 safe_mkdir_p "$TARGET/.claude/skills" || fail "cannot create $TARGET/.claude/skills (see symlink warning above)"
 safe_mkdir_p "$TARGET/.claude/agents" || fail "cannot create $TARGET/.claude/agents (see symlink warning above)"
-# .claude/rules is read as agent instructions on every session -- a planted
-# file here that differs from the framework's is as much a trust-surface
-# concern as a hook script, so it goes through
-# copy_missing_file(sensitive=1) too.
+# .claude/rules/post-compact-critical.md is operator-owned doctrine, the
+# same class as CLAUDE.md's operator text: an existing install carries the
+# operator's own rules and the installer must not replace them. Seed the
+# framework starter only when the file is absent; an existing file is kept
+# as-is (symlink-guarded, like every other single-file write).
 RULES_SRC="$SRC/.claude/rules/post-compact-critical.md"
 RULES_DST="$TARGET/.claude/rules/post-compact-critical.md"
 if [[ -f "$RULES_SRC" ]]; then
@@ -507,11 +508,16 @@ if [[ -f "$RULES_SRC" ]]; then
   # in-place mode SRC and TARGET canonicalize to the same directory, so a
   # blind cp here would target itself and fail hard on BSD/Windows cp.
   if [[ "$(abspath "$RULES_SRC")" != "$(abspath "$RULES_DST")" ]]; then
-    unsafeRawPromoteProcedureFile \
-      "$RULES_SRC" \
-      "$RULES_DST" \
-      "the post-compact rule is reviewed multiline procedure text promoted into Claude's runtime" \
-      || true
+    require_symlink_safe "$RULES_DST"
+    if [[ -f "$RULES_DST" ]]; then
+      printf '  [keep] operator rules file kept (%s)\n' "$RULES_DST"
+    else
+      unsafeRawPromoteProcedureFile \
+        "$RULES_SRC" \
+        "$RULES_DST" \
+        "the post-compact rule starter is reviewed multiline procedure text seeded only into a fresh install" \
+        || true
+    fi
   fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -500,7 +500,10 @@ safe_mkdir_p "$TARGET/.claude/agents" || fail "cannot create $TARGET/.claude/age
 # same class as CLAUDE.md's operator text: an existing install carries the
 # operator's own rules and the installer must not replace them. Seed the
 # framework starter only when the file is absent; an existing file is kept
-# as-is (symlink-guarded, like every other single-file write).
+# as-is (symlink-guarded, like every other single-file write). Keeping it
+# gives up quarantine protection against a file planted here before the
+# first install — the same accepted tradeoff as CLAUDE.md's free-text
+# region, and narrower than hooks/skills/agents, which stay quarantined.
 RULES_SRC="$SRC/.claude/rules/post-compact-critical.md"
 RULES_DST="$TARGET/.claude/rules/post-compact-critical.md"
 if [[ -f "$RULES_SRC" ]]; then

--- a/scripts/fleet-baseline-manifest.json
+++ b/scripts/fleet-baseline-manifest.json
@@ -7,7 +7,8 @@
     "Population rule: every executable .claude/settings.json.template wires as a hook or statusLine, plus the entry points install.sh names by path (managed runner, its dependency root, managed launcher), the settings template, the post-compact rule, and the system kernel root.",
     "scripts/doctor.sh is excluded: it is the measuring instrument, and this baseline was cut before the --attest change landed, so its post-merge bytes are not the pinned ones.",
     "CLAUDE.md, .claude/settings.json and .gitignore are excluded: the installer rewrites them (marker block, placeholder render, managed ignore block), so their installed bytes are never the repo bytes.",
-    ".claude/skill-index.json and skills/*/SKILL.md are excluded: caddy-enroll and operator-authored skills legitimately change them, so hashing them would report every customized install as NONCOMPLIANT."
+    ".claude/skill-index.json and skills/*/SKILL.md are excluded: caddy-enroll and operator-authored skills legitimately change them, so hashing them would report every customized install as NONCOMPLIANT.",
+    ".claude/rules/post-compact-critical.md is excluded: it is operator-owned doctrine (the CLAUDE.md class) -- the installer seeds the starter only into a fresh install and keeps an existing operator file, so its installed bytes are legitimately not the repo bytes."
   ],
   "required_files": {
     "daemons/statusline-ctx.sh": "49c1aa9d2336ce3515314e4c7a0bbdaf0c2576082413e53d3b09901d648bdb2e",
@@ -30,7 +31,6 @@
     "hooks/log-token-usage.sh": "5a009edd29267d54c34827a483b7309370d58f7a9483defe000061ec3804965c",
     "daemons/sessionend-flush.mjs": "d78b4c848f3be48e6eeaedaeb4fc1126803428fb1c9ab0f82b50363ee9e59974",
     ".claude/settings.json.template": "2a56f0b438f8c3280653854d75f6efee3c6f90492f788b821ccaf2f0c46782d0",
-    ".claude/rules/post-compact-critical.md": "5859c7d30e6f59188942930586f23e6669306d9d877e9219bbc57898dc9d883a",
     "system/00_identity.md": "593db8cc6acff24e6fb46e2afaf37b2d47d7b571d70b745a8dc6ac322a15d5b9",
     "daemons/pty-runner.mjs": "384f7a6b6be1e6be7882cd58e3d5b454390c39de31d64fc20e88c0749da79389",
     "daemons/auto-clear-transport.mjs": "c552f4270158e5b1efe248ffa2580a4b5baa3fe7b00ecf715c3e0b6a69dabe3f",

--- a/tests/test-installer-fast.sh
+++ b/tests/test-installer-fast.sh
@@ -16,7 +16,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT INT TERM
 
-TOTAL=18
+TOTAL=19
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -589,5 +589,21 @@ if [ "$UNICODE_SEPARATOR_PROBES" -eq 1 ]; then
 else
   printf '[18/%d] launcher settings/profile: hostile values quoted; newline refused; unicode probes SKIPPED\n' "$TOTAL"
 fi
+
+# ── 19. Operator rules file kept ─────────────────────────────────────────────
+# .claude/rules/post-compact-critical.md is operator-owned doctrine (the
+# CLAUDE.md class): an existing, diverged file must be KEPT — not
+# quarantine-replaced — and the framework starter seeds only a fresh install.
+RULES_KEEP_TARGET="$WORK/rules-keep-target"
+mkdir -p "$RULES_KEEP_TARGET/.claude/rules"
+printf '# Operator Critical Rules\nOPERATOR-DOCTRINE-SENTINEL\n' > "$RULES_KEEP_TARGET/.claude/rules/post-compact-critical.md"
+RULES_KEEP_OUT="$(cd "$FIXTURE" && bash install.sh --target "$RULES_KEEP_TARGET" --no-deps 2>&1)"
+printf '%s\n' "$RULES_KEEP_OUT" | grep -q "\[keep\] operator rules file kept"
+grep -q "OPERATOR-DOCTRINE-SENTINEL" "$RULES_KEEP_TARGET/.claude/rules/post-compact-critical.md"
+RULES_SEED_TARGET="$WORK/rules-seed-target"
+mkdir -p "$RULES_SEED_TARGET"
+(cd "$FIXTURE" && bash install.sh --target "$RULES_SEED_TARGET" --no-deps >/dev/null 2>&1)
+grep -q "critical" "$RULES_SEED_TARGET/.claude/rules/post-compact-critical.md"
+printf '[19/%d] operator rules file: existing doctrine kept, starter seeds fresh installs only\n' "$TOTAL"
 
 printf 'fast installer suite passed (%d/%d)\n' "$TOTAL" "$TOTAL"


### PR DESCRIPTION
An install onto an existing vault must not replace the operator's own .claude/rules/post-compact-critical.md with the framework starter. The installer now keeps an existing file (seeding the starter only into fresh installs), and the baseline manifest stops hashing it as a required framework file, extending the documented operator-rewritten exclusion set (CLAUDE.md, settings.json, .gitignore).

Measured on the first live seat migration: the quarantine-replace dropped a 95-line operator rules file (including a confidentiality deny-list) for the 17-line generic starter, and the manifest pin turned the restored file into a false NONCOMPLIANT.

Tradeoff named in-code: keeping the file gives up quarantine protection against pre-install planting for this one instruction-text file, the same accepted class as CLAUDE.md's free-text region; hooks/skills/agents stay quarantined.

Tests: test-installer-fast.sh check 19 pins keep + seed both ways (proven red on the pre-change installer); attest suite 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFAAgEhoTBXGhJfSySd5Nd