### PR TITLE
doctor --attest: verify installed statusLine.type against the pinned template

### DIFF
--- a/daemons/tests/fleet-baseline-attest.test.mjs
+++ b/daemons/tests/fleet-baseline-attest.test.mjs
@@ -282,6 +282,25 @@ test('malformed settings JSON attests NONCOMPLIANT', () => {
   });
 });
 
+test('a wrong statusLine type attests NONCOMPLIANT', () => {
+  withInstall((root) => {
+    const manifest = readManifest();
+    const settings = path.join(root, ...manifest.required_settings.path.split('/'));
+    const parsed = JSON.parse(readFileSync(settings, 'utf8'));
+    assert.equal(parsed.statusLine.type, 'command', 'fixture pins the template statusLine type');
+    parsed.statusLine.type = 'script';
+    writeFileSync(settings, `${JSON.stringify(parsed, null, 2)}\n`);
+
+    const { verdict, status, output } = attest(root);
+    assert.deepEqual(
+      { verdict, status },
+      { verdict: 'NONCOMPLIANT', status: 1 },
+      output,
+    );
+    assert.match(output, /settings statusLine type differs/);
+  });
+});
+
 test('a required hook under the wrong matcher attests NONCOMPLIANT', () => {
   withInstall((root) => {
     const manifest = readManifest();

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -309,9 +309,11 @@ if template_document is not MISSING:
         if isinstance(template_document, dict)
         else None
     )
+    expected_status_type = MISSING
     if isinstance(status_line, dict) and "command" in status_line:
         template_status = status_line["command"]
         expected_status = render_commands(template_status)
+        expected_status_type = status_line.get("type", MISSING)
         if isinstance(template_status, str):
             represented.update(
                 command for command in required_commands if command in template_status
@@ -347,10 +349,12 @@ if template_document is not MISSING:
 
     if settings_document is not MISSING:
         installed_status = MISSING
+        installed_status_type = MISSING
         if isinstance(settings_document, dict):
             status_line = settings_document.get("statusLine")
             if isinstance(status_line, dict):
                 installed_status = status_line.get("command", MISSING)
+                installed_status_type = status_line.get("type", MISSING)
         if (
             expected_status is not MISSING
             and not command_matches(installed_status, expected_status)
@@ -358,6 +362,13 @@ if template_document is not MISSING:
             findings.append(
                 "settings statusLine command differs: expected %s, got %s"
                 % (shown_commands(expected_status), shown(installed_status))
+            )
+        if expected_status_type is not MISSING and not same(
+            installed_status_type, expected_status_type
+        ):
+            findings.append(
+                "settings statusLine type differs: expected %s, got %s"
+                % (shown(expected_status_type), shown(installed_status_type))
             )
 
         installed_hooks = hook_records(settings_document)


### PR DESCRIPTION
Advisor-ordered narrow correction (program issue #21, 2026-08-21 disposition): the structural settings check compared only statusLine.command, so a settings object with the right command under the wrong or missing type could attest COMPLIANT although Claude Code may not execute it. Wrong or missing installed type is now NONCOMPLIANT when the template pins one.

One direct wrong-type regression specimen added; proven red on master's doctor.sh (attests COMPLIANT there) and green on this head. 21/21 suite. Non-author review SHIP bound to exact head f787b1f with an independent red re-proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFAAgEhoTBXGhJfSySd5Nd