### PR TITLE
semantic-search: machine-readable namespace registry with INDEX|SKIP|DENY

### DIFF
--- a/daemons/semantic-search/embed-vault.js
+++ b/daemons/semantic-search/embed-vault.js
@@ -13,6 +13,11 @@ import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, mkdirSy
 import { join, relative, extname, basename, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { requireDenyPrefixes, deniedPath } from './deny-list.mjs';
+import {
+  namespaceDispositionForPath,
+  requireDeclaredNamespaceDirectories,
+  requireNamespaceRegistry,
+} from './namespace-registry.mjs';
 import frontmatterReader from '../frontmatter-reader.cjs';
 
 const {
@@ -33,18 +38,6 @@ const MODEL_NAME = 'Xenova/all-MiniLM-L6-v2';
 const MAX_CHUNK_CHARS = 1800; // ~512 tokens at ~3.5 chars/token
 const CHUNK_OVERLAP_CHARS = 200;
 
-// Directories to scan (relative to VAULT_ROOT)
-const SCAN_DIRS = [
-  'daily',
-  'memory',
-  'concepts',
-  'projects',
-  'people',
-  'agents',
-  'research',
-  'templates',
-];
-
 // Directories/files to skip
 const SKIP_DIRS = new Set([
   'node_modules',
@@ -57,6 +50,11 @@ const SKIP_DIRS = new Set([
   'prompts',
   'tools',
 ]);
+
+// The registry is mandatory. Load it at module startup so missing or invalid
+// policy fails before the vault is walked, a model is loaded, or an index is
+// written.
+const NAMESPACE_REGISTRY = requireNamespaceRegistry(__dirname, 'embed-vault');
 
 // Confidential-class deny list. Anyone running semantic search over their own
 // vault can point it at client work, deal notes, or anything else under NDA, and
@@ -143,8 +141,9 @@ function scanDirectory(dir, fileList = []) {
 
 function collectFiles() {
   const files = [];
-  for (const dir of SCAN_DIRS) {
-    const fullDir = join(VAULT_ROOT, dir);
+  for (const row of NAMESPACE_REGISTRY.rows) {
+    if (row.disposition !== 'INDEX') continue;
+    const fullDir = join(VAULT_ROOT, row.path);
     if (existsSync(fullDir)) {
       scanDirectory(fullDir, files);
     }
@@ -187,6 +186,11 @@ async function embedText(text) {
 async function main() {
   const changedOnly = process.argv.includes('--changed-only');
 
+  // A physical memory namespace must be explicitly classified before any
+  // embedding work begins. Existing SKIP_DIRS infrastructure names are the only
+  // implicit exemptions (enforced by the shared registry module).
+  requireDeclaredNamespaceDirectories(NAMESPACE_REGISTRY, VAULT_ROOT, 'embed-vault');
+
   // Load existing embeddings if present
   let existing = { model: MODEL_NAME, updated: null, notes: [] };
   if (existsSync(EMBEDDINGS_PATH)) {
@@ -198,14 +202,26 @@ async function main() {
     }
   }
 
-  // Purge denied chunks from the carried-forward index (a --changed-only run must
-  // also strip previously-indexed confidential-class entries, not just skip new ones
-  // -- a prefix added to index-deny.json after the fact has to retroactively purge).
+  // Purge chunks that no longer belong to an INDEX namespace. This covers SKIP,
+  // DENY, and undeclared paths in stale or hand-edited indexes.
+  const beforeNamespacePurge = (existing.notes || []).length;
+  existing.notes = (existing.notes || []).filter(
+    (note) => namespaceDispositionForPath(NAMESPACE_REGISTRY, note.path) === 'INDEX',
+  );
+  if (beforeNamespacePurge !== existing.notes.length) {
+    console.log(`[namespace] purged ${beforeNamespacePurge - existing.notes.length} previously-indexed non-INDEX chunk(s)`);
+  }
+
+  // Purge denied chunks from the carried-forward index (a --changed-only run
+  // must also strip previously-indexed confidential-class entries, not just
+  // skip new ones -- a prefix added to index-deny.json after the fact has to
+  // retroactively purge).
   const beforePurge = (existing.notes || []).length;
   existing.notes = (existing.notes || []).filter((n) => !deniedPath(DENY_PREFIXES, n.path));
   if (beforePurge !== existing.notes.length) {
     console.log(`[deny] purged ${beforePurge - existing.notes.length} previously-indexed chunk(s) matching index-deny.json`);
   }
+  const carriedForwardPurged = beforeNamespacePurge !== beforePurge || beforePurge !== existing.notes.length;
 
   // Build a map of path → existing entries (for --changed-only)
   const existingByPath = new Map();
@@ -228,7 +244,7 @@ async function main() {
     console.log(`--changed-only: ${toEmbed.length} files modified since last index.`);
   }
 
-  if (toEmbed.length === 0) {
+  if (toEmbed.length === 0 && !carriedForwardPurged) {
     console.log('Nothing to embed. Index is up to date.');
     return;
   }

--- a/daemons/semantic-search/namespace-registry.json
+++ b/daemons/semantic-search/namespace-registry.json
@@ -1,0 +1,16 @@
+{
+  "schema": "MemoryNamespaceRegistry/v1",
+  "namespaces": [
+    { "path": "daily",     "disposition": "INDEX" },
+    { "path": "memory",    "disposition": "INDEX" },
+    { "path": "concepts",  "disposition": "INDEX" },
+    { "path": "projects",  "disposition": "INDEX" },
+    { "path": "people",    "disposition": "INDEX" },
+    { "path": "agents",    "disposition": "INDEX" },
+    { "path": "research",  "disposition": "INDEX" },
+    { "path": "feedback",  "disposition": "INDEX" },
+    { "path": "reference", "disposition": "INDEX" },
+    { "path": "templates", "disposition": "SKIP", "reason": "boilerplate scaffolding, not authored memory" },
+    { "path": "examples",  "disposition": "SKIP", "reason": "illustrative starter content, not operator signal" }
+  ]
+}

--- a/daemons/semantic-search/namespace-registry.mjs
+++ b/daemons/semantic-search/namespace-registry.mjs
@@ -1,0 +1,175 @@
+/**
+ * namespace-registry.mjs
+ * The single MemoryNamespaceRegistry/v1 loader and lookup implementation shared
+ * by semantic-search index construction and query-time filtering.
+ *
+ * The registry is fail-closed: there is no absent-file default, and no caller
+ * is allowed to recover a partial population from malformed input.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, posix, win32 } from 'node:path';
+
+const SCHEMA = 'MemoryNamespaceRegistry/v1';
+const DISPOSITIONS = new Set(['INDEX', 'SKIP', 'DENY']);
+
+// These are the pre-existing embed-vault.js SKIP_DIRS entries. They are runtime
+// infrastructure rather than authored-memory namespaces, so a physical copy at
+// the vault root is ignored by the undeclared-directory audit. No other name is
+// implicitly exempt.
+export const NAMESPACE_INFRASTRUCTURE_DIRS = Object.freeze([
+  'node_modules',
+  '.git',
+  'daemons',
+  '.claude',
+  'command-center-v2',
+  'graphify-out',
+  'recon',
+  'prompts',
+  'tools',
+]);
+
+function namespaceKey(value) {
+  return String(value).replace(/\\/g, '/').toLowerCase();
+}
+
+function validatePath(value, index) {
+  if (typeof value !== 'string') {
+    throw new Error(`namespaces[${index}].path must be a string`);
+  }
+  if (
+    value.length === 0
+    || value.trim() !== value
+    || value === '.'
+    || value === '..'
+    || value.includes('/')
+    || value.includes('\\')
+    || posix.isAbsolute(value)
+    || win32.isAbsolute(value)
+  ) {
+    throw new Error(`namespaces[${index}].path must be one normalized top-level segment`);
+  }
+}
+
+/**
+ * Read and validate <dir>/namespace-registry.json.
+ *
+ * Missing, unreadable, and malformed files all throw. The returned `rows`
+ * preserve registry order; `byPath` is keyed case-insensitively with normalized
+ * separators so duplicate detection and runtime lookup share one identity rule.
+ */
+export function loadNamespaceRegistry(dir) {
+  const registryPath = join(dir, 'namespace-registry.json');
+  let text;
+  try {
+    text = readFileSync(registryPath, 'utf8');
+  } catch (error) {
+    throw new Error(`cannot read ${registryPath}: ${error.message}`);
+  }
+
+  let raw;
+  try {
+    raw = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`cannot parse ${registryPath}: ${error.message}`);
+  }
+
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('namespace registry root must be an object');
+  }
+  if (raw.schema !== SCHEMA) {
+    throw new Error(`namespace registry schema must equal exactly ${SCHEMA}`);
+  }
+  if (!Array.isArray(raw.namespaces)) {
+    throw new Error('namespace registry namespaces must be an array');
+  }
+
+  const rows = [];
+  const byPath = new Map();
+  for (let index = 0; index < raw.namespaces.length; index++) {
+    const row = raw.namespaces[index];
+    if (!row || typeof row !== 'object' || Array.isArray(row)) {
+      throw new Error(`namespaces[${index}] must be an object`);
+    }
+
+    validatePath(row.path, index);
+    const key = namespaceKey(row.path);
+    if (byPath.has(key)) {
+      throw new Error(`duplicate namespace path: ${row.path}`);
+    }
+    if (!DISPOSITIONS.has(row.disposition)) {
+      throw new Error(`namespaces[${index}] has invalid disposition: ${String(row.disposition)}`);
+    }
+    if (
+      (row.disposition === 'SKIP' || row.disposition === 'DENY')
+      && (typeof row.reason !== 'string' || row.reason.trim().length === 0)
+    ) {
+      throw new Error(`namespaces[${index}] ${row.disposition} row requires a non-empty reason`);
+    }
+
+    rows.push(row);
+    byPath.set(key, row);
+  }
+
+  return { rows, byPath };
+}
+
+/** Return INDEX, SKIP, DENY, or undefined for one physical top-level segment. */
+export function namespaceDisposition(registry, topLevelSegment) {
+  if (typeof topLevelSegment !== 'string' || topLevelSegment.length === 0) return undefined;
+  return registry.byPath.get(namespaceKey(topLevelSegment))?.disposition;
+}
+
+/** Resolve a vault-relative note path through its normalized top-level segment. */
+export function namespaceDispositionForPath(registry, vaultRelativePath) {
+  if (typeof vaultRelativePath !== 'string') return undefined;
+  const topLevelSegment = vaultRelativePath.replace(/\\/g, '/').split('/')[0];
+  return namespaceDisposition(registry, topLevelSegment);
+}
+
+/**
+ * Return physical top-level directories that have no registry row. Dirent
+ * symlinks are intentionally not treated as directories: the contract calls
+ * for readdirSync({withFileTypes:true}) and physical directories only.
+ */
+export function undeclaredNamespaceDirectories(registry, vaultRoot) {
+  const infrastructure = new Set(NAMESPACE_INFRASTRUCTURE_DIRS);
+  const declaredPaths = new Set(registry.rows.map((row) => row.path));
+  return readdirSync(vaultRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => !infrastructure.has(name))
+    // Physical spelling is exact. Runtime note lookup is deliberately
+    // case-insensitive, but accepting `Feedback/` for a `feedback` row would
+    // make collectFiles() walk a different path on case-sensitive filesystems.
+    .filter((name) => !declaredPaths.has(name))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/** Throw, naming every physical directory not declared by the registry. */
+export function assertNoUndeclaredNamespaceDirectories(registry, vaultRoot) {
+  const undeclared = undeclaredNamespaceDirectories(registry, vaultRoot);
+  if (undeclared.length > 0) {
+    throw new Error(`undeclared vault namespace director${undeclared.length === 1 ? 'y' : 'ies'}: ${undeclared.join(', ')}`);
+  }
+}
+
+/** Fail-closed process gate matching deny-list.mjs's require idiom. */
+export function requireNamespaceRegistry(dir, label) {
+  try {
+    return loadNamespaceRegistry(dir);
+  } catch (error) {
+    console.error(`[${label}] REFUSING to run: namespace-registry.json cannot be used (${error.message}). Fix the registry before indexing or searching.`);
+    process.exit(1);
+  }
+}
+
+/** Fail-closed physical-directory gate shared by both runtime callers. */
+export function requireDeclaredNamespaceDirectories(registry, vaultRoot, label) {
+  try {
+    assertNoUndeclaredNamespaceDirectories(registry, vaultRoot);
+  } catch (error) {
+    console.error(`[${label}] REFUSING to run: ${error.message}. Declare the directory in namespace-registry.json before indexing or searching.`);
+    process.exit(1);
+  }
+}

--- a/daemons/semantic-search/search-vault.js
+++ b/daemons/semantic-search/search-vault.js
@@ -14,6 +14,11 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { requireDenyPrefixes, deniedPath } from './deny-list.mjs';
+import {
+  namespaceDispositionForPath,
+  requireDeclaredNamespaceDirectories,
+  requireNamespaceRegistry,
+} from './namespace-registry.mjs';
 
 // ── Config ──────────────────────────────────────────────────────────────────
 const __filename = fileURLToPath(import.meta.url);
@@ -24,6 +29,10 @@ const VAULT_ROOT = process.env.AIGENT_VAULT_ROOT || join(AIGENT_ROOT, 'vault');
 const EMBEDDINGS_PATH = join(VAULT_ROOT, 'memory', 'embeddings.json');
 const MODEL_NAME = 'Xenova/all-MiniLM-L6-v2';
 const DEFAULT_TOP_K = 5;
+
+// Missing or invalid namespace policy must stop the process before an index is
+// read or any result can be emitted.
+const NAMESPACE_REGISTRY = requireNamespaceRegistry(__dirname, 'search-vault');
 
 // Confidential-class deny list, re-checked at query time so this is safe even
 // against a stale or hand-edited embeddings.json built before a prefix was added
@@ -75,6 +84,11 @@ async function embedText(text) {
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 async function main() {
+  // Search refuses the same undeclared physical state as index construction.
+  // This is independent of the stale-entry filter below: a live namespace must
+  // be classified before either caller will operate.
+  requireDeclaredNamespaceDirectories(NAMESPACE_REGISTRY, VAULT_ROOT, 'search-vault');
+
   // Load index
   if (!existsSync(EMBEDDINGS_PATH)) {
     console.error(`Embeddings index not found at ${EMBEDDINGS_PATH}`);
@@ -88,8 +102,11 @@ async function main() {
   const beforeDeny = index.notes.length;
   index.notes = index.notes.filter((n) => !deniedPath(DENY_PREFIXES, n.path));
   const deniedCount = beforeDeny - index.notes.length;
+  const beforeNamespace = index.notes.length;
+  index.notes = index.notes.filter((note) => namespaceDispositionForPath(NAMESPACE_REGISTRY, note.path) === 'INDEX');
+  const namespaceCount = beforeNamespace - index.notes.length;
   if (!jsonOnly) {
-    console.log(`${index.notes.length} entries loaded.${deniedCount ? ` (${deniedCount} confidential-class chunk(s) filtered by index-deny.json)` : ''}`);
+    console.log(`${index.notes.length} entries loaded.${deniedCount ? ` (${deniedCount} confidential-class chunk(s) filtered by index-deny.json)` : ''}${namespaceCount ? ` (${namespaceCount} non-INDEX namespace chunk(s) filtered by namespace-registry.json)` : ''}`);
   }
 
   // Embed query

--- a/daemons/tests/semantic-search-deny.test.mjs
+++ b/daemons/tests/semantic-search-deny.test.mjs
@@ -26,7 +26,7 @@
 // Both scripts top-level `import '@xenova/transformers'`, whose model download
 // has no place in CI, and both resolve their deny file relative to their own
 // __dirname with no environment override (deliberately: an override would be a
-// bypass). So the behavioral tests copy the three real source files into a
+// bypass). So the behavioral tests copy the real source files into a
 // sandbox that has its own index-deny.json and a tiny stub package in
 // node_modules. The copies are read from the repo at run time, so any edit to
 // the real files is under test; nothing here reads a checked-in duplicate.
@@ -91,7 +91,13 @@ function makeSandbox(name, denyFileText) {
 
   const sem = path.join(root, 'daemons', 'semantic-search');
   mkdirSync(sem, { recursive: true });
-  for (const file of ['deny-list.mjs', 'embed-vault.js', 'search-vault.js']) {
+  for (const file of [
+    'deny-list.mjs',
+    'namespace-registry.mjs',
+    'namespace-registry.json',
+    'embed-vault.js',
+    'search-vault.js',
+  ]) {
     copyFileSync(path.join(SEM, file), path.join(sem, file));
   }
   copyFileSync(

--- a/daemons/tests/semantic-search-namespace-registry.test.mjs
+++ b/daemons/tests/semantic-search-namespace-registry.test.mjs
@@ -1,0 +1,614 @@
+// semantic-search-namespace-registry.test.mjs -- MemoryNamespaceRegistry/v1
+// end-to-end regression guard.
+//
+// This is a sibling of semantic-search-deny.test.mjs because the registry adds
+// three independently spawned programs (embed, search, and doctor), nine
+// falsifier groups, and a mutation witness. Folding those into the already
+// focused deny-list suite would obscure the fact that index-deny.json remains a
+// separate composing layer.
+//
+// Mutation witness transcript (the witness runs on every invocation):
+//
+//   $ node daemons/tests/semantic-search-namespace-registry.test.mjs
+//   WITNESS GREEN: stale DENY content blocked and healthy INDEX content returned
+//   WITNESS RED AS EXPECTED: replacing the query-time namespace predicate with
+//   true leaked CANARY-NAMESPACE-DENY-4f61c8-private-body
+//   WITNESS GREEN: restoring the original search source blocked stale DENY again
+//   All 201 namespace registry checks passed
+//
+// The mutation is made only in a temporary sandbox copy of search-vault.js. The
+// original bytes are restored before the final GREEN run and the sandbox is
+// removed at process exit.
+//
+// Run: node daemons/tests/semantic-search-namespace-registry.test.mjs
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  loadNamespaceRegistry,
+  namespaceDisposition,
+  namespaceDispositionForPath,
+} from '../semantic-search/namespace-registry.mjs';
+
+const DAEMONS = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ROOT = path.join(DAEMONS, '..');
+const SEM = path.join(DAEMONS, 'semantic-search');
+const DOCTOR = path.join(ROOT, 'scripts', 'doctor.sh');
+
+let failed = 0;
+let checked = 0;
+const check = (name, ok, detail = '') => {
+  checked++;
+  console.log(`${ok ? 'ok' : 'FAIL'}: ${name}${detail ? ` — ${detail}` : ''}`);
+  if (!ok) failed++;
+};
+
+const SCHEMA = 'MemoryNamespaceRegistry/v1';
+const STOCK_ROWS = [
+  { path: 'daily', disposition: 'INDEX' },
+  { path: 'memory', disposition: 'INDEX' },
+  { path: 'concepts', disposition: 'INDEX' },
+  { path: 'projects', disposition: 'INDEX' },
+  { path: 'people', disposition: 'INDEX' },
+  { path: 'agents', disposition: 'INDEX' },
+  { path: 'research', disposition: 'INDEX' },
+  { path: 'feedback', disposition: 'INDEX' },
+  { path: 'reference', disposition: 'INDEX' },
+  { path: 'templates', disposition: 'SKIP', reason: 'boilerplate scaffolding, not authored memory' },
+  { path: 'examples', disposition: 'SKIP', reason: 'illustrative starter content, not operator signal' },
+];
+
+const HEALTHY = 'CANARY-NAMESPACE-INDEX-a27c91-feedback-body';
+const STABLE = 'CANARY-NAMESPACE-STABLE-INDEX-5e83bd-reference-body';
+const SKIPPED = 'CANARY-NAMESPACE-SKIP-d21e70-template-body';
+const DENIED = 'CANARY-NAMESPACE-DENY-4f61c8-private-body';
+const ROGUE = 'CANARY-NAMESPACE-UNDECLARED-8b72aa-rogue-body';
+const FLIPPED = HEALTHY;
+const PRIVATE_DIR = 'private';
+const ROGUE_DIR = 'rogue';
+
+const TRANSFORMERS_STUB = `export async function pipeline() {
+  return async () => ({ data: Float32Array.from([1, 0, 0, 0]) });
+}
+`;
+
+const sandboxes = [];
+
+function cloneRows(rows = STOCK_ROWS) {
+  return JSON.parse(JSON.stringify(rows));
+}
+
+function registryText(rows = STOCK_ROWS) {
+  return JSON.stringify({ schema: SCHEMA, namespaces: rows }, null, 2);
+}
+
+function writeRegistry(box, text) {
+  const target = path.join(box.sem, 'namespace-registry.json');
+  rmSync(target, { recursive: true, force: true });
+  if (text !== null) writeFileSync(target, text);
+}
+
+function addNote(box, relativePath, canary) {
+  const target = path.join(box.vault, ...relativePath.split('/'));
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(
+    target,
+    `# Namespace fixture\n\n${canary}. This authored memory paragraph is deliberately long enough to pass the semantic chunker's near-empty note guard.\n`,
+  );
+  return target;
+}
+
+function makeSandbox(name, options = {}) {
+  const root = mkdtempSync(path.join(os.tmpdir(), `namespace-registry-${name}-`));
+  sandboxes.push(root);
+
+  const sem = path.join(root, 'daemons', 'semantic-search');
+  mkdirSync(sem, { recursive: true });
+  for (const file of ['deny-list.mjs', 'namespace-registry.mjs', 'embed-vault.js', 'search-vault.js']) {
+    copyFileSync(path.join(SEM, file), path.join(sem, file));
+  }
+  copyFileSync(
+    path.join(DAEMONS, 'frontmatter-reader.cjs'),
+    path.join(root, 'daemons', 'frontmatter-reader.cjs'),
+  );
+
+  const registry = Object.hasOwn(options, 'registryText')
+    ? options.registryText
+    : registryText();
+  if (registry !== null) writeFileSync(path.join(sem, 'namespace-registry.json'), registry);
+  writeFileSync(path.join(sem, 'index-deny.json'), options.denyText || '{"deny_prefixes":[]}');
+
+  const stub = path.join(root, 'node_modules', '@xenova', 'transformers');
+  mkdirSync(stub, { recursive: true });
+  writeFileSync(path.join(stub, 'package.json'), JSON.stringify({
+    name: '@xenova/transformers',
+    version: '0.0.0-test-stub',
+    type: 'module',
+    main: 'index.js',
+  }));
+  writeFileSync(path.join(stub, 'index.js'), TRANSFORMERS_STUB);
+
+  // Ordinary-doctor prerequisites: warnings are fine, but a valid registry
+  // fixture must have zero unrelated FAILs so negative statuses are meaningful.
+  mkdirSync(path.join(root, 'system'), { recursive: true });
+  writeFileSync(path.join(root, 'system', '00_identity.md'), '# fixture identity\n');
+  writeFileSync(path.join(root, 'CLAUDE.md'), '# fixture instructions\n');
+  mkdirSync(path.join(root, '.claude', 'skills'), { recursive: true });
+  mkdirSync(path.join(root, '.claude', 'agents'), { recursive: true });
+  writeFileSync(path.join(root, '.claude', 'skill-index.json'), '{}');
+  writeFileSync(path.join(root, '.claude', 'settings.json'), '{}');
+  writeFileSync(path.join(root, '.claude', 'agents', 'fixture.md'), '# fixture agent\n');
+  mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  copyFileSync(DOCTOR, path.join(root, 'scripts', 'doctor.sh'));
+
+  const vault = path.join(root, 'vault');
+  mkdirSync(path.join(vault, 'daily'), { recursive: true });
+  mkdirSync(path.join(vault, 'memory'), { recursive: true });
+  // Existing SKIP_DIRS infrastructure names are deliberately physical: they
+  // must not be mistaken for undeclared memory namespaces.
+  mkdirSync(path.join(vault, '.git'), { recursive: true });
+  mkdirSync(path.join(vault, 'node_modules'), { recursive: true });
+
+  const box = {
+    root,
+    sem,
+    vault,
+    embeddings: path.join(vault, 'memory', 'embeddings.json'),
+  };
+  addNote(box, 'feedback/healthy.md', HEALTHY);
+  return box;
+}
+
+function runNode(box, script, args = []) {
+  const result = spawnSync(process.execPath, [path.join(box.sem, script), ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      AIGENT_ROOT: box.root,
+      AIGENT_VAULT_ROOT: box.vault,
+    },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    all: `${result.stdout || ''}${result.stderr || ''}`,
+  };
+}
+
+function runDoctor(box) {
+  const result = spawnSync('bash', [path.join(box.root, 'scripts', 'doctor.sh'), box.root], {
+    encoding: 'utf8',
+    env: { ...process.env },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    all: `${result.stdout || ''}${result.stderr || ''}`,
+  };
+}
+
+function indexNote(notePath, chunk, embedding = [1, 0, 0, 0]) {
+  return {
+    path: notePath,
+    title: path.basename(notePath, '.md'),
+    tags: [],
+    chunk,
+    embedding,
+    mtime: 0,
+  };
+}
+
+function writeIndex(box, notes) {
+  const text = JSON.stringify({
+    model: 'Xenova/all-MiniLM-L6-v2',
+    updated: '2020-01-01T00:00:00.000Z',
+    noteCount: notes.length,
+    entryCount: notes.length,
+    notes,
+  });
+  writeFileSync(box.embeddings, text);
+  return text;
+}
+
+function readIndexText(box) {
+  return existsSync(box.embeddings) ? readFileSync(box.embeddings, 'utf8') : '';
+}
+
+function rowsWithPrivateDeny() {
+  return [
+    ...cloneRows(),
+    { path: PRIVATE_DIR, disposition: 'DENY', reason: 'test-only confidential namespace' },
+    { path: 'private-absent', disposition: 'DENY', reason: 'test-only absent confidential namespace' },
+  ];
+}
+
+function assertSearchIsolation(label, result, hidden, shown = HEALTHY) {
+  check(`${label}: exits 0`, result.status === 0, result.stderr.slice(0, 300));
+  check(`${label}: excluded canary is absent`, !result.all.includes(hidden));
+  check(`${label}: healthy INDEX canary is present`, result.stdout.includes(shown));
+}
+
+function establishHealthyControl(box, label) {
+  const embed = runNode(box, 'embed-vault.js');
+  check(`${label}: healthy control embed exits 0 before the negative mutation`, embed.status === 0, embed.stderr.slice(0, 300));
+  const raw = readIndexText(box);
+  check(`${label}: healthy INDEX canary is present before the negative mutation`, raw.includes(HEALTHY));
+  const search = runNode(box, 'search-vault.js', ['healthy namespace', '--top', '10']);
+  check(`${label}: healthy control search returns the INDEX canary`, search.status === 0 && search.stdout.includes(HEALTHY), search.stderr.slice(0, 300));
+  const doctor = runDoctor(box);
+  check(`${label}: healthy control doctor exits 0 before the negative mutation`, doctor.status === 0, doctor.all.slice(-500));
+}
+
+function assertInvalidRegistryMutation(name, mutate, detailPattern) {
+  assertInvalidRegistryMutation.sequence = (assertInvalidRegistryMutation.sequence || 0) + 1;
+  const box = makeSandbox(`invalid-${assertInvalidRegistryMutation.sequence}`);
+  establishHealthyControl(box, name);
+  const before = readIndexText(box);
+  mutate(box);
+
+  const embed = runNode(box, 'embed-vault.js');
+  check(`${name}: embed fails closed`, embed.status === 1, embed.all.slice(0, 300));
+  check(`${name}: embed names the registry problem`, detailPattern.test(embed.all), embed.all.slice(0, 300));
+  check(`${name}: failed embed leaves the healthy carried-forward index byte-for-byte unchanged`, readIndexText(box) === before);
+
+  const search = runNode(box, 'search-vault.js', ['healthy namespace', '--top', '10']);
+  check(`${name}: search fails closed`, search.status === 1, search.all.slice(0, 300));
+  check(`${name}: failed search returns no healthy result from the seeded index`, !search.stdout.includes(HEALTHY));
+  check(`${name}: search names the registry problem`, detailPattern.test(search.all), search.all.slice(0, 300));
+
+  const doctor = runDoctor(box);
+  check(`${name}: doctor fails closed`, doctor.status === 1, doctor.all.slice(-500));
+  check(`${name}: doctor reports a namespace-registry-specific failure`, /namespace registry check failed/i.test(doctor.all), doctor.all.slice(-500));
+  check(`${name}: doctor names the registry problem`, detailPattern.test(doctor.all), doctor.all.slice(-500));
+}
+
+// ── Loader validation and exact shipped population ──────────────────────────
+{
+  const shipped = JSON.parse(readFileSync(path.join(SEM, 'namespace-registry.json'), 'utf8'));
+  check(
+    'stock registry schema and ordered population are exact',
+    JSON.stringify(shipped) === JSON.stringify({ schema: SCHEMA, namespaces: STOCK_ROWS }),
+  );
+  check('stock registry contains 9 INDEX rows', shipped.namespaces.filter((row) => row.disposition === 'INDEX').length === 9);
+  check('stock registry contains 2 SKIP rows', shipped.namespaces.filter((row) => row.disposition === 'SKIP').length === 2);
+  check('stock registry contains 0 DENY rows', shipped.namespaces.filter((row) => row.disposition === 'DENY').length === 0);
+
+  const loaded = loadNamespaceRegistry(SEM);
+  check('loader returns all stock rows', loaded.rows.length === 11);
+  check('loader builds a case-insensitive byPath map', loaded.byPath.get('feedback')?.path === 'feedback');
+  check('namespaceDisposition is case-insensitive', namespaceDisposition(loaded, 'FEEDBACK') === 'INDEX');
+  check('namespaceDispositionForPath normalizes backslash separators', namespaceDispositionForPath(loaded, 'Templates\\starter.md') === 'SKIP');
+  check('namespaceDispositionForPath returns undefined for undeclared paths', namespaceDispositionForPath(loaded, 'not-declared/note.md') === undefined);
+}
+
+function loaderRejects(name, raw, setupAsDirectory = false) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'namespace-loader-invalid-'));
+  try {
+    const target = path.join(dir, 'namespace-registry.json');
+    const healthyPath = path.join(dir, 'feedback', 'healthy.md');
+    mkdirSync(path.dirname(healthyPath), { recursive: true });
+    writeFileSync(healthyPath, HEALTHY);
+    writeFileSync(target, registryText());
+    const control = loadNamespaceRegistry(dir);
+    check(
+      `${name}: healthy INDEX canary is present before the loader-negative mutation`,
+      namespaceDisposition(control, 'feedback') === 'INDEX' && readFileSync(healthyPath, 'utf8').includes(HEALTHY),
+    );
+
+    rmSync(target, { force: true });
+    if (setupAsDirectory) mkdirSync(target);
+    else if (raw !== null) writeFileSync(target, raw);
+    let threw = false;
+    try {
+      loadNamespaceRegistry(dir);
+    } catch {
+      threw = true;
+    }
+    check(`loader rejects ${name}`, threw);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const invalidDocuments = [
+  ['missing registry', null],
+  ['malformed JSON', '{'],
+  ['non-object root', 'null'],
+  ['wrong schema', JSON.stringify({ schema: 'MemoryNamespaceRegistry/v0', namespaces: [] })],
+  ['namespaces missing', JSON.stringify({ schema: SCHEMA })],
+  ['namespaces not an array', JSON.stringify({ schema: SCHEMA, namespaces: {} })],
+  ['non-object row', registryText([null])],
+  ['non-string path', registryText([{ path: 7, disposition: 'INDEX' }])],
+  ['empty path', registryText([{ path: '', disposition: 'INDEX' }])],
+  ['whitespace-padded path', registryText([{ path: ' feedback', disposition: 'INDEX' }])],
+  ['dot path', registryText([{ path: '.', disposition: 'INDEX' }])],
+  ['dot-dot path', registryText([{ path: '..', disposition: 'INDEX' }])],
+  ['slash path', registryText([{ path: 'feedback/private', disposition: 'INDEX' }])],
+  ['backslash path', registryText([{ path: 'feedback\\private', disposition: 'INDEX' }])],
+  ['POSIX absolute path', registryText([{ path: '/feedback', disposition: 'INDEX' }])],
+  ['Windows absolute path', registryText([{ path: 'C:\\feedback', disposition: 'INDEX' }])],
+  ['case-insensitive duplicate path', registryText([
+    { path: 'feedback', disposition: 'INDEX' },
+    { path: 'Feedback', disposition: 'INDEX' },
+  ])],
+  ['missing disposition', registryText([{ path: 'feedback' }])],
+  ['lowercase disposition', registryText([{ path: 'feedback', disposition: 'index' }])],
+  ['SKIP without reason', registryText([{ path: 'templates', disposition: 'SKIP' }])],
+  ['SKIP with blank reason', registryText([{ path: 'templates', disposition: 'SKIP', reason: '   ' }])],
+  ['DENY with non-string reason', registryText([{ path: 'private', disposition: 'DENY', reason: 7 }])],
+];
+for (const [name, raw] of invalidDocuments) loaderRejects(name, raw);
+loaderRejects('unreadable registry path', null, true);
+
+// ── 1. Valid INDEX content reaches both the artifact and search output ───────
+// feedback/ is intentional: the old hardcoded SCAN_DIRS omitted it, so this is
+// a falsifier for accidentally retaining the pre-registry scan population.
+{
+  const box = makeSandbox('valid-index');
+  const embed = runNode(box, 'embed-vault.js');
+  check('valid INDEX: embed exits 0', embed.status === 0, embed.stderr.slice(0, 300));
+  const raw = readIndexText(box);
+  check('valid INDEX: feedback canary is present in embeddings.json', raw.includes(HEALTHY));
+  const search = runNode(box, 'search-vault.js', ['healthy namespace', '--top', '10']);
+  check('valid INDEX: search exits 0', search.status === 0, search.stderr.slice(0, 300));
+  check('valid INDEX: feedback canary is present in search stdout', search.stdout.includes(HEALTHY));
+  const doctor = runDoctor(box);
+  check('valid INDEX: doctor exits 0', doctor.status === 0, doctor.all.slice(-500));
+  check('valid INDEX: doctor emits NAMESPACE_INDEX_PRESENT', /NAMESPACE_INDEX_PRESENT\s+feedback(?:\s|$)/.test(doctor.stdout));
+  check('declared absent research is informational', /NAMESPACE_INDEX_ABSENT\s+research(?:\s|$)/.test(doctor.stdout));
+  const declaredLines = doctor.stdout.match(/NAMESPACE_(?:INDEX|SKIP|DENY)_(?:PRESENT|ABSENT)/g) || [];
+  check('doctor emits exactly one line per stock namespace', declaredLines.length === STOCK_ROWS.length, `${declaredLines.length} lines`);
+}
+
+// ── 2. SKIP content is absent at build and query time; doctor reports it ─────
+{
+  const box = makeSandbox('skip');
+  addNote(box, 'templates/starter.md', SKIPPED);
+  const embed = runNode(box, 'embed-vault.js');
+  check('SKIP: embed exits 0', embed.status === 0, embed.stderr.slice(0, 300));
+  const raw = readIndexText(box);
+  check('SKIP: template canary is absent from embeddings.json', !raw.includes(SKIPPED));
+  check('SKIP: healthy INDEX canary is present in the same artifact', raw.includes(HEALTHY));
+
+  // Seed a stale SKIP entry so query-time behavior is observable independently
+  // of the build-time exclusion.
+  writeIndex(box, [
+    indexNote('templates/starter.md', SKIPPED, [1, 0, 0, 0]),
+    indexNote('feedback/healthy.md', HEALTHY, [0, 1, 0, 0]),
+  ]);
+  const search = runNode(box, 'search-vault.js', ['starter template', '--top', '10']);
+  assertSearchIsolation('SKIP search', search, SKIPPED);
+
+  const doctor = runDoctor(box);
+  check('SKIP: doctor exits 0', doctor.status === 0, doctor.all.slice(-500));
+  check('SKIP: doctor emits NAMESPACE_SKIP_PRESENT', /NAMESPACE_SKIP_PRESENT\s+templates(?:\s|$)/.test(doctor.stdout));
+  check('SKIP: doctor emits NAMESPACE_SKIP_ABSENT', /NAMESPACE_SKIP_ABSENT\s+examples(?:\s|$)/.test(doctor.stdout));
+}
+
+// ── 3. Fixture DENY content is absent from build/search and reported ─────────
+{
+  const box = makeSandbox('deny', { registryText: registryText(rowsWithPrivateDeny()) });
+  addNote(box, `${PRIVATE_DIR}/secret.md`, DENIED);
+  const embed = runNode(box, 'embed-vault.js');
+  check('DENY: embed exits 0', embed.status === 0, embed.stderr.slice(0, 300));
+  const raw = readIndexText(box);
+  check('DENY: private canary is absent from embeddings.json', !raw.includes(DENIED));
+  check('DENY: healthy INDEX canary is present in the same artifact', raw.includes(HEALTHY));
+  const search = runNode(box, 'search-vault.js', ['private secret', '--top', '10']);
+  assertSearchIsolation('DENY search over built index', search, DENIED);
+  const doctor = runDoctor(box);
+  check('DENY: doctor exits 0', doctor.status === 0, doctor.all.slice(-500));
+  check('DENY: doctor emits NAMESPACE_DENY_PRESENT', /NAMESPACE_DENY_PRESENT\s+private(?:\s|$)/.test(doctor.stdout));
+  check('DENY: doctor emits NAMESPACE_DENY_ABSENT', /NAMESPACE_DENY_ABSENT\s+private-absent(?:\s|$)/.test(doctor.stdout));
+}
+
+// ── 4. Stale hand-built DENY entry is blocked at the query chokepoint ────────
+{
+  const box = makeSandbox('stale-deny', { registryText: registryText(rowsWithPrivateDeny()) });
+  mkdirSync(path.join(box.vault, PRIVATE_DIR), { recursive: true });
+  writeIndex(box, [
+    indexNote(`${PRIVATE_DIR}/secret.md`, DENIED, [1, 0, 0, 0]),
+    indexNote('feedback/healthy.md', HEALTHY, [0, 1, 0, 0]),
+  ]);
+  check('stale DENY: healthy INDEX canary is present in the seeded artifact', readIndexText(box).includes(HEALTHY));
+  const search = runNode(box, 'search-vault.js', ['private secret', '--top', '10']);
+  assertSearchIsolation('stale DENY query-time chokepoint', search, DENIED);
+  check('stale DENY: denied namespace path is absent from all output', !search.all.includes(`${PRIVATE_DIR}/secret.md`));
+}
+
+// A stale undeclared path with no corresponding physical directory is also
+// removed at query time, while a physical undeclared directory is fatal below.
+{
+  const box = makeSandbox('stale-undeclared');
+  writeIndex(box, [
+    indexNote(`${ROGUE_DIR}/secret.md`, ROGUE, [1, 0, 0, 0]),
+    indexNote('feedback/healthy.md', HEALTHY, [0, 1, 0, 0]),
+  ]);
+  const search = runNode(box, 'search-vault.js', ['rogue secret', '--top', '10']);
+  assertSearchIsolation('stale undeclared query-time chokepoint', search, ROGUE);
+}
+
+// ── 5. INDEX -> SKIP plus --changed-only purges carried-forward chunks ───────
+{
+  const box = makeSandbox('flip');
+  addNote(box, 'reference/stable.md', STABLE);
+  const first = runNode(box, 'embed-vault.js');
+  check('INDEX -> SKIP: initial embed exits 0', first.status === 0, first.stderr.slice(0, 300));
+  const initial = readIndexText(box);
+  check('INDEX -> SKIP: soon-to-be-flipped canary starts indexed', initial.includes(FLIPPED));
+  check('INDEX -> SKIP: stable healthy INDEX canary starts indexed', initial.includes(STABLE));
+
+  const flippedRows = cloneRows();
+  const feedback = flippedRows.find((row) => row.path === 'feedback');
+  feedback.disposition = 'SKIP';
+  feedback.reason = 'test-only namespace flip';
+  writeRegistry(box, registryText(flippedRows));
+
+  const changed = runNode(box, 'embed-vault.js', ['--changed-only']);
+  check('INDEX -> SKIP: changed-only embed exits 0', changed.status === 0, changed.stderr.slice(0, 300));
+  check('INDEX -> SKIP: changed-only run reaches the zero-files path', /--changed-only: 0 files modified/.test(changed.stdout), changed.stdout.slice(-500));
+  const after = readIndexText(box);
+  check('INDEX -> SKIP: previously indexed chunk is purged from carried-forward embeddings.json', !after.includes(FLIPPED));
+  check('INDEX -> SKIP: stable INDEX content survives the carried-forward purge', after.includes(STABLE));
+}
+
+// ── 6. A physical undeclared directory fails all three programs closed ──────
+{
+  const box = makeSandbox('undeclared');
+  establishHealthyControl(box, 'undeclared physical directory');
+  addNote(box, `${ROGUE_DIR}/secret.md`, ROGUE);
+  const before = readIndexText(box);
+
+  const embed = runNode(box, 'embed-vault.js');
+  check('undeclared: embed exits nonzero', embed.status === 1, embed.all.slice(0, 300));
+  check('undeclared: embed names the physical directory', embed.all.includes(ROGUE_DIR));
+  check('undeclared: embed refuses before loading the model', !embed.stdout.includes('Loading model'));
+  check('undeclared: embed leaves the healthy index byte-for-byte unchanged', readIndexText(box) === before && before.includes(HEALTHY));
+
+  writeIndex(box, [
+    indexNote(`${ROGUE_DIR}/secret.md`, ROGUE, [1, 0, 0, 0]),
+    indexNote('feedback/healthy.md', HEALTHY, [0, 1, 0, 0]),
+  ]);
+  const search = runNode(box, 'search-vault.js', ['rogue secret', '--top', '10']);
+  check('undeclared: search exits nonzero', search.status === 1, search.all.slice(0, 300));
+  check('undeclared: search names the physical directory', search.all.includes(ROGUE_DIR));
+  check('undeclared: search returns neither rogue nor healthy results', !search.stdout.includes(ROGUE) && !search.stdout.includes(HEALTHY));
+
+  const doctor = runDoctor(box);
+  check('undeclared: doctor exits nonzero', doctor.status === 1, doctor.all.slice(-500));
+  check('undeclared: doctor emits NAMESPACE_UNDECLARED', /NAMESPACE_UNDECLARED\s+rogue(?:\s|$)/.test(doctor.stdout));
+}
+
+// A declared path's physical spelling must match exactly. Runtime lookups stay
+// case-insensitive for stale index paths, but accepting a differently-cased
+// physical directory would silently omit it on a case-sensitive filesystem
+// because embedding walks the literal registry spelling.
+{
+  const box = makeSandbox('physical-case-mismatch');
+  establishHealthyControl(box, 'physical namespace case mismatch');
+  const mismatchedRows = cloneRows();
+  mismatchedRows.find((row) => row.path === 'feedback').path = 'Feedback';
+  writeRegistry(box, registryText(mismatchedRows));
+  const before = readIndexText(box);
+
+  const embed = runNode(box, 'embed-vault.js');
+  check('physical case mismatch: embed fails closed', embed.status === 1 && embed.all.includes('feedback'), embed.all.slice(0, 300));
+  check('physical case mismatch: failed embed leaves the healthy index unchanged', readIndexText(box) === before && before.includes(HEALTHY));
+
+  const search = runNode(box, 'search-vault.js', ['healthy namespace', '--top', '10']);
+  check('physical case mismatch: search fails closed with no result', search.status === 1 && !search.stdout.includes(HEALTHY), search.all.slice(0, 300));
+
+  const doctor = runDoctor(box);
+  check('physical case mismatch: doctor fails closed', doctor.status === 1, doctor.all.slice(-500));
+  check('physical case mismatch: declared spelling is reported absent', /NAMESPACE_INDEX_ABSENT\s+Feedback(?:\s|$)/.test(doctor.stdout));
+  check('physical case mismatch: physical spelling is reported undeclared', /NAMESPACE_UNDECLARED\s+feedback(?:\s|$)/.test(doctor.stdout));
+}
+
+// ── 7-9. Invalid registry states fail embed, search, and doctor closed ────────
+assertInvalidRegistryMutation(
+  'duplicate registry path',
+  (box) => writeRegistry(box, registryText([
+    ...cloneRows(),
+    { path: 'Feedback', disposition: 'INDEX' },
+  ])),
+  /duplicate namespace path/i,
+);
+
+assertInvalidRegistryMutation(
+  'invalid disposition',
+  (box) => writeRegistry(box, registryText([
+    ...cloneRows(),
+    { path: PRIVATE_DIR, disposition: 'ALLOW' },
+  ])),
+  /has invalid disposition/i,
+);
+
+assertInvalidRegistryMutation(
+  'missing registry',
+  (box) => writeRegistry(box, null),
+  /cannot read|missing or unreadable/i,
+);
+
+assertInvalidRegistryMutation(
+  'malformed registry JSON',
+  (box) => writeRegistry(box, '{'),
+  /cannot parse|malformed JSON/i,
+);
+
+// Representative structural/reason failures prove doctor mirrors the shared
+// loader's validation rather than treating merely parseable JSON as healthy.
+assertInvalidRegistryMutation(
+  'wrong registry schema',
+  (box) => writeRegistry(box, JSON.stringify({ schema: 'MemoryNamespaceRegistry/v0', namespaces: cloneRows() })),
+  /schema must equal exactly/i,
+);
+
+assertInvalidRegistryMutation(
+  'missing SKIP reason',
+  (box) => writeRegistry(box, registryText([
+    ...cloneRows().filter((row) => row.path !== 'templates'),
+    { path: 'templates', disposition: 'SKIP' },
+  ])),
+  /requires a non-empty reason/i,
+);
+
+// ── Mutation witness: weaken only search's query-time namespace predicate ───
+{
+  const box = makeSandbox('mutation-witness', { registryText: registryText(rowsWithPrivateDeny()) });
+  mkdirSync(path.join(box.vault, PRIVATE_DIR), { recursive: true });
+  writeIndex(box, [
+    indexNote(`${PRIVATE_DIR}/secret.md`, DENIED, [1, 0, 0, 0]),
+    indexNote('feedback/healthy.md', HEALTHY, [0, 1, 0, 0]),
+  ]);
+  const searchPath = path.join(box.sem, 'search-vault.js');
+  const original = readFileSync(searchPath, 'utf8');
+  const enforcement = "  index.notes = index.notes.filter((note) => namespaceDispositionForPath(NAMESPACE_REGISTRY, note.path) === 'INDEX');";
+  const occurrences = original.split(enforcement).length - 1;
+  check('mutation witness: query-time namespace enforcement has one scriptable chokepoint', occurrences === 1, `${occurrences} occurrences`);
+
+  const baseline = runNode(box, 'search-vault.js', ['private secret', '--top', '10']);
+  const baselineGreen = baseline.status === 0 && !baseline.all.includes(DENIED) && baseline.stdout.includes(HEALTHY);
+  check('mutation witness: stale-DENY contract is GREEN before mutation', baselineGreen, baseline.all.slice(-500));
+  if (baselineGreen) console.log('WITNESS GREEN: stale DENY content blocked and healthy INDEX content returned');
+
+  let mutant = null;
+  let restored = null;
+  try {
+    if (occurrences === 1) {
+      writeFileSync(searchPath, original.replace(
+        enforcement,
+        '  index.notes = index.notes.filter(() => true); // MUTATION: namespace enforcement removed',
+      ));
+      mutant = runNode(box, 'search-vault.js', ['private secret', '--top', '10']);
+    }
+  } finally {
+    writeFileSync(searchPath, original);
+    restored = runNode(box, 'search-vault.js', ['private secret', '--top', '10']);
+  }
+
+  const mutantRed = mutant && mutant.status === 0 && mutant.stdout.includes(DENIED);
+  check('mutation witness: replacing the predicate with true makes the same stale-DENY contract RED', mutantRed, mutant?.all.slice(-500) || 'mutation did not run');
+  if (mutantRed) console.log(`WITNESS RED AS EXPECTED: replacing the query-time namespace predicate with true leaked ${DENIED}`);
+
+  const restoredGreen = restored.status === 0 && !restored.all.includes(DENIED) && restored.stdout.includes(HEALTHY);
+  check('mutation witness: restoring the source makes the contract GREEN again', restoredGreen, restored.all.slice(-500));
+  if (restoredGreen) console.log('WITNESS GREEN: restoring the original search source blocked stale DENY again');
+}
+
+for (const box of sandboxes) rmSync(box, { recursive: true, force: true });
+
+console.log(failed ? `\n${failed} of ${checked} namespace registry check(s) FAILED` : `\nAll ${checked} namespace registry checks passed`);
+process.exit(failed ? 1 : 0);

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -25,6 +25,7 @@
 #   - .claude/settings.json present and AIGENT_ROOT placeholder resolved
 #   - Node.js available (optional)
 #   - semantic search node_modules present (if Node available)
+#   - semantic search namespace registry valid and physically complete
 #   - all shell scripts pass bash -n syntax check
 #   - all JSON files parse cleanly
 
@@ -719,6 +720,163 @@ if [ "$NODE_OK" -eq 1 ]; then
   fi
 else
   warn "semantic search install check skipped (Node not available)"
+fi
+
+# -- 9b. Semantic search namespace registry -----------------------------------
+# Validate the whole document before emitting any records. The extractor lives
+# in a temp file, matching check 7b's set -euo pipefail-safe pattern; capturing
+# its status directly (rather than through process substitution) ensures a
+# parser failure cannot be mistaken for an empty, healthy registry.
+NAMESPACE_REGISTRY="$ROOT/daemons/semantic-search/namespace-registry.json"
+if command -v python3 >/dev/null 2>&1; then
+  _NAMESPACE_PY=$(mktemp /tmp/doctor_namespace_registry.XXXXXX.py)
+  cat > "$_NAMESPACE_PY" << 'NAMESPACEPY'
+import json
+import ntpath
+import os
+import posixpath
+import sys
+
+SCHEMA = "MemoryNamespaceRegistry/v1"
+DISPOSITIONS = {"INDEX", "SKIP", "DENY"}
+INFRASTRUCTURE = {
+    "node_modules",
+    ".git",
+    "daemons",
+    ".claude",
+    "command-center-v2",
+    "graphify-out",
+    "recon",
+    "prompts",
+    "tools",
+}
+
+
+def stop(message):
+    print(message)
+    raise SystemExit(1)
+
+
+def reject_json_constant(value):
+    raise ValueError("invalid JSON constant: %s" % value)
+
+
+registry_path, vault_root = sys.argv[1:3]
+try:
+    with open(registry_path, encoding="utf-8") as registry_file:
+        registry_text = registry_file.read()
+except (OSError, UnicodeError) as error:
+    stop("namespace registry missing or unreadable: %s (%s)" % (registry_path, error))
+
+try:
+    document = json.loads(registry_text, parse_constant=reject_json_constant)
+except (ValueError, UnicodeError, RecursionError) as error:
+    stop("namespace registry malformed JSON: %s" % error)
+
+if type(document) is not dict:
+    stop("namespace registry root must be an object")
+if document.get("schema") != SCHEMA:
+    stop("namespace registry schema must equal exactly %s" % SCHEMA)
+
+namespaces = document.get("namespaces")
+if type(namespaces) is not list:
+    stop("namespace registry namespaces must be an array")
+
+rows = []
+seen = set()
+for index, row in enumerate(namespaces):
+    if type(row) is not dict:
+        stop("namespaces[%d] must be an object" % index)
+
+    namespace_path = row.get("path")
+    if type(namespace_path) is not str:
+        stop("namespaces[%d].path must be a string" % index)
+    if (
+        not namespace_path
+        or namespace_path.strip() != namespace_path
+        or namespace_path in (".", "..")
+        or "/" in namespace_path
+        or "\\" in namespace_path
+        or posixpath.isabs(namespace_path)
+        or ntpath.isabs(namespace_path)
+    ):
+        stop("namespaces[%d].path must be one normalized top-level segment" % index)
+
+    key = namespace_path.replace("\\", "/").lower()
+    if key in seen:
+        stop("duplicate namespace path: %s" % namespace_path)
+    seen.add(key)
+
+    disposition = row.get("disposition")
+    if type(disposition) is not str or disposition not in DISPOSITIONS:
+        stop("namespaces[%d] has invalid disposition: %s" % (index, disposition))
+    if disposition in ("SKIP", "DENY"):
+        reason = row.get("reason")
+        if type(reason) is not str or not reason.strip():
+            stop("namespaces[%d] %s row requires a non-empty reason" % (index, disposition))
+
+    rows.append((namespace_path, disposition, key))
+
+physical = []
+if os.path.exists(vault_root):
+    if not os.path.isdir(vault_root):
+        stop("vault root is not a directory: %s" % vault_root)
+    try:
+        with os.scandir(vault_root) as entries:
+            for entry in entries:
+                try:
+                    if entry.is_dir(follow_symlinks=False):
+                        physical.append(entry.name)
+                except OSError as error:
+                    stop("cannot inspect vault namespace %s: %s" % (entry.name, error))
+    except OSError as error:
+        stop("cannot enumerate vault root %s: %s" % (vault_root, error))
+
+memory_directories = [name for name in physical if name not in INFRASTRUCTURE]
+physical_names = set(physical)
+declared_names = {namespace_path for namespace_path, _, _ in rows}
+
+records = []
+for namespace_path, disposition, key in rows:
+    presence = "PRESENT" if namespace_path in physical_names else "ABSENT"
+    records.append(("NAMESPACE_%s_%s" % (disposition, presence), namespace_path))
+
+for name in sorted(
+    (name for name in memory_directories if name not in declared_names),
+    key=lambda value: (value.lower(), value),
+):
+    records.append(("NAMESPACE_UNDECLARED", name))
+
+for label, namespace_path in records:
+    print("%s\t%s" % (label, namespace_path))
+NAMESPACEPY
+
+  NAMESPACE_OUTPUT=""
+  NAMESPACE_RC=0
+  NAMESPACE_OUTPUT="$(python3 "$_NAMESPACE_PY" "$NAMESPACE_REGISTRY" "$ROOT/vault" 2>&1)" || NAMESPACE_RC=$?
+  rm -f "$_NAMESPACE_PY"
+
+  if [ "$NAMESPACE_RC" -ne 0 ]; then
+    fail "namespace registry check failed: ${NAMESPACE_OUTPUT:-unknown validation error}"
+  else
+    while IFS=$'\t' read -r namespace_label namespace_path; do
+      [ -z "$namespace_label" ] && continue
+      namespace_path="${namespace_path%$'\r'}"
+      case "$namespace_label" in
+        NAMESPACE_INDEX_PRESENT|NAMESPACE_INDEX_ABSENT|NAMESPACE_SKIP_PRESENT|NAMESPACE_SKIP_ABSENT|NAMESPACE_DENY_PRESENT|NAMESPACE_DENY_ABSENT)
+          pass "$namespace_label $namespace_path"
+          ;;
+        NAMESPACE_UNDECLARED)
+          fail "$namespace_label $namespace_path"
+          ;;
+        *)
+          fail "namespace registry check failed: unexpected extractor record: $namespace_label $namespace_path"
+          ;;
+      esac
+    done <<< "$NAMESPACE_OUTPUT"
+  fi
+else
+  fail "namespace registry check failed: python3 not available"
 fi
 
 # -- 10. Shell script syntax check ---------------------------------------------


### PR DESCRIPTION
Implements wrg32786/aigent-os-program issue #37 from exact master 66e0359, full contract: MemoryNamespaceRegistry/v1 array schema (duplicates mechanically visible), one shared runtime loader for embed+search, fail-closed on missing/unreadable/malformed/duplicate/invalid registry at BOTH chokepoints, undeclared physical namespaces fail closed everywhere, --changed-only purges carried-forward SKIP/DENY/undeclared chunks before the early return, independent query-time re-filtering (stale or hand-edited embeddings.json cannot leak non-INDEX paths), doctor ordinary-pass leg with the 7 fixed NAMESPACE_* labels. FleetBaselineManifest/v1 byte-untouched (v2 recut follows separately). Operator-private index-deny.json unchanged as a composing layer.

Stock registry: 9 INDEX, 2 SKIP with reasons, 0 DENY; research/ declared-but-absent (reported, not failed).

Tests: 201-check namespace suite + 39-check deny suite green; in-suite executed mutation witness (weakened query-time predicate leaks the DENY canary, restored blocks it); every negative fixture carries a healthy INDEX canary. Non-author review SHIP, zero findings, bound to exact head 1a1fe4de.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFAAgEhoTBXGhJfSySd5Nd