### PR TITLE
fleet-baseline: recut as FleetBaselineManifest/v2 from 30598546

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so fleet-baseline-attest's pinned-commit case runs
+          # here instead of skipping (the skip guard below rightly refuses
+          # non-platform skips).
+          fetch-depth: 0
 
       - name: Shell syntax
         shell: bash

--- a/daemons/tests/fleet-baseline-attest.test.mjs
+++ b/daemons/tests/fleet-baseline-attest.test.mjs
@@ -22,6 +22,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   cpSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -552,8 +553,9 @@ test('every declared required path exists in the tree with no duplicate declarat
   const manifest = readManifest();
   const declared = Object.keys(manifest.required_files);
   for (const relative of declared) {
+    const full = path.join(REPO, ...relative.split('/'));
     assert.ok(
-      statSync(path.join(REPO, ...relative.split('/'))).isFile(),
+      existsSync(full) && statSync(full).isFile(),
       `declared required path missing from the tree: ${relative}`,
     );
   }
@@ -579,15 +581,26 @@ test('every declared required path resolves at the pinned source commit', (t) =>
   const commit = manifest.public_product_commit;
   const probe = spawnSync('git', ['-C', REPO, 'cat-file', '-e', `${commit}^{commit}`]);
   if (probe.status !== 0) {
-    // A shallow CI clone does not carry the pinned commit object. Skip LOUDLY
-    // rather than assert against an unreachable object; the tree-existence
-    // case above still runs everywhere.
-    t.skip(`pinned commit ${commit.slice(0, 8)} not present in this clone (shallow checkout)`);
+    // Only a shallow clone excuses the missing object. In a full clone an
+    // unreachable public_product_commit means the manifest pins a wrong or
+    // rewritten commit -- that must FAIL, not skip.
+    const shallow = spawnSync('git', ['-C', REPO, 'rev-parse', '--is-shallow-repository'], { encoding: 'utf8' });
+    assert.equal(
+      shallow.stdout?.trim(),
+      'true',
+      `pinned commit ${commit} is unreachable in a full clone -- wrong or rewritten public_product_commit`,
+    );
+    t.skip(`pinned commit ${commit.slice(0, 8)} not present (shallow clone)`);
     return;
   }
+  const tree = spawnSync('git', ['-C', REPO, 'ls-tree', '-r', '--name-only', commit], {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  assert.equal(tree.status, 0, `git ls-tree failed for ${commit.slice(0, 8)}`);
+  const present = new Set(tree.stdout.split('\n'));
   for (const relative of Object.keys(manifest.required_files)) {
-    const result = spawnSync('git', ['-C', REPO, 'cat-file', '-e', `${commit}:${relative}`]);
-    assert.equal(result.status, 0, `not present at ${commit.slice(0, 8)}: ${relative}`);
+    assert.ok(present.has(relative), `not present at ${commit.slice(0, 8)}: ${relative}`);
   }
 });
 
@@ -630,7 +643,10 @@ test('flipping the expected namespace-registry hash turns the exact install red;
   });
 });
 
-test('attest prints the measured population count from the manifest', () => {
+// Locks the population line's presence and format. Both sides parse the same
+// manifest bytes, so this does NOT independently detect truncation -- the
+// duplicate-declaration raw-text case above carries that coverage.
+test('attest output states the declared population count', () => {
   withInstall((root) => {
     const { output } = attest(root);
     const count = Object.keys(readManifest().required_files).length;

--- a/daemons/tests/fleet-baseline-attest.test.mjs
+++ b/daemons/tests/fleet-baseline-attest.test.mjs
@@ -524,3 +524,120 @@ test('--attest writes nothing into the tree it attests', () => {
     assert.equal(digest(root), before, '--attest must not modify the attested tree');
   });
 });
+
+// -- FleetBaselineManifest/v2 -------------------------------------------------
+
+const REGISTRY = 'daemons/semantic-search/namespace-registry.json';
+
+test('v2 manifest identity pins the recut population', () => {
+  const manifest = readManifest();
+  assert.equal(manifest.schema, 'FleetBaselineManifest/v2');
+  assert.equal(manifest.baseline_id, 'aigent-os-2026-08-22-30598546');
+  assert.equal(
+    manifest.public_product_commit,
+    '30598546a36a19cc1e2863ecf792d3743276fa06',
+  );
+  assert.ok(
+    manifest.baseline_id.endsWith(manifest.public_product_commit.slice(0, 8)),
+    'baseline_id embeds the commit prefix it was cut from',
+  );
+  assert.match(
+    manifest.required_files[REGISTRY] ?? '',
+    /^[0-9a-f]{64}$/,
+    'the product namespace policy artifact is pinned',
+  );
+});
+
+test('every declared required path exists in the tree with no duplicate declarations', () => {
+  const manifest = readManifest();
+  const declared = Object.keys(manifest.required_files);
+  for (const relative of declared) {
+    assert.ok(
+      statSync(path.join(REPO, ...relative.split('/'))).isFile(),
+      `declared required path missing from the tree: ${relative}`,
+    );
+  }
+  assert.equal(
+    new Set(declared.map((key) => path.posix.normalize(key))).size,
+    declared.length,
+    'two declarations normalize to the same path',
+  );
+  // JSON.parse collapses duplicate keys silently, so the parsed object can
+  // never show one. Count declarations in the raw manifest text instead.
+  const raw = readFileSync(MANIFEST, 'utf8');
+  const block = raw.slice(raw.indexOf('"required_files"'), raw.indexOf('"required_settings"'));
+  const rawDeclarations = block.match(/"[^"\n]+": "[0-9a-f]{64}"/g) ?? [];
+  assert.equal(
+    rawDeclarations.length,
+    declared.length,
+    'raw manifest text declares a required path the parsed object lost (duplicate key)',
+  );
+});
+
+test('every declared required path resolves at the pinned source commit', (t) => {
+  const manifest = readManifest();
+  const commit = manifest.public_product_commit;
+  const probe = spawnSync('git', ['-C', REPO, 'cat-file', '-e', `${commit}^{commit}`]);
+  if (probe.status !== 0) {
+    // A shallow CI clone does not carry the pinned commit object. Skip LOUDLY
+    // rather than assert against an unreachable object; the tree-existence
+    // case above still runs everywhere.
+    t.skip(`pinned commit ${commit.slice(0, 8)} not present in this clone (shallow checkout)`);
+    return;
+  }
+  for (const relative of Object.keys(manifest.required_files)) {
+    const result = spawnSync('git', ['-C', REPO, 'cat-file', '-e', `${commit}:${relative}`]);
+    assert.equal(result.status, 0, `not present at ${commit.slice(0, 8)}: ${relative}`);
+  }
+});
+
+test('a byte changed in the namespace policy artifact attests NONCOMPLIANT', () => {
+  withInstall((root) => {
+    const file = path.join(root, ...REGISTRY.split('/'));
+    writeFileSync(file, `${readFileSync(file, 'utf8')}\n`);
+
+    const { verdict, status, output } = attest(root);
+    assert.equal(verdict, 'NONCOMPLIANT', output);
+    assert.equal(status, 1, 'NONCOMPLIANT exits 1');
+    assert.match(output, /required file changed: daemons\/semantic-search\/namespace-registry\.json/);
+  });
+});
+
+// THE v2 MUTATION WITNESS. The expected namespace-registry hash is flipped in
+// the installed manifest while the artifact on disk stays untouched: the
+// exact-install case must turn red, and a byte-identical restore must turn it
+// green again -- proving the green depends on exactly these bytes.
+test('flipping the expected namespace-registry hash turns the exact install red; restoring turns it green', () => {
+  withInstall((root) => {
+    const installed = path.join(root, 'scripts', 'fleet-baseline-manifest.json');
+    const original = readFileSync(installed);
+
+    assert.equal(attest(root).verdict, 'COMPLIANT', 'exact install is green before the mutation');
+
+    const manifest = JSON.parse(original.toString('utf8'));
+    assert.ok(manifest.required_files[REGISTRY], 'fixture manifest pins the registry');
+    manifest.required_files[REGISTRY] = 'f'.repeat(64);
+    writeFileSync(installed, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const red = attest(root);
+    assert.equal(red.verdict, 'NONCOMPLIANT', red.output);
+    assert.match(red.output, /required file changed: daemons\/semantic-search\/namespace-registry\.json/);
+
+    writeFileSync(installed, original);
+    const green = attest(root);
+    assert.equal(green.verdict, 'COMPLIANT', green.output);
+    assert.equal(green.status, 0, 'byte-identical restore returns the exact install to green');
+  });
+});
+
+test('attest prints the measured population count from the manifest', () => {
+  withInstall((root) => {
+    const { output } = attest(root);
+    const count = Object.keys(readManifest().required_files).length;
+    assert.match(
+      output,
+      new RegExp(`population ${count} required files`),
+      'the population line must state the declared required-file count',
+    );
+  });
+});

--- a/daemons/tests/fleet-baseline-attest.test.mjs
+++ b/daemons/tests/fleet-baseline-attest.test.mjs
@@ -593,7 +593,9 @@ test('every declared required path resolves at the pinned source commit', (t) =>
     t.skip(`pinned commit ${commit.slice(0, 8)} not present (shallow clone)`);
     return;
   }
-  const tree = spawnSync('git', ['-C', REPO, 'ls-tree', '-r', '--name-only', commit], {
+  // core.quotePath=false: without it, git C-quotes any non-ASCII byte in a
+  // path and Set.has never matches the raw UTF-8 manifest key.
+  const tree = spawnSync('git', ['-C', REPO, '-c', 'core.quotePath=false', 'ls-tree', '-r', '--name-only', commit], {
     encoding: 'utf8',
     maxBuffer: 16 * 1024 * 1024,
   });

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -116,8 +116,8 @@ findings = []
 
 print("info:baseline %s" % manifest["baseline_id"])
 print("info:commit %s" % manifest["public_product_commit"])
-# A silently truncated population would attest green over fewer files than the
-# baseline declares; printing the count makes the measured population loud.
+# A bare verdict is not self-describing about coverage: COMPLIANT over 31
+# files and COMPLIANT over 1 file print identically without this line.
 print("info:population %d required files" % len(manifest["required_files"]))
 
 # Required files, byte for byte. A missing file and a changed file are the

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -116,6 +116,9 @@ findings = []
 
 print("info:baseline %s" % manifest["baseline_id"])
 print("info:commit %s" % manifest["public_product_commit"])
+# A silently truncated population would attest green over fewer files than the
+# baseline declares; printing the count makes the measured population loud.
+print("info:population %d required files" % len(manifest["required_files"]))
 
 # Required files, byte for byte. A missing file and a changed file are the
 # same terminal but not the same fact, so they stay separate lines.

--- a/scripts/fleet-baseline-manifest.json
+++ b/scripts/fleet-baseline-manifest.json
@@ -1,11 +1,13 @@
 {
-  "schema": "FleetBaselineManifest/v1",
-  "baseline_id": "aigent-os-2026-08-19-41051d9e",
-  "public_product_commit": "41051d9e544063309d3b69462aecb7aa4edbe149",
+  "schema": "FleetBaselineManifest/v2",
+  "baseline_id": "aigent-os-2026-08-22-30598546",
+  "public_product_commit": "30598546a36a19cc1e2863ecf792d3743276fa06",
   "notes": [
     "Every sha256 below is the blob at public_product_commit. .gitattributes forces eol=lf, so an installed tree's bytes match on every platform.",
     "Population rule: every executable .claude/settings.json.template wires as a hook or statusLine, plus the entry points install.sh names by path (managed runner, its dependency root, managed launcher), the settings template, the post-compact rule, and the system kernel root.",
-    "scripts/doctor.sh is excluded: it is the measuring instrument, and this baseline was cut before the --attest change landed, so its post-merge bytes are not the pinned ones.",
+    "scripts/doctor.sh is excluded: it is the measuring instrument, not a member of the measured population.",
+    "daemons/semantic-search/namespace-registry.json pins the product-owned namespace policy artifact. v2 does not attest every semantic-search implementation byte; it pins this policy artifact plus the existing load-bearing population.",
+    "FleetBaselineManifest/v1 (aigent-os-2026-08-19-41051d9e) is superseded by this baseline as the current public baseline and remains historical evidence in git history.",
     "CLAUDE.md, .claude/settings.json and .gitignore are excluded: the installer rewrites them (marker block, placeholder render, managed ignore block), so their installed bytes are never the repo bytes.",
     ".claude/skill-index.json and skills/*/SKILL.md are excluded: caddy-enroll and operator-authored skills legitimately change them, so hashing them would report every customized install as NONCOMPLIANT.",
     ".claude/rules/post-compact-critical.md is excluded: it is operator-owned doctrine (the CLAUDE.md class) -- the installer seeds the starter only into a fresh install and keeps an existing operator file, so its installed bytes are legitimately not the repo bytes."
@@ -40,7 +42,8 @@
     "launcher/aigent.sh": "5aebacaf419b421f87260ff5aa31c0b7b68a795435031475b92e9c65d8419335",
     "launcher/aigent.ps1": "44e21c52268c77fb64e190b698beeeffc27ab188e315c5f5d3b173af950508b0",
     "launcher/install.sh": "cdb11fd4a4f0d0f5a39ba044ac2e3a509482ee35d1964b677a32f52f78dd2285",
-    "launcher/install.ps1": "472cb70b6bfba4c1d3ff38cf72855eadde2953ac5063bcdfc89c3fa05ae93574"
+    "launcher/install.ps1": "472cb70b6bfba4c1d3ff38cf72855eadde2953ac5063bcdfc89c3fa05ae93574",
+    "daemons/semantic-search/namespace-registry.json": "5bcc603c8e813f272be3ef17aa94b92ac1cccd9e31fb5b02d6d5589d60025060"
   },
   "required_settings": {
     "path": ".claude/settings.json",


### PR DESCRIPTION
Recuts the fleet baseline from the exact master commit that contains MemoryNamespaceRegistry/v1, without redesigning attestation.

## Manifest
- schema `FleetBaselineManifest/v2`, baseline_id `aigent-os-2026-08-22-30598546`, public_product_commit `30598546a36a19cc1e2863ecf792d3743276fa06`
- every required-file sha256 recomputed from the pinned commit (31 files; nothing carried forward on trust — v1 vs v2 hash drift measured at 0 for the 30 carried paths)
- adds `daemons/semantic-search/namespace-registry.json` (the product-owned namespace policy artifact). v2 does not claim to attest every semantic-search implementation byte
- population rule, exclusions (incl. doctor-as-instrument and operator-owned `.claude/rules/post-compact-critical.md`), terminal mapping, and v1 structure otherwise preserved; v1 superseded as current baseline, retained as git history

## doctor --attest
One added `info` line printing the measured population count — a bare verdict is not self-describing about coverage (COMPLIANT over 31 files and over 1 file printed identically before this).

## Tests (fleet-baseline-attest, 27/27)
- registry byte change → NONCOMPLIANT
- mutation witness: flip the expected registry hash → exact install red → byte-identical restore → green
- v2 identity pins schema/baseline/commit
- declared paths exist in tree (named diagnostics) and at the pinned commit (one `ls-tree`, `core.quotePath=false`; skip only on a proven shallow clone — unreachable commit in a full clone FAILS)
- duplicate declarations detected in raw manifest text (JSON.parse collapses duplicate keys silently)
- population line asserted (format lock; truncation coverage lives in the raw-text case)

Full suite: 344 tests, 0 fail (5 pre-existing platform-conditional skips). Attestation remains read-only (existing digest-before/after case).