### PR TITLE
statusline: visible line without jq + FleetBaselineManifest/v3 recut

### DIFF
--- a/daemons/statusline-ctx.sh
+++ b/daemons/statusline-ctx.sh
@@ -24,6 +24,7 @@ INPUT=$(cat)
 
 SENSOR_DIR="$HOME/.claude/ctx-refresh"
 HAS_JQ=0
+DELEGATE="${AIGENT_STATUSLINE_DELEGATE:-$HOME/.claude/statusline-command.sh}"
 
 if [ "${CTX_TELEMETRY_FORCE_NODE:-0}" != "1" ] && command -v jq >/dev/null 2>&1; then
   HAS_JQ=1
@@ -49,14 +50,22 @@ if [ "${CTX_TELEMETRY_FORCE_NODE:-0}" != "1" ] && command -v jq >/dev/null 2>&1;
 elif command -v node >/dev/null 2>&1; then
   SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd)
   if [ -n "$SCRIPT_DIR" ]; then
-    printf '%s' "$INPUT" \
-      | node "$SCRIPT_DIR/ctx-telemetry.mjs" --write-only >/dev/null 2>&1 \
-      || true
+    if [ -f "$DELEGATE" ]; then
+      # A delegate is wired: write telemetry only here, the display block
+      # below invokes the delegate once.
+      printf '%s' "$INPUT" \
+        | node "$SCRIPT_DIR/ctx-telemetry.mjs" --write-only >/dev/null 2>&1 \
+        || true
+    else
+      # No delegate and no jq: ctx-telemetry.mjs's own CLI already writes
+      # telemetry AND prints a built-in line (model + ctx %) — jq just isn't
+      # here to do it, so let Node do both instead of only the write half.
+      printf '%s' "$INPUT" | node "$SCRIPT_DIR/ctx-telemetry.mjs" 2>/dev/null || true
+    fi
   fi
 fi
 
 # Display: delegate to an existing statusline script unchanged, if one is wired.
-DELEGATE="${AIGENT_STATUSLINE_DELEGATE:-$HOME/.claude/statusline-command.sh}"
 if [ -f "$DELEGATE" ]; then
   printf '%s' "$INPUT" | bash "$DELEGATE"
 elif [ "$HAS_JQ" -eq 1 ]; then

--- a/daemons/tests/fleet-baseline-attest.test.mjs
+++ b/daemons/tests/fleet-baseline-attest.test.mjs
@@ -526,17 +526,17 @@ test('--attest writes nothing into the tree it attests', () => {
   });
 });
 
-// -- FleetBaselineManifest/v2 -------------------------------------------------
+// -- FleetBaselineManifest/v3 -------------------------------------------------
 
 const REGISTRY = 'daemons/semantic-search/namespace-registry.json';
 
-test('v2 manifest identity pins the recut population', () => {
+test('v3 manifest identity pins the recut population', () => {
   const manifest = readManifest();
-  assert.equal(manifest.schema, 'FleetBaselineManifest/v2');
-  assert.equal(manifest.baseline_id, 'aigent-os-2026-08-22-30598546');
+  assert.equal(manifest.schema, 'FleetBaselineManifest/v3');
+  assert.equal(manifest.baseline_id, 'aigent-os-2026-08-23-3bfe7ea3');
   assert.equal(
     manifest.public_product_commit,
-    '30598546a36a19cc1e2863ecf792d3743276fa06',
+    '3bfe7ea3739498423585bdc8a54b177b7a212469',
   );
   assert.ok(
     manifest.baseline_id.endsWith(manifest.public_product_commit.slice(0, 8)),
@@ -618,7 +618,7 @@ test('a byte changed in the namespace policy artifact attests NONCOMPLIANT', () 
   });
 });
 
-// THE v2 MUTATION WITNESS. The expected namespace-registry hash is flipped in
+// THE v3 MUTATION WITNESS. The expected namespace-registry hash is flipped in
 // the installed manifest while the artifact on disk stays untouched: the
 // exact-install case must turn red, and a byte-identical restore must turn it
 // green again -- proving the green depends on exactly these bytes.

--- a/daemons/tests/statusline-ctx.test.mjs
+++ b/daemons/tests/statusline-ctx.test.mjs
@@ -152,6 +152,72 @@ test('delegates the visible line to an existing statusline script unchanged', { 
   }
 });
 
+// --- program issue #41: the no-jq branch must still show something ---------
+//
+// Forces the exact branch the script takes when jq is genuinely absent — the
+// gate is literally `"${CTX_TELEMETRY_FORCE_NODE:-0}" != "1" && command -v jq`,
+// so this env var is indistinguishable, from the script's own perspective,
+// from jq missing off PATH. Reused from the existing pattern in
+// daemons/tests/auto-clear-transport.run1.test.mjs (test 7) rather than
+// fighting PATH-format differences between a Windows-launched node and the
+// bash it spawns. These three cases are NOT gated on skipReason: they must
+// hold regardless of whether jq happens to be installed on the runner.
+const FORCE_NODE = { CTX_TELEMETRY_FORCE_NODE: '1' };
+const visibleLines = (stdout) => stdout.split('\n').filter((l) => l.length > 0);
+
+test('no jq, no delegate: telemetry still lands and a visible line prints once', () => {
+  const home = freshHome();
+  try {
+    const res = run(PAYLOAD, home, FORCE_NODE);
+    assert.equal(res.status, 0, res.stderr);
+    const file = path.join(home, '.claude', 'ctx-refresh', 'sess-abc123.json');
+    assert.ok(existsSync(file), 'telemetry must still be written with no jq');
+    assert.equal(JSON.parse(readFileSync(file, 'utf8')).used_percentage, 42.5);
+    const lines = visibleLines(res.stdout);
+    assert.equal(lines.length, 1, `expected exactly one visible line, got ${JSON.stringify(res.stdout)}`);
+    assert.equal(lines[0], 'TestModel | ctx 42%');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('no jq, with delegate: telemetry lands and the delegate output prints exactly once', () => {
+  const home = freshHome();
+  try {
+    mkdirSync(path.join(home, '.claude'), { recursive: true });
+    // Dependency-free delegate (no jq call) so this proves the statusline
+    // script's own dispatch, not whether jq happens to exist on the runner.
+    writeFileSync(
+      path.join(home, '.claude', 'statusline-command.sh'),
+      '#!/bin/bash\nINPUT=$(cat)\ncase "$INPUT" in *TestModel*) echo "DELEGATE saw TestModel";; *) echo "DELEGATE saw UNKNOWN";; esac\n',
+    );
+    const res = run(PAYLOAD, home, FORCE_NODE);
+    assert.equal(res.status, 0, res.stderr);
+    const lines = visibleLines(res.stdout);
+    assert.equal(lines.length, 1, `expected the delegate line exactly once, got ${JSON.stringify(res.stdout)}`);
+    assert.equal(lines[0], 'DELEGATE saw TestModel');
+    assert.ok(
+      existsSync(path.join(home, '.claude', 'ctx-refresh', 'sess-abc123.json')),
+      'telemetry still written alongside delegation',
+    );
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('no jq, malformed payload: no crash, no fabricated percentage', () => {
+  const home = freshHome();
+  try {
+    const res = run('not json at all', home, FORCE_NODE);
+    assert.equal(res.status, 0, 'always exits 0');
+    assert.doesNotMatch(res.stdout, /ctx \d/, 'never fabricates a percentage from unparseable input');
+    const dir = path.join(home, '.claude', 'ctx-refresh');
+    if (existsSync(dir)) assert.deepEqual(readdirSync(dir), []);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test('prunes >7-day-idle *.json but never the sensor\'s *.state files', { skip: skipReason }, () => {
   const home = freshHome();
   try {

--- a/scripts/fleet-baseline-manifest.json
+++ b/scripts/fleet-baseline-manifest.json
@@ -1,19 +1,20 @@
 {
-  "schema": "FleetBaselineManifest/v2",
-  "baseline_id": "aigent-os-2026-08-22-30598546",
-  "public_product_commit": "30598546a36a19cc1e2863ecf792d3743276fa06",
+  "schema": "FleetBaselineManifest/v3",
+  "baseline_id": "aigent-os-2026-08-23-3bfe7ea3",
+  "public_product_commit": "3bfe7ea3739498423585bdc8a54b177b7a212469",
   "notes": [
     "Every sha256 below is the blob at public_product_commit. .gitattributes forces eol=lf, so an installed tree's bytes match on every platform.",
     "Population rule: every executable .claude/settings.json.template wires as a hook or statusLine, plus the entry points install.sh names by path (managed runner, its dependency root, managed launcher), the settings template, the post-compact rule, and the system kernel root.",
     "scripts/doctor.sh is excluded: it is the measuring instrument, not a member of the measured population.",
-    "daemons/semantic-search/namespace-registry.json pins the product-owned namespace policy artifact. v2 does not attest every semantic-search implementation byte; it pins this policy artifact plus the existing load-bearing population.",
-    "FleetBaselineManifest/v1 (aigent-os-2026-08-19-41051d9e) is superseded by this baseline as the current public baseline and remains historical evidence in git history.",
+    "daemons/semantic-search/namespace-registry.json pins the product-owned namespace policy artifact. v3 does not attest every semantic-search implementation byte; it pins this policy artifact plus the existing load-bearing population.",
+    "FleetBaselineManifest/v2 (aigent-os-2026-08-22-30598546) is superseded by this baseline as the current public baseline and remains historical evidence in git history. FleetBaselineManifest/v1 (aigent-os-2026-08-19-41051d9e) remains historical evidence one generation further back.",
+    "v3 recut reason (program issue #41): daemons/statusline-ctx.sh changed to fix a silent statusline when jq is absent and no delegate is wired (telemetry still wrote, but nothing displayed) — every other hash was recomputed from the same commit and found unchanged.",
     "CLAUDE.md, .claude/settings.json and .gitignore are excluded: the installer rewrites them (marker block, placeholder render, managed ignore block), so their installed bytes are never the repo bytes.",
     ".claude/skill-index.json and skills/*/SKILL.md are excluded: caddy-enroll and operator-authored skills legitimately change them, so hashing them would report every customized install as NONCOMPLIANT.",
     ".claude/rules/post-compact-critical.md is excluded: it is operator-owned doctrine (the CLAUDE.md class) -- the installer seeds the starter only into a fresh install and keeps an existing operator file, so its installed bytes are legitimately not the repo bytes."
   ],
   "required_files": {
-    "daemons/statusline-ctx.sh": "49c1aa9d2336ce3515314e4c7a0bbdaf0c2576082413e53d3b09901d648bdb2e",
+    "daemons/statusline-ctx.sh": "fa30a56b9eb5a2f385065e8d1737ae0ec70084b23737a1f3e1c43fcea196f468",
     "daemons/sessionstart-reinject.mjs": "f088db2faba158af4008dc56321d80cb52a7544d37a952d51472d69fa9e39496",
     "daemons/resume-verb.mjs": "abc505d1581e28c5640eb018e41cfbd1f637da85d36312320abe9c7444052dc5",
     "daemons/caddy.sh": "3985a94194fb5914b77c0f6089188045a08dd863f8143e02ffad85728f5c3b0e",


### PR DESCRIPTION
Two logical commits, per the program work order (#41):

**Commit A (3bfe7ea)** — red-first test + smallest fix: `daemons/statusline-ctx.sh` no-jq branch previously called `ctx-telemetry.mjs --write-only` unconditionally, so telemetry wrote but no visible line ever printed (no jq + no delegate = silent statusline). Fix reuses ctx-telemetry.mjs's own built-in rendering: `--write-only` only when a delegate is wired; otherwise the node call writes and prints itself. jq branch byte-unchanged. Three new tests in `daemons/tests/statusline-ctx.test.mjs`; the no-jq/no-delegate case is RED at cc34f468 (`expected exactly one visible line, got "" — 0 !== 1`).

**Commit B (0c6dd60)** — honest baseline recut: `FleetBaselineManifest/v3`, baseline_id `aigent-os-2026-08-23-3bfe7ea3`, `public_product_commit` = exact commit A. All 31 required-file hashes recomputed from commit A blobs (scripted); only statusline-ctx.sh's hash moved. Namespace-registry pin, exclusions, terminal classes, and doctor.sh's instrument role preserved; v1/v2 remain historical evidence.

Proofs (evidence bundle in the program record): red witness at base / 8/8 green at head; fresh install at head → `--attest` COMPLIANT; one-byte statusline mutation → NONCOMPLIANT → restore → COMPLIANT; telemetry still written in the no-jq path; 39/39 daemon test files; installer smoke 19/19; attest suite 27/27 incl. mutation witness.

**Merge contract: normal merge commit only — no squash, no rebase.** The v3 manifest's `public_product_commit` must remain a reachable exact ancestor (commit A). Merge gated on a fresh exact-head non-author PASS.