### PR TITLE
namespace-registry: seat-owned local extension registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ __pycache__/
 # tracked; the real file stays local.
 **/semantic-search/index-deny.json
 
+# The seat-owned namespace extension registry (issue #48): operator-authored
+# local additions to the pinned core namespace-registry.json. Only
+# namespace-registry.local.example.json is tracked.
+**/semantic-search/namespace-registry.local.json
+
 # aigent-os:generated-state:start
 .aigent/
 vault/memory/embeddings.json

--- a/daemons/semantic-search/namespace-registry.local.example.json
+++ b/daemons/semantic-search/namespace-registry.local.example.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "EXAMPLE only. Copy this file to namespace-registry.local.json in the same directory and declare your own vault-relative top-level directories in the copy: namespace-registry.mjs's requireNamespaceRegistry() only reads namespace-registry.local.json, and only that copy is gitignored. Do not rename this file in place. This is the seat-owned extension registry (issue #48): the core namespace-registry.json is product-owned and pinned by the fleet baseline manifest, so a legitimate new vault directory belongs here instead of edited into the pinned file, which would make the seat permanently NONCOMPLIANT. Same schema and row rules as the core file -- one normalized top-level path per row, disposition INDEX/SKIP/DENY, and a non-empty reason on SKIP/DENY rows. A local path may only ADD a new top-level namespace: declaring a path that already exists in the core registry (with any disposition) fails closed everywhere -- embed, search, and doctor -- rather than silently overriding the pinned policy. With no namespace-registry.local.json present at all, only the core registry applies, exactly as before this file existed.",
+  "schema": "MemoryNamespaceRegistry/v1",
+  "namespaces": [
+    { "path": "operator-extension-example", "disposition": "INDEX" }
+  ]
+}

--- a/daemons/semantic-search/namespace-registry.mjs
+++ b/daemons/semantic-search/namespace-registry.mjs
@@ -12,6 +12,7 @@ import { join, posix, win32 } from 'node:path';
 
 const SCHEMA = 'MemoryNamespaceRegistry/v1';
 const DISPOSITIONS = new Set(['INDEX', 'SKIP', 'DENY']);
+const LOCAL_REGISTRY_FILENAME = 'namespace-registry.local.json';
 
 // These are the pre-existing embed-vault.js SKIP_DIRS entries. They are runtime
 // infrastructure rather than authored-memory namespaces, so a physical copy at
@@ -52,6 +53,35 @@ function validatePath(value, index) {
 }
 
 /**
+ * Validate one namespaces[] row and fold it into the given accumulators.
+ * Shared, byte-identical, between the core loader and the local extension
+ * loader below so the two can never drift on what a valid row is.
+ */
+function validateAndCollectRow(row, index, rows, byPath) {
+  if (!row || typeof row !== 'object' || Array.isArray(row)) {
+    throw new Error(`namespaces[${index}] must be an object`);
+  }
+
+  validatePath(row.path, index);
+  const key = namespaceKey(row.path);
+  if (byPath.has(key)) {
+    throw new Error(`duplicate namespace path: ${row.path}`);
+  }
+  if (!DISPOSITIONS.has(row.disposition)) {
+    throw new Error(`namespaces[${index}] has invalid disposition: ${String(row.disposition)}`);
+  }
+  if (
+    (row.disposition === 'SKIP' || row.disposition === 'DENY')
+    && (typeof row.reason !== 'string' || row.reason.trim().length === 0)
+  ) {
+    throw new Error(`namespaces[${index}] ${row.disposition} row requires a non-empty reason`);
+  }
+
+  rows.push(row);
+  byPath.set(key, row);
+}
+
+/**
  * Read and validate <dir>/namespace-registry.json.
  *
  * Missing, unreadable, and malformed files all throw. The returned `rows`
@@ -87,30 +117,76 @@ export function loadNamespaceRegistry(dir) {
   const rows = [];
   const byPath = new Map();
   for (let index = 0; index < raw.namespaces.length; index++) {
-    const row = raw.namespaces[index];
-    if (!row || typeof row !== 'object' || Array.isArray(row)) {
-      throw new Error(`namespaces[${index}] must be an object`);
-    }
+    validateAndCollectRow(raw.namespaces[index], index, rows, byPath);
+  }
 
-    validatePath(row.path, index);
+  return { rows, byPath };
+}
+
+/**
+ * Read and validate <dir>/namespace-registry.local.json: the optional,
+ * operator-owned extension registry (issue #48). Absent is the fresh-install
+ * state and is valid -- returns null, meaning "no local extension configured".
+ * Present-but-unusable (unreadable, malformed JSON, wrong schema, invalid row)
+ * throws, matching the core loader's fail-closed contract and row-validation
+ * rules exactly (same validateAndCollectRow).
+ */
+export function loadLocalNamespaceRegistry(dir, fileName = LOCAL_REGISTRY_FILENAME) {
+  const registryPath = join(dir, fileName);
+  let text;
+  try {
+    text = readFileSync(registryPath, 'utf8');
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return null;
+    throw new Error(`cannot read ${registryPath}: ${error.message}`);
+  }
+
+  let raw;
+  try {
+    raw = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`cannot parse ${registryPath}: ${error.message}`);
+  }
+
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`local namespace registry root must be an object: ${registryPath}`);
+  }
+  if (raw.schema !== SCHEMA) {
+    throw new Error(`local namespace registry schema must equal exactly ${SCHEMA}: ${registryPath}`);
+  }
+  if (!Array.isArray(raw.namespaces)) {
+    throw new Error(`local namespace registry namespaces must be an array: ${registryPath}`);
+  }
+
+  const rows = [];
+  const byPath = new Map();
+  for (let index = 0; index < raw.namespaces.length; index++) {
+    validateAndCollectRow(raw.namespaces[index], index, rows, byPath);
+  }
+
+  return { rows, byPath };
+}
+
+/**
+ * Compose the pinned core registry with the optional local extension.
+ * Local rows may only ADD top-level paths: any local path that already
+ * exists in the core registry throws, closed, regardless of whether the
+ * disposition matches -- a local row can never override or duplicate a core
+ * path. `local === null` (no local file) returns `core` unchanged.
+ */
+export function composeNamespaceRegistry(core, local) {
+  if (!local) return core;
+
+  const rows = core.rows.slice();
+  const byPath = new Map(core.byPath);
+  for (const row of local.rows) {
     const key = namespaceKey(row.path);
     if (byPath.has(key)) {
-      throw new Error(`duplicate namespace path: ${row.path}`);
+      throw new Error(`local namespace registry duplicates a core-registry path: ${row.path}`);
     }
-    if (!DISPOSITIONS.has(row.disposition)) {
-      throw new Error(`namespaces[${index}] has invalid disposition: ${String(row.disposition)}`);
-    }
-    if (
-      (row.disposition === 'SKIP' || row.disposition === 'DENY')
-      && (typeof row.reason !== 'string' || row.reason.trim().length === 0)
-    ) {
-      throw new Error(`namespaces[${index}] ${row.disposition} row requires a non-empty reason`);
-    }
-
     rows.push(row);
     byPath.set(key, row);
   }
-
   return { rows, byPath };
 }
 
@@ -154,12 +230,19 @@ export function assertNoUndeclaredNamespaceDirectories(registry, vaultRoot) {
   }
 }
 
-/** Fail-closed process gate matching deny-list.mjs's require idiom. */
+/**
+ * Fail-closed process gate matching deny-list.mjs's require idiom. This is
+ * the ONE composed loader: embed-vault.js and search-vault.js both call this
+ * (never loadNamespaceRegistry/loadLocalNamespaceRegistry directly), so the
+ * core+local composition lives here exactly once for both callers.
+ */
 export function requireNamespaceRegistry(dir, label) {
   try {
-    return loadNamespaceRegistry(dir);
+    const core = loadNamespaceRegistry(dir);
+    const local = loadLocalNamespaceRegistry(dir);
+    return composeNamespaceRegistry(core, local);
   } catch (error) {
-    console.error(`[${label}] REFUSING to run: namespace-registry.json cannot be used (${error.message}). Fix the registry before indexing or searching.`);
+    console.error(`[${label}] REFUSING to run: the namespace registry cannot be used (${error.message}). Fix the registry before indexing or searching.`);
     process.exit(1);
   }
 }

--- a/daemons/tests/fleet-baseline-attest.test.mjs
+++ b/daemons/tests/fleet-baseline-attest.test.mjs
@@ -618,6 +618,33 @@ test('a byte changed in the namespace policy artifact attests NONCOMPLIANT', () 
   });
 });
 
+// namespace-registry.local.json (issue #48) is deliberately unpinned: it is
+// operator-owned, so it is not in required_files and --attest never reads its
+// content. This proves that by construction rather than by inspection -- a
+// populated local registry present on a fresh install stays COMPLIANT, and
+// tampering the CORE registry still flips NONCOMPLIANT with the local file
+// present, so the two never get coupled by a future manifest change.
+test('a populated local namespace registry does not affect --attest, and core tamper still attests NONCOMPLIANT with it present', () => {
+  withInstall((root) => {
+    const localFile = path.join(root, 'daemons', 'semantic-search', 'namespace-registry.local.json');
+    writeFileSync(localFile, JSON.stringify({
+      schema: 'MemoryNamespaceRegistry/v1',
+      namespaces: [{ path: 'operator-extension', disposition: 'INDEX' }],
+    }, null, 2));
+
+    const green = attest(root);
+    assert.equal(green.verdict, 'COMPLIANT', green.output);
+    assert.equal(green.status, 0, 'populated local registry keeps the fresh install COMPLIANT');
+
+    const coreFile = path.join(root, ...REGISTRY.split('/'));
+    writeFileSync(coreFile, `${readFileSync(coreFile, 'utf8')}\n`);
+    const red = attest(root);
+    assert.equal(red.verdict, 'NONCOMPLIANT', red.output);
+    assert.equal(red.status, 1, 'NONCOMPLIANT exits 1');
+    assert.match(red.output, /required file changed: daemons\/semantic-search\/namespace-registry\.json/);
+  });
+});
+
 // THE v3 MUTATION WITNESS. The expected namespace-registry hash is flipped in
 // the installed manifest while the artifact on disk stays untouched: the
 // exact-install case must turn red, and a byte-identical restore must turn it

--- a/daemons/tests/semantic-search-namespace-registry.test.mjs
+++ b/daemons/tests/semantic-search-namespace-registry.test.mjs
@@ -99,6 +99,14 @@ function writeRegistry(box, text) {
   if (text !== null) writeFileSync(target, text);
 }
 
+// The optional, operator-owned extension registry (issue #48). Same shape as
+// writeRegistry above; absent (never called) is the default valid state.
+function writeLocalRegistry(box, text) {
+  const target = path.join(box.sem, 'namespace-registry.local.json');
+  rmSync(target, { recursive: true, force: true });
+  if (text !== null) writeFileSync(target, text);
+}
+
 function addNote(box, relativePath, canary) {
   const target = path.join(box.vault, ...relativePath.split('/'));
   mkdirSync(path.dirname(target), { recursive: true });
@@ -564,6 +572,111 @@ assertInvalidRegistryMutation(
   ])),
   /requires a non-empty reason/i,
 );
+
+// ── Local extension registry (issue #48) ─────────────────────────────────────
+// namespace-registry.local.json is the optional, operator-owned extension: a
+// local row may ADD a new declared top-level path, but never override or
+// duplicate a core path. This is the fix for the measured contradiction --
+// FleetBaselineManifest pins namespace-registry.json, so a legitimate new
+// vault directory could previously only be declared by editing the pinned
+// core file, which made a properly customized seat permanently NONCOMPLIANT.
+
+// 10. A new physical namespace declared ONLY in the local registry is
+// accepted (INDEX content built and returned, doctor reports it PRESENT
+// rather than UNDECLARED) under its declared disposition. Before this fix
+// (loadLocalNamespaceRegistry/composeNamespaceRegistry did not exist and
+// namespace-registry.local.json was never read), this exact fixture is the
+// master-branch red case: the directory is undeclared everywhere.
+{
+  const box = makeSandbox('local-index');
+  const LOCAL_PATH = 'operator-extension';
+  const LOCAL_CANARY = 'CANARY-NAMESPACE-LOCAL-INDEX-7c19ab-extension-body';
+  addNote(box, `${LOCAL_PATH}/note.md`, LOCAL_CANARY);
+  writeLocalRegistry(box, registryText([{ path: LOCAL_PATH, disposition: 'INDEX' }]));
+
+  const embed = runNode(box, 'embed-vault.js');
+  check('local INDEX: embed exits 0', embed.status === 0, embed.stderr.slice(0, 300));
+  const raw = readIndexText(box);
+  check('local INDEX: local-namespace canary is present in embeddings.json', raw.includes(LOCAL_CANARY));
+  check('local INDEX: core healthy canary is also present in the same artifact', raw.includes(HEALTHY));
+
+  const search = runNode(box, 'search-vault.js', ['extension namespace', '--top', '10']);
+  check('local INDEX: search exits 0', search.status === 0, search.stderr.slice(0, 300));
+  check('local INDEX: search returns the local-namespace canary', search.stdout.includes(LOCAL_CANARY));
+
+  const doctor = runDoctor(box);
+  check('local INDEX: doctor exits 0', doctor.status === 0, doctor.all.slice(-500));
+  check(
+    'local INDEX: doctor emits NAMESPACE_INDEX_PRESENT for the locally declared path',
+    new RegExp(`NAMESPACE_INDEX_PRESENT\\s+${LOCAL_PATH}(?:\\s|$)`).test(doctor.stdout),
+  );
+  check('local INDEX: doctor does not report the locally declared path as undeclared', !new RegExp(`NAMESPACE_UNDECLARED\\s+${LOCAL_PATH}(?:\\s|$)`).test(doctor.stdout));
+}
+
+// 11. The local extension is additive, not a blanket bypass: a physical
+// namespace declared in NEITHER registry stays red even while a local
+// registry is present and valid (declaring an unrelated path).
+{
+  const box = makeSandbox('local-present-but-undeclared');
+  writeLocalRegistry(box, registryText([{ path: 'operator-extension', disposition: 'INDEX' }]));
+  establishHealthyControl(box, 'local present but sibling still undeclared');
+  addNote(box, `${ROGUE_DIR}/secret.md`, ROGUE);
+  const before = readIndexText(box);
+
+  const embed = runNode(box, 'embed-vault.js');
+  check('local present but sibling still undeclared: embed exits nonzero', embed.status === 1, embed.all.slice(0, 300));
+  check('local present but sibling still undeclared: embed names the physical directory', embed.all.includes(ROGUE_DIR));
+  check('local present but sibling still undeclared: healthy index unchanged', readIndexText(box) === before && before.includes(HEALTHY));
+
+  const doctor = runDoctor(box);
+  check('local present but sibling still undeclared: doctor exits nonzero', doctor.status === 1, doctor.all.slice(-500));
+  check('local present but sibling still undeclared: doctor emits NAMESPACE_UNDECLARED', /NAMESPACE_UNDECLARED\s+rogue(?:\s|$)/.test(doctor.stdout));
+}
+
+// 12. Duplicate core/local path fails closed everywhere, even when the local
+// disposition matches the core disposition exactly.
+assertInvalidRegistryMutation(
+  'duplicate core/local path',
+  (box) => writeLocalRegistry(box, registryText([{ path: 'feedback', disposition: 'INDEX' }])),
+  /duplicate/i,
+);
+
+// 13. A local row cannot override a core disposition either -- same
+// duplicate-path guard, exercised with a mismatched disposition so an
+// "override" attempt is falsified as its own fixture per the issue's bullet.
+assertInvalidRegistryMutation(
+  'override of a core disposition',
+  (box) => writeLocalRegistry(box, registryText([{ path: 'templates', disposition: 'INDEX' }])),
+  /duplicate/i,
+);
+
+// 14. Invalid/malformed local registry fails closed everywhere, same as a
+// malformed core registry.
+assertInvalidRegistryMutation(
+  'malformed local registry JSON',
+  (box) => writeLocalRegistry(box, '{'),
+  /cannot parse|malformed JSON/i,
+);
+
+// 15. A stale hand-built DENY entry declared ONLY in the local registry is
+// blocked at the query-time chokepoint, exactly like a core DENY row (test 4
+// above) -- proving the composed registry, not just the core one, reaches
+// search-vault.js's existing namespaceDispositionForPath() filter.
+{
+  const box = makeSandbox('local-stale-deny');
+  writeLocalRegistry(box, registryText([
+    { path: PRIVATE_DIR, disposition: 'DENY', reason: 'test-only local confidential namespace' },
+  ]));
+  mkdirSync(path.join(box.vault, PRIVATE_DIR), { recursive: true });
+  writeIndex(box, [
+    indexNote(`${PRIVATE_DIR}/secret.md`, DENIED, [1, 0, 0, 0]),
+    indexNote('feedback/healthy.md', HEALTHY, [0, 1, 0, 0]),
+  ]);
+  check('local stale DENY: healthy INDEX canary is present in the seeded artifact', readIndexText(box).includes(HEALTHY));
+  const search = runNode(box, 'search-vault.js', ['private secret', '--top', '10']);
+  assertSearchIsolation('local stale DENY query-time chokepoint', search, DENIED);
+  check('local stale DENY: denied namespace path is absent from all output', !search.all.includes(`${PRIVATE_DIR}/secret.md`));
+}
 
 // ── Mutation witness: weaken only search's query-time namespace predicate ───
 {

--- a/install.sh
+++ b/install.sh
@@ -840,7 +840,9 @@ GI_BLOCK="$AIGENT_TMP/gitignore.block"
 # is opened as a vault, and the settings.local.json Claude Code itself writes
 # for machine-local overrides. The semantic-search index-deny.json belongs here
 # too: it is hand-written rather than generated, but it names the operator's own
-# confidential folders, so it must never be committable from TARGET.
+# confidential folders, so it must never be committable from TARGET. Same
+# treatment for namespace-registry.local.json (issue #48): the seat-owned
+# extension registry, hand-written and never generated.
 cat > "$GI_BLOCK" <<EOF_GI
 $GI_START
 .aigent/
@@ -855,6 +857,7 @@ memory/.daemon-errors.log
 **/runtime/stop-writer/
 **/runtime/NIGHTLY_PASS_STATE.json
 **/semantic-search/index-deny.json
+**/semantic-search/namespace-registry.local.json
 node_modules/
 .obsidian/
 $GI_END

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -730,7 +730,13 @@ fi
 # in a temp file, matching check 7b's set -euo pipefail-safe pattern; capturing
 # its status directly (rather than through process substitution) ensures a
 # parser failure cannot be mistaken for an empty, healthy registry.
+#
+# namespace-registry.local.json (issue #48) is the optional, operator-owned
+# extension registry: same schema and row rules as the core file, composed
+# in below rather than reimplemented, so doctor can never drift from what
+# embed-vault.js/search-vault.js's shared namespace-registry.mjs accepts.
 NAMESPACE_REGISTRY="$ROOT/daemons/semantic-search/namespace-registry.json"
+NAMESPACE_LOCAL_REGISTRY="$ROOT/daemons/semantic-search/namespace-registry.local.json"
 if command -v python3 >/dev/null 2>&1; then
   _NAMESPACE_PY=$(mktemp /tmp/doctor_namespace_registry.XXXXXX.py)
   cat > "$_NAMESPACE_PY" << 'NAMESPACEPY'
@@ -764,7 +770,46 @@ def reject_json_constant(value):
     raise ValueError("invalid JSON constant: %s" % value)
 
 
+def validate_rows(namespaces, seen, source_label):
+    rows = []
+    for index, row in enumerate(namespaces):
+        if type(row) is not dict:
+            stop("%s[%d] must be an object" % (source_label, index))
+
+        namespace_path = row.get("path")
+        if type(namespace_path) is not str:
+            stop("%s[%d].path must be a string" % (source_label, index))
+        if (
+            not namespace_path
+            or namespace_path.strip() != namespace_path
+            or namespace_path in (".", "..")
+            or "/" in namespace_path
+            or "\\" in namespace_path
+            or posixpath.isabs(namespace_path)
+            or ntpath.isabs(namespace_path)
+        ):
+            stop("%s[%d].path must be one normalized top-level segment" % (source_label, index))
+
+        key = namespace_path.replace("\\", "/").lower()
+        if key in seen:
+            stop("duplicate namespace path: %s" % namespace_path)
+        seen.add(key)
+
+        disposition = row.get("disposition")
+        if type(disposition) is not str or disposition not in DISPOSITIONS:
+            stop("%s[%d] has invalid disposition: %s" % (source_label, index, disposition))
+        if disposition in ("SKIP", "DENY"):
+            reason = row.get("reason")
+            if type(reason) is not str or not reason.strip():
+                stop("%s[%d] %s row requires a non-empty reason" % (source_label, index, disposition))
+
+        rows.append((namespace_path, disposition, key))
+    return rows
+
+
 registry_path, vault_root = sys.argv[1:3]
+local_registry_path = sys.argv[3] if len(sys.argv) > 3 else None
+
 try:
     with open(registry_path, encoding="utf-8") as registry_file:
         registry_text = registry_file.read()
@@ -785,40 +830,40 @@ namespaces = document.get("namespaces")
 if type(namespaces) is not list:
     stop("namespace registry namespaces must be an array")
 
-rows = []
 seen = set()
-for index, row in enumerate(namespaces):
-    if type(row) is not dict:
-        stop("namespaces[%d] must be an object" % index)
+rows = validate_rows(namespaces, seen, "namespaces")
 
-    namespace_path = row.get("path")
-    if type(namespace_path) is not str:
-        stop("namespaces[%d].path must be a string" % index)
-    if (
-        not namespace_path
-        or namespace_path.strip() != namespace_path
-        or namespace_path in (".", "..")
-        or "/" in namespace_path
-        or "\\" in namespace_path
-        or posixpath.isabs(namespace_path)
-        or ntpath.isabs(namespace_path)
-    ):
-        stop("namespaces[%d].path must be one normalized top-level segment" % index)
+# namespace-registry.local.json: optional, operator-owned. Absent (ENOENT) is
+# valid -- no local rows. Present-but-unusable fails closed exactly like the
+# core file. A local path colliding with a core path (already in `seen`)
+# fails closed via the same duplicate-path check validate_rows uses
+# internally: local rows may add top-level paths only, never override or
+# duplicate a core one.
+if local_registry_path:
+    try:
+        with open(local_registry_path, encoding="utf-8") as local_file:
+            local_text = local_file.read()
+    except FileNotFoundError:
+        local_text = None
+    except (OSError, UnicodeError) as error:
+        stop("local namespace registry missing or unreadable: %s (%s)" % (local_registry_path, error))
 
-    key = namespace_path.replace("\\", "/").lower()
-    if key in seen:
-        stop("duplicate namespace path: %s" % namespace_path)
-    seen.add(key)
+    if local_text is not None:
+        try:
+            local_document = json.loads(local_text, parse_constant=reject_json_constant)
+        except (ValueError, UnicodeError, RecursionError) as error:
+            stop("local namespace registry malformed JSON: %s" % error)
 
-    disposition = row.get("disposition")
-    if type(disposition) is not str or disposition not in DISPOSITIONS:
-        stop("namespaces[%d] has invalid disposition: %s" % (index, disposition))
-    if disposition in ("SKIP", "DENY"):
-        reason = row.get("reason")
-        if type(reason) is not str or not reason.strip():
-            stop("namespaces[%d] %s row requires a non-empty reason" % (index, disposition))
+        if type(local_document) is not dict:
+            stop("local namespace registry root must be an object")
+        if local_document.get("schema") != SCHEMA:
+            stop("local namespace registry schema must equal exactly %s" % SCHEMA)
 
-    rows.append((namespace_path, disposition, key))
+        local_namespaces = local_document.get("namespaces")
+        if type(local_namespaces) is not list:
+            stop("local namespace registry namespaces must be an array")
+
+        rows += validate_rows(local_namespaces, seen, "local namespaces")
 
 physical = []
 if os.path.exists(vault_root):
@@ -856,7 +901,7 @@ NAMESPACEPY
 
   NAMESPACE_OUTPUT=""
   NAMESPACE_RC=0
-  NAMESPACE_OUTPUT="$(python3 "$_NAMESPACE_PY" "$NAMESPACE_REGISTRY" "$ROOT/vault" 2>&1)" || NAMESPACE_RC=$?
+  NAMESPACE_OUTPUT="$(python3 "$_NAMESPACE_PY" "$NAMESPACE_REGISTRY" "$ROOT/vault" "$NAMESPACE_LOCAL_REGISTRY" 2>&1)" || NAMESPACE_RC=$?
   rm -f "$_NAMESPACE_PY"
 
   if [ "$NAMESPACE_RC" -ne 0 ]; then

--- a/tests/test-installer-fast.sh
+++ b/tests/test-installer-fast.sh
@@ -16,7 +16,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT INT TERM
 
-TOTAL=19
+TOTAL=20
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -605,5 +605,25 @@ mkdir -p "$RULES_SEED_TARGET"
 (cd "$FIXTURE" && bash install.sh --target "$RULES_SEED_TARGET" --no-deps >/dev/null 2>&1)
 grep -q "critical" "$RULES_SEED_TARGET/.claude/rules/post-compact-critical.md"
 printf '[19/%d] operator rules file: existing doctrine kept, starter seeds fresh installs only\n' "$TOTAL"
+
+# ── 20. Existing local namespace registry preserved (issue #48) ─────────────
+# namespace-registry.local.json is operator-owned and never shipped by the
+# framework (SRC never contains it, gitignored), so copy_missing_tree's
+# source-driven daemons/ copy has no path that could ever touch a
+# pre-existing one at TARGET -- this proves that by construction, across a
+# fresh copy install AND a rerun (reinstall) of the same TARGET.
+LOCAL_REGISTRY_TARGET="$WORK/local-registry-target"
+mkdir -p "$LOCAL_REGISTRY_TARGET/daemons/semantic-search"
+cat > "$LOCAL_REGISTRY_TARGET/daemons/semantic-search/namespace-registry.local.json" <<'JSON'
+{"schema":"MemoryNamespaceRegistry/v1","namespaces":[{"path":"operator-extension-sentinel","disposition":"INDEX"}]}
+JSON
+LOCAL_REGISTRY_BEFORE="$(cat "$LOCAL_REGISTRY_TARGET/daemons/semantic-search/namespace-registry.local.json")"
+(cd "$FIXTURE" && bash install.sh --target "$LOCAL_REGISTRY_TARGET" --no-deps >/dev/null 2>&1)
+test -f "$LOCAL_REGISTRY_TARGET/daemons/semantic-search/namespace-registry.local.json"
+test "$(cat "$LOCAL_REGISTRY_TARGET/daemons/semantic-search/namespace-registry.local.json")" = "$LOCAL_REGISTRY_BEFORE"
+# Reinstall (rerun against the same TARGET) must not touch it either.
+(cd "$FIXTURE" && bash install.sh --target "$LOCAL_REGISTRY_TARGET" --no-deps >/dev/null 2>&1)
+test "$(cat "$LOCAL_REGISTRY_TARGET/daemons/semantic-search/namespace-registry.local.json")" = "$LOCAL_REGISTRY_BEFORE"
+printf '[20/%d] local namespace registry: pre-existing file survives install and reinstall untouched\n' "$TOTAL"
 
 printf 'fast installer suite passed (%d/%d)\n' "$TOTAL" "$TOTAL"


### PR DESCRIPTION
Seat-owned namespace extension registry, resolving the measured governance contradiction: the core namespace-registry.json is manifest-pinned while runtime told operators to edit it for legitimate new vault directories — a properly customized seat became permanently NONCOMPLIANT.

Two commits off master 85f72fa:

**8dbcde4** — implementation. New optional operator-owned `daemons/semantic-search/namespace-registry.local.json` (gitignored; tracked `.example.json` mirrors the index-deny.json convention — the existing operator-owned chokepoint pattern this reuses). `requireNamespaceRegistry()` composes core+local internally — the single function embed and search already call, so both callers are covered with zero changes to them. doctor.sh's embedded python validator extended with one shared `validate_rows()` run over core then local against one `seen` set (duplicate detection is the same mechanism, not a second implementation). Local rows: top-level additions only; no override or duplicate of core paths; malformed/duplicate/override fail CLOSED; missing file valid; installer preserves an existing local registry.

**ee64004** — falsifiers. 5 new fixtures (36 checks) red with the implementation reverted to master, green at head: local-INDEX accepted, duplicate core/local, override-of-core-disposition, malformed local, local stale DENY (filtered at query time). Every negative fixture carries a healthy INDEX canary. New attest test: populated local registry present → --attest COMPLIANT; core-registry tamper with local present → NONCOMPLIANT. Manifest unchanged by design (root .gitignore/install.sh not in required_files; pinned launcher/install.sh untouched, hash verified).

Suites: namespace-registry 262/262 · fleet-baseline-attest 28/28 · installer 20/20 (new: local registry survives fresh install + reinstall byte-for-byte) · full daemons discovery 39/39.

Merge gated on a fresh exact-head non-author PASS.